### PR TITLE
Adding support for alignment tests via sub-datasets

### DIFF
--- a/test/test_AllReduce.cpp
+++ b/test/test_AllReduce.cpp
@@ -32,6 +32,8 @@ namespace CorrectnessTests
 
         // Check results
         ValidateResults(dataset);
+
+        dataset.Release();
     }
 
     INSTANTIATE_TEST_CASE_P(AllReduceCorrectnessSweep,

--- a/test/test_Broadcast.cpp
+++ b/test/test_Broadcast.cpp
@@ -41,6 +41,8 @@ namespace CorrectnessTests
             // Check results
             ValidateResults(dataset);
         }
+
+        dataset.Release();
     }
 
     INSTANTIATE_TEST_CASE_P(BroadcastCorrectnessSweep,

--- a/test/test_GroupCalls.cpp
+++ b/test/test_GroupCalls.cpp
@@ -92,6 +92,7 @@ namespace CorrectnessTests
         for (int i = 0; i < 5; i++)
         {
             ValidateResults(datasets[i]);
+            datasets[i].Release();
         }
     }
 

--- a/test/test_Reduce.cpp
+++ b/test/test_Reduce.cpp
@@ -40,6 +40,8 @@ namespace CorrectnessTests
             // Check results
             ValidateResults(dataset);
         }
+
+        dataset.Release();
     }
 
     INSTANTIATE_TEST_CASE_P(ReduceCorrectnessSweep,

--- a/test/test_ReduceScatter.cpp
+++ b/test/test_ReduceScatter.cpp
@@ -39,6 +39,8 @@ namespace CorrectnessTests
 
         // Check results
         ValidateResults(dataset);
+
+        dataset.Release();
     }
 
     INSTANTIATE_TEST_CASE_P(ReduceScatterCorrectnessSweep,


### PR DESCRIPTION
Added sample alignment test for AllGather
Datasets no longer free memory on destruction so Release() must be used