### PR TITLE
Adding static library building option.

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -9,7 +9,7 @@ def runCompileCommand(platform, project, jobName)
     def command = """#!/usr/bin/env bash
                 set -x
                 cd ${project.paths.project_build_prefix}
-                LD_LIBRARY_PATH=/opt/rocm/hcc/lib ${project.paths.build_command} -t ${hipclangArgs}
+                LD_LIBRARY_PATH=/opt/rocm/hcc/lib ${project.paths.build_command} ${hipclangArgs}
             """
 
     platform.runCommand(this,command)

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -14,7 +14,7 @@ def runCI =
     nodeDetails, jobName->
 
     def prj  = new rocProject('rccl', 'PreCheckin')
-    prj.paths.build_command = './install.sh'
+    prj.paths.build_command = './install.sh -t '
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -41,7 +41,7 @@ def runCI =
         commonGroovy.runPackageCommand(platform, project)
     }
 
-    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, testCommand, packageCommand)
+    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, null, packageCommand)
 }
 
 ci: { 

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -41,7 +41,7 @@ def runCI =
         commonGroovy.runPackageCommand(platform, project)
     }
 
-    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, null, packageCommand)
+    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, null, null)
 }
 
 ci: { 

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -1,0 +1,84 @@
+#!/usr/bin/env groovy
+@Library('rocJenkins@pong') _
+import com.amd.project.*
+import com.amd.docker.*
+import java.nio.file.Path;
+
+def runCI =
+{
+    nodeDetails, jobName->
+    
+    def prj = new rocProject('rccl', 'Static Library PreCheckin')
+    prj.paths.build_command = './install.sh --static'
+    
+
+    def nodes = new dockerNodes(nodeDetails, jobName, prj)
+
+    def commonGroovy
+
+    boolean formatCheck = false
+     
+    def compileCommand =
+    {
+        platform, project->
+
+        commonGroovy = load "${project.paths.project_src_prefix}/.jenkins/common.groovy"
+        commonGroovy.runCompileCommand(platform, project, jobName)
+    }
+
+    
+    def testCommand =
+    {
+        platform, project->
+
+        commonGroovy.runTestCommand(platform, project)
+    }
+
+    def packageCommand =
+    {
+        platform, project->
+
+        commonGroovy.runPackageCommand(platform, project)
+    }
+
+    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, testCommand, packageCommand)
+}
+
+ci: { 
+    String urlJobName = auxiliary.getTopJobName(env.BUILD_URL)
+
+    def propertyList = ["compute-rocm-dkms-no-npi":[pipelineTriggers([cron('0 1 * * 0')])], 
+                        "compute-rocm-dkms-no-npi-hipclang":[pipelineTriggers([cron('0 1 * * 0')])],
+                        "rocm-docker":[]]
+    propertyList = auxiliary.appendPropertyList(propertyList)
+
+    def jobNameList = ["compute-rocm-dkms-no-npi":([ubuntu16:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx908']]), 
+                       "compute-rocm-dkms-no-npi-hipclang":([ubuntu16:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx908']]), 
+                       "rocm-docker":([ubuntu16:['gfx900'],centos7:['gfx906'],sles15sp1:['gfx908']])]
+    jobNameList = auxiliary.appendJobNameList(jobNameList)
+
+    propertyList.each 
+    {
+        jobName, property->
+        if (urlJobName == jobName)
+            properties(auxiliary.addCommonProperties(property))
+    }
+
+    jobNameList.each
+    {
+        jobName, nodeDetails->
+        if (urlJobName == jobName)
+            stage(jobName) {
+                runCI(nodeDetails, jobName)
+            }
+    }
+
+    // For url job names that are not listed by the jobNameList i.e. compute-rocm-dkms-no-npi-1901
+    if(!jobNameList.keySet().contains(urlJobName))
+    {
+        properties(auxiliary.addCommonProperties([pipelineTriggers([cron('0 1 * * *')])]))
+        stage(urlJobName) {
+            runCI([ubuntu16:['4gfx906']], urlJobName)
+        }
+    }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # We use C++14 features, this will add compile option: -std=c++14
 set( CMAKE_CXX_STANDARD 14 )
@@ -68,13 +68,18 @@ rocm_setup_version(VERSION ${VERSION_STRING})
 list(APPEND CMAKE_PREFIX_PATH
             /opt/rocm
             /opt/rocm/hip
+            /opt/rocm/llvm
             /opt/rocm/hcc)
 
 find_package(hip REQUIRED)
 message(STATUS "HIP compiler: ${HIP_COMPILER}")
 message(STATUS "HIP runtime: ${HIP_RUNTIME}")
 
-option(BUILD_SHARED_LIBS "Build as a shared library" ON)
+if(BUILD_STATIC)
+  option(BUILD_SHARED_LIBS "Build as a shared library" OFF)
+else()
+  option(BUILD_SHARED_LIBS "Build as a shared library" ON)
+endif()
 
 configure_file(src/nccl.h.in ${PROJECT_BINARY_DIR}/rccl.h)
 configure_file(src/nccl.h.in ${PROJECT_BINARY_DIR}/nccl.h)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The root of this repository has a helper script 'install.sh' to build and instal
 *  `./install.sh -t` -- builds library including unit tests
 *  `./install.sh -r` -- runs unit tests (must be already built)
 *  `./install.sh -p` -- builds RCCL package
+*  `./install.sh -s` -- builds RCCL as a static library (default: shared)
 *  `./install.sh -hcc` -- builds RCCL with hcc compiler; note that hcc is now deprecated. (default:hip-clang)
 *  `./install.sh --prefix` -- specify custom path to install RCCL to (default:/opt/rocm)
 

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ function display_help()
     echo "    [-p|--package_build] Build RCCL package."
     echo "    [-t|--tests_build] Build unit tests, but do not run."
     echo "    [-r|--run_tests_quick] Run small subset of unit tests (must be built already.)"
+    echo "    [-s|--static] Build RCCL as a static library instead of shared library."
     echo "    [--run_tests_all] Run all unit tests (must be built already.)"
     echo "    [--hcc] Build library using deprecated hcc compiler (default:hip-clang)."
     echo "    [--prefix] Specify custom directory to install RCCL to (default: /opt/rocm)."
@@ -32,6 +33,7 @@ install_library=false
 build_hip_clang=true
 clean_build=true
 install_dependencies=false
+build_static=false
 
 # #################################################
 # Parameter parsing
@@ -40,7 +42,7 @@ install_dependencies=false
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,dependencies,package_build,tests_build,run_tests_quick,run_tests_all,hcc,hip-clang,no_clean,prefix: --options hiptr -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,dependencies,package_build,tests_build,run_tests_quick,static,run_tests_all,hcc,hip-clang,no_clean,prefix: --options hiptrs -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -73,6 +75,9 @@ while true; do
         shift ;;
     -r|--run_tests_quick)
         run_tests=true
+        shift ;;
+    -s|--static)
+        build_static=true
         shift ;;
     --run_tests_all)
         run_tests=true
@@ -145,6 +150,11 @@ if [[ "${build_release}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DCMAKE_BUILD_TYPE=Release"
 else
     cmake_common_options="${cmake_common_options} -DCMAKE_BUILD_TYPE=Debug"
+fi
+
+# shared vs static
+if [[ "${build_static}" == true ]]; then
+    cmake_common_options="${cmake_common_options} -DBUILD_STATIC=ON"
 fi
 
 compiler=hipcc


### PR DESCRIPTION
Users can now choose to build RCCL as a static library by passing in -s or --static to the install script.

