### PR TITLE
Adding better naming to unit tests for filtering; adding short and full unit test suites

### DIFF
--- a/test/CorrectnessTest.hpp
+++ b/test/CorrectnessTest.hpp
@@ -170,6 +170,51 @@ namespace CorrectnessTests
     // - Each test is instantiated with a different TestTuple
     class CorrectnessTest : public testing::TestWithParam<TestTuple>
     {
+    public:
+        struct PrintToStringParamName
+        {
+            std::string operator()(const testing::TestParamInfo<CorrectnessTest::ParamType>& info)
+            {
+                std::string name;
+
+                name += opStrings[std::get<0>(info.param)] + "_";
+                name += dataTypeStrings[std::get<1>(info.param)] + "_";
+                name += std::to_string(std::get<2>(info.param)) + "elements_";
+                name += std::to_string(std::get<3>(info.param)) + "devices_";
+                name += std::get<4>(info.param) == true ? "inplace_" : "outofplace_";
+                std::string envVars = std::string(std::get<5>(info.param));
+                std::replace(envVars.begin(), envVars.end(), '=', '_');
+                name += envVars;
+
+                return name;
+            }
+
+            std::map<ncclRedOp_t, std::string> opStrings
+            {
+                {ncclSum,  "sum"},
+                {ncclProd, "prod"},
+                {ncclMax,  "max"},
+                {ncclMin,  "min"}
+            };
+
+            std::map<ncclDataType_t, std::string> dataTypeStrings
+            {
+                {ncclInt8,     "int8"},
+                {ncclChar,     "char"},
+                {ncclUint8,    "uint8"},
+                {ncclInt32,    "int32"},
+                {ncclInt,      "int"},
+                {ncclUint32,   "uint32"},
+                {ncclInt64,    "int64"},
+                {ncclUint64,   "uint64"},
+                {ncclFloat16,  "float16"},
+                {ncclHalf,     "half"},
+                {ncclFloat32,  "float32"},
+                {ncclFloat64,  "float64"},
+                {ncclDouble,   "double"},
+                {ncclBfloat16, "bfloat16"}
+            };
+        };
     protected:
 
         // This code is called per test-tuple

--- a/test/test_AllGather.cpp
+++ b/test/test_AllGather.cpp
@@ -88,7 +88,7 @@ namespace CorrectnessTests
     }
 
 
-    INSTANTIATE_TEST_CASE_P(AllGatherCorrectnessSweep,
+    INSTANTIATE_TEST_SUITE_P(AllGatherCorrectnessSweep,
                             AllGatherCorrectnessTest,
                             testing::Combine(
                                 // Reduction operator (not used)
@@ -110,5 +110,6 @@ namespace CorrectnessTests
                                 testing::Values(2,3,4,5,6,7,8),
                                 // In-place or not
                                 testing::Values(false, true),
-                                testing::Values("")));
+                                testing::Values("")),
+                            CorrectnessTest::PrintToStringParamName());
 } // namespace

--- a/test/test_AllReduce.cpp
+++ b/test/test_AllReduce.cpp
@@ -36,7 +36,7 @@ namespace CorrectnessTests
         dataset.Release();
     }
 
-    INSTANTIATE_TEST_CASE_P(AllReduceCorrectnessSweep,
+    INSTANTIATE_TEST_SUITE_P(AllReduceCorrectnessSweep,
                             AllReduceCorrectnessTest,
                             testing::Combine(
                                 // Reduction operator
@@ -58,5 +58,6 @@ namespace CorrectnessTests
                                 testing::Values(2,3,4,5,6,7,8),
                                 // In-place or not
                                 testing::Values(false, true),
-                                testing::Values("")));
+                                testing::Values("")),
+                            CorrectnessTest::PrintToStringParamName());
 } // namespace

--- a/test/test_AllReduceAbort.cpp
+++ b/test/test_AllReduceAbort.cpp
@@ -126,7 +126,7 @@ namespace CorrectnessTests
         dataset.Release();
     }
 
-    INSTANTIATE_TEST_CASE_P(AllReduceAbortSweep,
+    INSTANTIATE_TEST_SUITE_P(AllReduceAbortSweep,
                             AllReduceAbortTest,
                             testing::Combine(
                                 // Reduction operator
@@ -139,5 +139,6 @@ namespace CorrectnessTests
                                 testing::Values(2, 4),
                                 // In-place or not
                                 testing::Values(false),
-                                testing::Values("")));
+                                testing::Values("")),
+                            CorrectnessTest::PrintToStringParamName());
 } // namespace

--- a/test/test_AllToAll.cpp
+++ b/test/test_AllToAll.cpp
@@ -40,7 +40,7 @@ namespace CorrectnessTests
         dataset.Release();
     }
 
-    INSTANTIATE_TEST_CASE_P(AllToAllCorrectnessSweep,
+    INSTANTIATE_TEST_SUITE_P(AllToAllCorrectnessSweep,
                             AllToAllCorrectnessTest,
                             testing::Combine(
                                 // Reduction operator is not used
@@ -62,5 +62,6 @@ namespace CorrectnessTests
                                 testing::Values(2,3,4,5,6,7,8),
                                 // In-place or not
                                 testing::Values(false),
-                                testing::Values("RCCL_ALLTOALL_KERNEL_DISABLE=0", "RCCL_ALLTOALL_KERNEL_DISABLE=1")));
+                                testing::Values("RCCL_ALLTOALL_KERNEL_DISABLE=0", "RCCL_ALLTOALL_KERNEL_DISABLE=1")),
+                            CorrectnessTest::PrintToStringParamName());
 } // namespace

--- a/test/test_Broadcast.cpp
+++ b/test/test_Broadcast.cpp
@@ -44,7 +44,7 @@ namespace CorrectnessTests
         dataset.Release();
     }
 
-    INSTANTIATE_TEST_CASE_P(BroadcastCorrectnessSweep,
+    INSTANTIATE_TEST_SUITE_P(BroadcastCorrectnessSweep,
                             BroadcastCorrectnessTest,
                             testing::Combine(
                                 // Reduction operator is not used
@@ -66,5 +66,6 @@ namespace CorrectnessTests
                                 testing::Values(2,3,4,5,6,7,8),
                                 // In-place or not
                                 testing::Values(false, true),
-                                testing::Values("")));
+                                testing::Values("")),
+                            CorrectnessTest::PrintToStringParamName());
 } // namespace

--- a/test/test_BroadcastAbort.cpp
+++ b/test/test_BroadcastAbort.cpp
@@ -129,7 +129,7 @@ namespace CorrectnessTests
         dataset.Release();
     }
 
-    INSTANTIATE_TEST_CASE_P(BroadcastAbortSweep,
+    INSTANTIATE_TEST_SUITE_P(BroadcastAbortSweep,
                             BroadcastAbortTest,
                             testing::Combine(
                                 // Reduction operator
@@ -142,5 +142,6 @@ namespace CorrectnessTests
                                 testing::Values(2, 4),
                                 // In-place or not
                                 testing::Values(false),
-                                testing::Values("")));
+                                testing::Values("")),
+                            CorrectnessTest::PrintToStringParamName());
 } // namespace

--- a/test/test_CombinedCalls.cpp
+++ b/test/test_CombinedCalls.cpp
@@ -74,7 +74,7 @@ namespace CorrectnessTests
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(CombinedCallsCorrectnessSweep,
+    INSTANTIATE_TEST_SUITE_P(CombinedCallsCorrectnessSweep,
                             CombinedCallsCorrectnessTest,
                             testing::Combine(
                                 // Reduction operator (not used)
@@ -96,5 +96,6 @@ namespace CorrectnessTests
                                 testing::Values(2,3,4,5,6,7,8),
                                 // In-place or not
                                 testing::Values(false, true),
-                                testing::Values("")));
+                                testing::Values("")),
+                            CorrectnessTest::PrintToStringParamName());
 } // namespace

--- a/test/test_Gather.cpp
+++ b/test/test_Gather.cpp
@@ -44,7 +44,7 @@ namespace CorrectnessTests
         dataset.Release();
     }
 
-    INSTANTIATE_TEST_CASE_P(GatherCorrectnessSweep,
+    INSTANTIATE_TEST_SUITE_P(GatherCorrectnessSweep,
                             GatherCorrectnessTest,
                             testing::Combine(
                                 // Reduction operator is not used
@@ -66,5 +66,6 @@ namespace CorrectnessTests
                                 testing::Values(2,3,4,5,6,7,8),
                                 // In-place or not
                                 testing::Values(false),
-                                testing::Values("RCCL_ALLTOALL_KERNEL_DISABLE=0", "RCCL_ALLTOALL_KERNEL_DISABLE=1")));
+                                testing::Values("RCCL_ALLTOALL_KERNEL_DISABLE=0", "RCCL_ALLTOALL_KERNEL_DISABLE=1")),
+                            CorrectnessTest::PrintToStringParamName());
 } // namespace

--- a/test/test_GroupCalls.cpp
+++ b/test/test_GroupCalls.cpp
@@ -94,9 +94,9 @@ namespace CorrectnessTests
         }
     }
 
-    INSTANTIATE_TEST_CASE_P(GroupCallsCorrectnessSweep,
-                            GroupCallsCorrectnessTest,
-                            testing::Combine(
+    INSTANTIATE_TEST_SUITE_P(GroupCallsCorrectnessSweep,
+                             GroupCallsCorrectnessTest,
+                             testing::Combine(
                                 // Reduction operator (not used)
                                 testing::Values(ncclSum),
                                 // Data types
@@ -116,5 +116,6 @@ namespace CorrectnessTests
                                 testing::Values(2,3,4,5,6,7,8),
                                 // In-place or not
                                 testing::Values(false, true),
-                                testing::Values("")));
+                                testing::Values("")),
+                             CorrectnessTest::PrintToStringParamName());
 } // namespace

--- a/test/test_Reduce.cpp
+++ b/test/test_Reduce.cpp
@@ -44,9 +44,9 @@ namespace CorrectnessTests
         dataset.Release();
     }
 
-    INSTANTIATE_TEST_CASE_P(ReduceCorrectnessSweep,
-                            ReduceCorrectnessTest,
-                            testing::Combine(
+    INSTANTIATE_TEST_SUITE_P(ReduceCorrectnessSweep,
+                             ReduceCorrectnessTest,
+                             testing::Combine(
                                 // Reduction operator
                                 testing::Values(ncclSum, ncclProd, ncclMax, ncclMin),
                                 // Data types
@@ -66,5 +66,6 @@ namespace CorrectnessTests
                                 testing::Values(2,3,4,5,6,7,8),
                                 // In-place or not
                                 testing::Values(false, true),
-                                testing::Values("")));
+                                testing::Values("")),
+                             CorrectnessTest::PrintToStringParamName());
 } // namespace

--- a/test/test_ReduceScatter.cpp
+++ b/test/test_ReduceScatter.cpp
@@ -42,9 +42,9 @@ namespace CorrectnessTests
         dataset.Release();
     }
 
-    INSTANTIATE_TEST_CASE_P(ReduceScatterCorrectnessSweep,
-                            ReduceScatterCorrectnessTest,
-                            testing::Combine(
+    INSTANTIATE_TEST_SUITE_P(ReduceScatterCorrectnessSweep,
+                             ReduceScatterCorrectnessTest,
+                             testing::Combine(
                                 // Reduction operator
                                 testing::Values(ncclSum, ncclProd, ncclMax, ncclMin),
                                 // Data types
@@ -64,5 +64,6 @@ namespace CorrectnessTests
                                 testing::Values(2,3,4,5,6,7,8),
                                 // In-place or not
                                 testing::Values(false, true),
-                                testing::Values("")));
+                                testing::Values("")),
+                             CorrectnessTest::PrintToStringParamName());
 } // namespace

--- a/test/test_Scatter.cpp
+++ b/test/test_Scatter.cpp
@@ -44,7 +44,7 @@ namespace CorrectnessTests
         dataset.Release();
     }
 
-    INSTANTIATE_TEST_CASE_P(ScatterCorrectnessSweep,
+    INSTANTIATE_TEST_SUITE_P(ScatterCorrectnessSweep,
                             ScatterCorrectnessTest,
                             testing::Combine(
                                 // Reduction operator is not used
@@ -66,5 +66,6 @@ namespace CorrectnessTests
                                 testing::Values(2,3,4,5,6,7,8),
                                 // In-place or not
                                 testing::Values(false),
-                                testing::Values("RCCL_ALLTOALL_KERNEL_DISABLE=0", "RCCL_ALLTOALL_KERNEL_DISABLE=1")));
+                                testing::Values("RCCL_ALLTOALL_KERNEL_DISABLE=0", "RCCL_ALLTOALL_KERNEL_DISABLE=1")),
+                            CorrectnessTest::PrintToStringParamName());
 } // namespace


### PR DESCRIPTION
Unit test names are now of the format:

`[CollectiveCall]CorrectnessSweep/[CollectiveCall]CorrectnessTest.[Type of test]/[ncclRedOp_t]_[datatype]_[number of elements]_[number of devices]_[in place/out of place]_[environment variables]`

e.g. AllGatherCorrectnessSweep/AllGatherCorrectnessTest.Correctness/sum_bfloat16_3026520elements_8devices_outofplace_

This allows us to filter which unit tests we can run by the parameter values by passing the --gtest_filter command line flag, for example `--gtest_filter="AllReduceCorrectnessSweep*float32*"` will run only AllReduce correctness tests with float32 datatype.  See "Running a Subset of the Tests" at https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/docs/advanced.md for more information on how to form more advanced filters.

With this, I've made the the default unit test invocation in the install script to run the subset of unit tests as suggested by Wenkai: Broadcast unit test will run with all datatypes, all other collectives will run with just float32.  This cuts down the runtime of the unit tests considerably, which will be necessary once I put in the multiprocess unit tests.

I added an extra option --run_tests_all to the unit test to run the full suite, plus a new hidden convenience option --no_clean which prevents the install script from deleting the entire build folder.  I also made the install script automatically build the unit tests if the user passes in -r or -run_tests_all but did not specify to build the unit tests.

Also changed INSTANTIATE_TEST_CASE_P to INSTANTIATE_TEST_SUITE_P, as INSTANTIATE_TEST_CASE_P is now deprecated.