### PR TITLE
Revert "Temporary disable 0x803 target due to build error"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "")
 
 project(rccl CXX)
 
-set(AMDGPU_TARGETS gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target")
+set(AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target")
 
 find_package(ROCM
              REQUIRED


### PR DESCRIPTION
This reverts commit cd7ab1425bd5d89ff4a685c85a3dba3604e6f759.