### PR TITLE
check for fine grain support at top of p2pCanConnect

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -171,11 +171,14 @@ void parseHsaForceFineGrainVramPcie() {
     errno = 0;
     int64_t v = strtoll(str, NULL, 0);
     if (errno || (v != 0 && v != 1)) {
-      INFO(NCCL_ALL,"Invalid value %s for %s, using default %u.", str, "HSA_FORCE_FINE_GRAIN_PCIE", useFineGrainVramPcie); \
+      INFO(NCCL_ALL,"Invalid value %s for %s, using default %u.", str, "HSA_FORCE_FINE_GRAIN_PCIE", useFineGrainVramPcie);
     } else {
       useFineGrainVramPcie = v;
-      INFO(NCCL_ALL,"%s set by environment to %u.", "HSA_FORCE_FINE_GRAIN_PCIE", useFineGrainVramPcie);  \
+      INFO(NCCL_ALL,"%s set by environment to %u.", "HSA_FORCE_FINE_GRAIN_PCIE", useFineGrainVramPcie);
     }
+  }
+  else {
+    INFO(NCCL_ALL,"%s not set by environment.", "HSA_FORCE_FINE_GRAIN_PCIE");
   }
 }
 

--- a/src/transport/p2p.cc
+++ b/src/transport/p2p.cc
@@ -86,6 +86,10 @@ ncclResult_t p2pCanConnect(ncclTvalue_t* ret, struct ncclPeerInfo* myInfo, struc
 
   *ret = 0;
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HCC__) || defined(__HIPCC__)
+  if (!useFineGrainVramPcie) return ncclSuccess;
+#endif
+
   if (p2pLevel == 0) return ncclSuccess;
 
   // Rule out different nodes

--- a/src/transport/p2p.cc
+++ b/src/transport/p2p.cc
@@ -86,10 +86,6 @@ ncclResult_t p2pCanConnect(ncclTvalue_t* ret, struct ncclPeerInfo* myInfo, struc
 
   *ret = 0;
 
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HCC__) || defined(__HIPCC__)
-  if (!useFineGrainVramPcie) return ncclSuccess;
-#endif
-
   if (p2pLevel == 0) return ncclSuccess;
 
   // Rule out different nodes
@@ -116,6 +112,9 @@ ncclResult_t p2pCanConnect(ncclTvalue_t* ret, struct ncclPeerInfo* myInfo, struc
 
   // Do not detect topology if we're on the same GPU. Note this is not really supported.
   if (myInfo->cudaDev == peerCudaDev) {
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HCC__) || defined(__HIPCC__)
+    if (!useFineGrainVramPcie) return ncclSuccess;
+#endif
     *ret = 1 + PATH_SYS;
     return ncclSuccess;
   }


### PR DESCRIPTION
This fixes a TensorFlow unit test where the HSA_FORCE_FINE_GRAIN_PCIE env var is not set, HIP_VISIBLE_DEVICES=0 is set, and two ranks are created on the same device.  The p2p transport should always be skipped if fine grain memory is not requested.