### PR TITLE
Adding fix for unsufficient devices / better logging for skipped tests

### DIFF
--- a/test/CorrectnessTest.hpp
+++ b/test/CorrectnessTest.hpp
@@ -173,8 +173,13 @@ namespace CorrectnessTests
             // Only proceed with testing if there are enough GPUs
             if (numDevices > numDevicesAvailable)
             {
-                fprintf(stdout, "Skipping test requring %d devices (only %d available)\n",
+                fprintf(stdout, "[  SKIPPED ] Test requires %d devices (only %d available)\n",
                         numDevices, numDevicesAvailable);
+
+                // Modify the number of devices so that tear-down doesn't occur
+                // This is temporary until GTEST_SKIP() becomes available
+                numDevices = 0;
+                numDevicesAvailable = -1;
                 return;
             }
 


### PR DESCRIPTION
GTEST_SKIP() does not currently exist in the Google test 1.8.1.
For now, avoid segmentation fault from unnecessary frees/teardown by resetting numDevices to 0 / numAvailableDevices to -1.