### PR TITLE
Revise the previous fix to use the canonical path to HSA.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if("${HIP_COMPILER}" MATCHES "clang")
     PRIVATE --amdgpu-target=gfx908
     PRIVATE -fgpu-rdc)
   target_link_libraries(rccl PRIVATE -fgpu-rdc)
-  target_include_directories(rccl PRIVATE /opt/rocm/include)
+  target_include_directories(rccl PRIVATE /opt/rocm/hsa/include)
 endif()
 
 if("${HIP_COMPILER}" MATCHES "hcc")

--- a/src/transport.cu
+++ b/src/transport.cu
@@ -7,7 +7,8 @@
 
 #include "core.h"
 #include "common_coll.h"
-#include <hsa.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
 
 extern struct ncclTransport p2pTransport;
 extern struct ncclTransport shmTransport;


### PR DESCRIPTION
- This fix the build failures under certain environments.