### PR TITLE
Making hip-clang the default compiler; documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,22 +27,23 @@ The root of this repository has a helper script 'install.sh' to build and instal
 *  `./install.sh -t` -- builds library including unit tests
 *  `./install.sh -r` -- runs unit tests (must be already built)
 *  `./install.sh -p` -- builds RCCL package
+*  `./install.sh -hcc` -- builds RCCL with hcc compiler; note that hcc is now deprecated. (default:hip-clang)
 *  `./install.sh --prefix` -- specify custom path to install RCCL to (default:/opt/rocm)
 
 ## Manual build
 #### To build the library :
 
 ```shell
-$ git clone https://github.com/ROCmSoftwarePlatform/rccl.git
+$ git clone https://github.com/ROCmSoftwarePlatform/rccl.git
 $ cd rccl
 $ mkdir build
 $ cd build
-$ CXX=/opt/rocm/bin/hcc cmake ..
+$ CXX=/opt/rocm/bin/hipcc cmake ..
 $ make -j 8
 ```
 You may substitute an installation path of your own choosing by passing CMAKE_INSTALL_PREFIX. For example:
 ```shell
-$ CXX=/opt/rocm/bin/hcc cmake -DCMAKE_INSTALL_PREFIX=$PWD/rccl-install ..
+$ CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_INSTALL_PREFIX=$PWD/rccl-install ..
 ```
 Note: ensure rocm-cmake is installed, `apt install rocm-cmake`.
 

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ function display_help()
     echo "    [-p|--package_build] Build RCCL package."
     echo "    [-t|--tests_build] Build unit tests, but do not run."
     echo "    [-r|--run_tests] Run unit tests (must be built already.)"
-    echo "    [--hip-clang] Build library using hip-clang compiler."
+    echo "    [--hcc] Build library using deprecated hcc compiler (default:hip-clang)."
     echo "    [--prefix] Specify custom directory to install RCCL to (default: /opt/rocm)."
 }
 
@@ -27,7 +27,7 @@ build_tests=false
 run_tests=false
 build_release=true
 install_library=false
-build_hip_clang=false
+build_hip_clang=true
 
 # #################################################
 # Parameter parsing
@@ -36,7 +36,7 @@ build_hip_clang=false
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package_build,tests_build,run_tests,hip-clang,prefix: --options hiptr -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package_build,tests_build,run_tests,hcc,prefix: --options hiptr -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -67,8 +67,8 @@ while true; do
     -r|--run_tests)
         run_tests=true
         shift ;;
-    --hip-clang)
-        build_hip_clang=true
+    --hcc)
+        build_hip_clang=false
         shift ;;
     --prefix)
         install_prefix=${2}
@@ -81,6 +81,14 @@ while true; do
     done
 
 rocm_path=/opt/rocm/bin
+
+# throw error code after running a command in the install script
+check_exit_code( )
+{
+  if (( $1 != 0 )); then
+    exit $1
+  fi
+}
 
 # #################################################
 # prep
@@ -109,9 +117,9 @@ else
     cmake_common_options="${cmake_common_options} -DCMAKE_BUILD_TYPE=Debug"
 fi
 
-compiler=hcc
-if [[ "${build_hip_clang}" == true ]]; then
-    compiler=hipcc
+compiler=hipcc
+if [[ "${build_hip_clang}" == false ]]; then
+    compiler=hcc
 fi
 
 cmake_executable=cmake
@@ -121,21 +129,25 @@ if [[ -e /etc/redhat-release ]]; then
 else
     apt install chrpath libomp-dev
 fi
+check_exit_code "$?"
 
 if ($build_tests); then
-    CXX=$rocm_path/$compiler $cmake_executable -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=$install_prefix ../../.
+    CXX=$rocm_path/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=$install_prefix ../../.
 else
-    CXX=$rocm_path/$compiler $cmake_executable -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$install_prefix ../../.
+    CXX=$rocm_path/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$install_prefix ../../.
 fi
+check_exit_code "$?"
 
 if ($install_library); then
     make -j$(nproc) install
 else
     make -j$(nproc)
 fi
+check_exit_code "$?"
 
 if ($build_package); then
     make package
+    check_exit_code "$?"
 fi
 
 # Optionally, run tests if they're enabled.

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ build_hip_clang=true
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package_build,tests_build,run_tests,hcc,prefix: --options hiptr -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,package_build,tests_build,run_tests,hcc,hip-clang,prefix: --options hiptr -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -69,6 +69,9 @@ while true; do
         shift ;;
     --hcc)
         build_hip_clang=false
+        shift ;;
+    --hip-clang)
+        build_hip_clang=true
         shift ;;
     --prefix)
         install_prefix=${2}


### PR DESCRIPTION
For now, I've provided users the option to build with hcc if they still wish by replacing the --hip-clang option with --hcc.