### PR TITLE
Fix #54. Replace std::atomic with HIP atomic.

### DIFF
--- a/src/rcclTracker.cpp
+++ b/src/rcclTracker.cpp
@@ -25,12 +25,9 @@ RingNodePool_t::RingNodePool_t() {
     HIPCHECK(
         hipHostMalloc(&barrier_, sizeof(Barrier_t), hipHostMallocCoherent));
 
-    std::atomic_store_explicit(&(barrier_->bar_in), 0,
-                               std::memory_order_seq_cst);
-    std::atomic_store_explicit(&(barrier_->bar_out), 0,
-                               std::memory_order_seq_cst);
-    std::atomic_store_explicit(&(barrier_->times_done), 0,
-                               std::memory_order_seq_cst);
+    barrier_->bar_in = 0;
+    barrier_->bar_out = 0;
+    barrier_->times_done = 0;
 }
 
 //! @brief Default destructor
@@ -62,12 +59,9 @@ RingNodePool_t::RingNodePool_t(const int* device_indices, int num_devices)
         hipHostMalloc(&barrier_, sizeof(Barrier_t), hipHostMallocCoherent));
 
     //! Reset fields in Barrier_t
-    std::atomic_store_explicit(&(barrier_->bar_in), 0,
-                               std::memory_order_seq_cst);
-    std::atomic_store_explicit(&(barrier_->bar_out), 0,
-                               std::memory_order_seq_cst);
-    std::atomic_store_explicit(&(barrier_->times_done), 0,
-                               std::memory_order_seq_cst);
+    barrier_->bar_in = 0;
+    barrier_->bar_out = 0;
+    barrier_->times_done = 0;
 
     //! Allocate RingNode_t as system pinned memory for gpu and add its hip
     //! device index

--- a/src/rcclTracker.h
+++ b/src/rcclTracker.h
@@ -16,7 +16,6 @@ All rights reserved.
 #pragma once
 
 #include <hip/hip_runtime.h>
-#include <atomic>
 #include <map>
 #include "rcclCheck.h"
 
@@ -51,7 +50,7 @@ constexpr unsigned knum_vectors_per_workgroup = 1024;
 //! barrier. bar_in tracks how many gpus have entered the barrier. bar_out
 //! tracks how many gpus have exited. Owned by rcclUniqueId or RingNodePool_t
 struct Barrier_t {
-    std::atomic<int> bar_in, bar_out, times_done;
+    int bar_in, bar_out, times_done;
 };
 
 //! @brief Node for each gpu
@@ -64,10 +63,6 @@ struct RingNode_t {
     struct RingNode_t* prev_gpu;
     //! Point to RingNode_t owned by next gpu in clique
     struct RingNode_t* next_gpu;
-
-    //! We use atomic data type to store pointer to buffers on a gpu, because
-    //! there are multiple readers (all peer gpus) and single writer (current
-    //! gpu)
 
     //! Stores source buffer on current gpu
     void* src_buffer;


### PR DESCRIPTION
HIP atomics do not provide load and store operations. They are instead emulated using atomicAdd and atomicExch, respectively.