### PR TITLE
Optimize rcclBroadcast performance.

### DIFF
--- a/src/rcclBcast.cpp
+++ b/src/rcclBcast.cpp
@@ -78,7 +78,7 @@ rcclResult_t rcclBcast(void *buff, int count, rcclDataType_t datatype, int root,
 
     //! Check if current gpu is root or not
     bool is_root = pcomm->track_->rank == root;
-
+    hipEvent_t event = pcomm->event_;
     //! If current gpu is root, call internal implementation for root
     if (is_root) {
         RcclInternalBroadcastRoot(pcurr_track, stream, buff, this_time,
@@ -97,40 +97,40 @@ rcclResult_t rcclBcast(void *buff, int count, rcclDataType_t datatype, int root,
         case rcclChar: {
             RcclInternalBroadcast<signed char>(pcurr_track, proot_track, count,
                                                stream, buff, this_time,
-                                               num_gpus);
+                                               num_gpus, event);
             break;
         }
         case rcclHalf: {
             RcclInternalBroadcast<__fp16>(pcurr_track, proot_track, count,
-                                          stream, buff, this_time, num_gpus);
+                                          stream, buff, this_time, num_gpus, event);
             break;
         }
         case rcclInt: {
             RcclInternalBroadcast<signed int>(pcurr_track, proot_track, count,
                                               stream, buff, this_time,
-                                              num_gpus);
+                                              num_gpus, event);
             break;
         }
         case rcclFloat: {
             RcclInternalBroadcast<float>(pcurr_track, proot_track, count,
-                                         stream, buff, this_time, num_gpus);
+                                         stream, buff, this_time, num_gpus, event);
             break;
         }
         case rcclInt64: {
             RcclInternalBroadcast<signed long>(pcurr_track, proot_track, count,
                                                stream, buff, this_time,
-                                               num_gpus);
+                                               num_gpus, event);
             break;
         }
         case rcclUint64: {
             RcclInternalBroadcast<unsigned long>(pcurr_track, proot_track,
                                                  count, stream, buff, this_time,
-                                                 num_gpus);
+                                                 num_gpus, event);
             break;
         }
         case rcclDouble: {
             RcclInternalBroadcast<double>(pcurr_track, proot_track, count,
-                                          stream, buff, this_time, num_gpus);
+                                          stream, buff, this_time, num_gpus, event);
             break;
         }
         default: { return rcclInvalidType; }

--- a/src/rcclScalarBroadcastKernels.h
+++ b/src/rcclScalarBroadcastKernels.h
@@ -16,7 +16,7 @@ All rights reserved.
 //! @brief Definition of RcclKernelScalarCopyFromRoot
 template <typename DataType_t>
 __global__ void RcclKernelScalarCopyFromRoot(RingNode_t* proot_track,
-                                             void* recv_buff, int count) {
+                                             void* recv_buff, int count, int offset) {
     int tx = threadIdx.x;
     int bx = blockIdx.x;
     int tid = tx + bx * knum_vectors_per_workgroup;
@@ -24,8 +24,53 @@ __global__ void RcclKernelScalarCopyFromRoot(RingNode_t* proot_track,
     if (tid < count) {
         //! Copy data from root gpu source buffer to current gpu destination
         //! buffer
-        reinterpret_cast<DataType_t*>(recv_buff)[tid] =
-            reinterpret_cast<DataType_t*>(proot_track->src_buffer)[tid];
+        int index = tid + offset;
+        reinterpret_cast<DataType_t*>(recv_buff)[index] =
+            reinterpret_cast<DataType_t*>(proot_track->src_buffer)[index];
     }
     __syncthreads();
+}
+
+//! @brief Definition of RcclKernelCopyRest
+//! Gather data (which is not operated on by current gpu) from all gpus
+template <typename DataType_t>
+__global__ void RcclKernelBcastCopyRest(RingNode_t* pcurr_track, int num_gpus,
+                                   int rank, int count_per_gpu,
+                                   int max_count_per_gpu) {
+    int tx = threadIdx.x;
+    int bx = blockIdx.x;
+    int tid = tx + bx * knum_workitems;
+
+    RingNode_t* pnext_track = pcurr_track->next_gpu;
+
+    //! Get pointer to current gpu destination buffer
+    DataType_t* curr_dst_buff =
+        reinterpret_cast<DataType_t*>(pcurr_track->dst_buffer);
+
+    //! Iterate over all the gpus and gather data from them
+    while (pnext_track->rank != rank) {
+        //! Get pointer to peer gpu source buffer
+        DataType_t* next_src_buff =
+            reinterpret_cast<DataType_t*>(pnext_track->dst_buffer);
+
+        int curr_rank = pnext_track->rank;
+
+        int count = count_per_gpu;
+
+        //! If the rank of peer gpu is last the last gpu, update the number of
+        //! elements it operates on
+        if (curr_rank == num_gpus - 1) {
+            count = max_count_per_gpu;
+        }
+
+        //! Read data from peer gpu and store it to current gpu destination
+        //! buffer
+        if (tid < count) {
+            curr_dst_buff[tid + curr_rank * count_per_gpu] =
+                next_src_buff[tid + curr_rank * count_per_gpu];
+        }
+
+        //! Get next gpu tracker
+        pnext_track = pnext_track->next_gpu;
+    }
 }

--- a/src/rcclScalarBroadcastRuntime.h
+++ b/src/rcclScalarBroadcastRuntime.h
@@ -22,8 +22,8 @@ All rights reserved.
 void RcclInternalBroadcastRoot(RingNode_t* pcurr_track, hipStream_t stream,
                                void* send_buff, int* this_time, int num_gpus) {
     //! Set source pointer on root gpu
-    hipLaunchKernelGGL((RcclKernelSetSrcPtr), dim3(1, 1, 1), dim3(1, 1, 1), 0,
-                       stream, pcurr_track, send_buff);
+    hipLaunchKernelGGL(RcclKernelSetSrcDstPtr, dim3(1, 1, 1), dim3(1, 1, 1), 0,
+                       stream, pcurr_track, (void*)send_buff, send_buff);
 
     //! Get the barrier instance used count
     int barrier_value = *this_time;
@@ -32,7 +32,11 @@ void RcclInternalBroadcastRoot(RingNode_t* pcurr_track, hipStream_t stream,
     hipLaunchKernelGGL((RcclKernelBarrierWait), dim3(1, 1, 1), dim3(1, 1, 1), 0,
                        stream, pcurr_track, barrier_value++, num_gpus);
 
-    //! Wait until everyone finished reading from source buffer
+    //! Wait until everyone finished reading chunked data from source buffer
+    hipLaunchKernelGGL((RcclKernelBarrierWait), dim3(1, 1, 1), dim3(1, 1, 1), 0,
+                       stream, pcurr_track, barrier_value++, num_gpus);
+
+    //! Wait until everyone finishes reading rest chunked data
     hipLaunchKernelGGL((RcclKernelBarrierWait), dim3(1, 1, 1), dim3(1, 1, 1), 0,
                        stream, pcurr_track, barrier_value++, num_gpus);
 
@@ -45,10 +49,34 @@ void RcclInternalBroadcastRoot(RingNode_t* pcurr_track, hipStream_t stream,
 template <typename DataType_t>
 void RcclInternalBroadcast(RingNode_t* pcurr_track, RingNode_t* proot_track,
                            int count, hipStream_t stream, void* recv_buff,
-                           int* this_time, int num_gpus) {
-    bool check_count = count > knum_workitems;
-    int num_workitems = check_count ? knum_workitems : count;
-    int num_workgroups = check_count ? count / knum_workitems + 1 : 1;
+                           int* this_time, int num_gpus, hipEvent_t event) {
+    int num_workitems = 0, num_workgroups = 0;
+    int rank = pcurr_track->rank;
+    int offset = (count / num_gpus) * rank;
+
+    //! Three counts are required to implement chunked broadcast
+    //! - op_gpu_count stores how many elements each gpu operates on,
+    //! depending on rank of gpu.
+    //! - regular_gpu_count stores how many elements each gpu holds,
+    //! except for the highest ranking gpu
+    //! - last_gpu_count stores how many elements last ranked gpu holds
+    int regular_gpu_count = count / num_gpus;
+    int last_gpu_count = ((count / num_gpus) + (count % num_gpus));
+    int op_gpu_count =
+        (rank == num_gpus - 1) ? last_gpu_count : regular_gpu_count;
+
+    //! Explain why you need last_gpu_count number of workitems
+    if (last_gpu_count < knum_workitems) {
+        num_workitems = last_gpu_count;
+        num_workgroups = 1;
+    } else {
+        num_workitems = knum_workitems;
+        num_workgroups = (last_gpu_count / knum_workitems) + 1;
+    }
+
+    //! Set source and destination buffers for current gpu
+    hipLaunchKernelGGL(RcclKernelSetSrcDstPtr, dim3(1, 1, 1), dim3(1, 1, 1), 0,
+                       stream, pcurr_track, (void*)recv_buff, recv_buff);
 
     //! Get barrier instance used count
     int barrier_value = *this_time;
@@ -57,12 +85,30 @@ void RcclInternalBroadcast(RingNode_t* pcurr_track, RingNode_t* proot_track,
     hipLaunchKernelGGL((RcclKernelBarrierWait), dim3(1, 1, 1), dim3(1, 1, 1), 0,
                        stream, pcurr_track, barrier_value++, num_gpus);
 
-    //! Read data from root gpu
+    //! Read chunked data from root gpu
     hipLaunchKernelGGL((RcclKernelScalarCopyFromRoot<DataType_t>),
                        dim3(num_workgroups, 1, 1), dim3(num_workitems, 1, 1), 0,
-                       stream, proot_track, recv_buff, count);
+                       stream, proot_track, recv_buff, op_gpu_count, offset);
 
-    //! Wait until everyone finishes reading
+    //! Flush gpu l2 cache
+    hipEventRecord(event, stream);
+
+    //! Wait until all gpus have finished reading chunked data
+    hipLaunchKernelGGL((RcclKernelBarrierWait), dim3(1, 1, 1), dim3(1, 1, 1), 0,
+                       stream, pcurr_track, barrier_value++, num_gpus);
+
+    //! Once all gpus have done copy, gather result from all gpus to
+    //! current gpu destination buffer
+    hipLaunchKernelGGL((RcclKernelBcastCopyRest<DataType_t>),
+                       dim3(num_workgroups, 1, 1), dim3(num_workitems, 1, 1), 0,
+                       stream, pcurr_track, num_gpus, rank, regular_gpu_count,
+                       last_gpu_count);
+
+    //! Flush gpu l2 cache
+    hipEventRecord(event, stream);
+
+
+    //! Wait until everyone finishes reading rest chunked data
     hipLaunchKernelGGL((RcclKernelBarrierWait), dim3(1, 1, 1), dim3(1, 1, 1), 0,
                        stream, pcurr_track, barrier_value++, num_gpus);
 


### PR DESCRIPTION
Originally, 3cards and 4cards performance is 5Gbs and 3Gbs.
With this patch, performance is 7Gbs and 6Gbs.