### PR TITLE
Removing UnitTest as install, removing unused env var

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -178,7 +178,7 @@ fi
 # Optionally, run tests if they're enabled.
 if ($run_tests); then
     if (test -f "./test/UnitTests"); then
-        HSA_FORCE_FINE_GRAIN_PCIE=1 ./test/UnitTests
+        ./test/UnitTests
     else
         echo "Unit tests have not been built yet; please re-run script with -t to build unit tests."
         exit 1

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,15 +56,6 @@ if(BUILD_TESTS)
   add_executable(UnitTests ${TEST_SOURCES})
   target_include_directories(UnitTests PRIVATE /opt/rocm)
   target_link_libraries(UnitTests PRIVATE gtest_main PRIVATE rccl)
-  install(TARGETS UnitTests RUNTIME DESTINATION test)
-
-  # HCC adds /opt/rocm/lib as RPATH, even though the install process is supposed to
-  # remove RPATH.  As a work-around, set the correct RPATH for the unit test executable
-  # as a post-install step
-  install(
-    CODE
-      "execute_process(COMMAND chrpath -r ${CMAKE_INSTALL_PREFIX}/lib:/opt/rocm/lib ${CMAKE_INSTALL_PREFIX}/test/UnitTests)"
-    )
 else()
   message("Not building unit tests")
 endif()

--- a/test/CorrectnessTest.hpp
+++ b/test/CorrectnessTest.hpp
@@ -175,13 +175,6 @@ namespace CorrectnessTests
         // This code is called per test-tuple
         void SetUp() override
         {
-            // Check for fine-grained env variable (otherwise will hang)
-            if (!getenv("HSA_FORCE_FINE_GRAIN_PCIE"))
-            {
-                printf("Must set HSA_FORCE_FINE_GRAIN_PCIE=1 prior to execution\n");
-                exit(0);
-            }
-
             // Make the test tuple parameters accessible
             std::tie(op, dataType, numElements, numDevices, inPlace, envVals) = GetParam();
 


### PR DESCRIPTION
No longer installing UnitTests
Removing unused HSA_FORCE_FINE_GRAIN_PCIE env variable checks
