### PR TITLE
Fix HIP-Clang build with HSA headers

### DIFF
--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -13,6 +13,10 @@
 #include "core.h"
 #include "nvmlwrap.h"
 #include "xml.h"
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HCC__) || defined(__HIPCC__)
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+#endif
 
 /*******************/
 /* XML File Parser */

--- a/tools/TransferBench/TransferBench.cpp
+++ b/tools/TransferBench/TransferBench.cpp
@@ -34,6 +34,10 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 #include "copy_kernel.h"
 #include "TransferBench.hpp"
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HCC__) || defined(__HIPCC__)
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+#endif
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
HIP-Clang does not include these HSA headers, and they need to be explicitly added in RCCL.