### PR TITLE
Changes to topology based on XGMI

### DIFF
--- a/src/graph/paths.cc
+++ b/src/graph/paths.cc
@@ -30,6 +30,84 @@ static ncclResult_t getPath(struct ncclTopoSystem* system, struct ncclTopoNode* 
   return ncclInternalError;
 }
 
+// [RCCL]
+// This function traverses only XGMI links (including multi-GPU hops) and builds them into the
+// topology system, which corresponds to how XGMI hardware operates
+static ncclResult_t ncclTopoSetXgmi(struct ncclTopoSystem* system)
+{
+  // Compute paths to GPU g
+  for (int g=0; g<system->nodes[GPU].count; g++) {
+    struct ncclTopoNode *baseNode = system->nodes[GPU].nodes+g;
+
+    if (baseNode->paths[baseNode->type] == NULL) {
+      NCCLCHECK(ncclCalloc(baseNode->paths+baseNode->type, system->nodes[baseNode->type].count));
+    }
+
+    // breadth-first search to set all paths to that node in the system
+    struct ncclTopoNodeList nodeList;
+    struct ncclTopoNodeList nextNodeList;
+    nodeList.count = 1; nodeList.list[0] = baseNode;
+    nextNodeList.count = 0;
+    struct ncclTopoLinkList* basePath;
+    NCCLCHECK(getPath(system, baseNode, baseNode->type, baseNode->id, &basePath));
+    basePath->count = 0;
+    basePath->width = LOC_WIDTH;
+    basePath->type = PATH_LOC;
+
+    while (nodeList.count) {
+      nextNodeList.count = 0;
+      for (int n=0; n<nodeList.count; n++) {
+        struct ncclTopoNode* node = nodeList.list[n];
+        struct ncclTopoLinkList* path;
+        NCCLCHECK(getPath(system, node, baseNode->type, baseNode->id, &path));
+        for (int l=0; l<node->nlinks; l++) {
+          struct ncclTopoLink* link = node->links+l;
+          struct ncclTopoNode* remNode = link->remNode;
+
+          // Skip non-XGMI links
+          if (link->type != LINK_NVL) continue;
+
+          if (remNode->paths[baseNode->type] == NULL) {
+            NCCLCHECK(ncclCalloc(remNode->paths+baseNode->type, system->nodes[baseNode->type].count));
+          }
+
+          struct ncclTopoLinkList* remPath;
+          NCCLCHECK(getPath(system, remNode, baseNode->type, baseNode->id, &remPath));
+          float width = std::min(path->width, link->width);
+          if (remPath->width < width) {
+            // Find reverse link
+            for (int l=0; l<remNode->nlinks; l++) {
+              if (remNode->links[l].remNode == node) {
+                remPath->list[0] = remNode->links+l;
+                break;
+              }
+            }
+            if (remPath->list[0] == NULL) {
+              WARN("Failed to find reverse path from remNode %d/%lx nlinks %d to node %d/%lx",
+                   remNode->type, remNode->id, remNode->nlinks, node->type, node->id);
+              return ncclInternalError;
+            }
+            // Copy the rest of the path
+            for (int i=0; i<path->count; i++) remPath->list[i+1] = path->list[i];
+            remPath->count = path->count + 1;
+            remPath->width = width;
+            remPath->type = PATH_NVL;
+
+            // Add to the list for the next iteration if not already in the list
+            // In this case, permit GPUs are intermediate XGMI steps
+            for (int i=0; i<nextNodeList.count; i++) if (nextNodeList.list[i] == remNode) continue;
+            nextNodeList.list[nextNodeList.count++] = remNode;
+          }
+        }
+      }
+      memcpy(&nodeList, &nextNodeList, sizeof(nodeList));
+    }
+  }
+  return ncclSuccess;
+}
+// [/RCCL]
+
+
 static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclTopoSystem* system) {
   if (baseNode->paths[baseNode->type] == NULL) {
     NCCLCHECK(ncclCalloc(baseNode->paths+baseNode->type, system->nodes[baseNode->type].count));
@@ -61,7 +139,14 @@ static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclT
         struct ncclTopoLinkList* remPath;
         NCCLCHECK(getPath(system, remNode, baseNode->type, baseNode->id, &remPath));
         float width = std::min(path->width, link->width);
-        if (remPath->width < width) {
+
+        // [RCCL] Do not let XGMI paths be overwritten (even if PCIe path may be faster)
+        //        Unless they are of shorter length
+     // if (remPath->width < width) {
+        bool notXGMI = remPath->type != PATH_NVL;
+        if (remPath->width < width && notXGMI) {
+        // [/RCCL]
+
           // Find reverse link
           for (int l=0; l<remNode->nlinks; l++) {
             if (remNode->links[l].remNode == node) {
@@ -358,6 +443,10 @@ ncclResult_t ncclTopoComputePaths(struct ncclTopoSystem* system, struct ncclPeer
   for (int c=0; c<system->nodes[CPU].count; c++) {
     NCCLCHECK(ncclTopoSetPaths(system->nodes[CPU].nodes+c, system));
   }
+
+  // [RCCL] Add XGMI-only links between GPUs first before any other paths
+  NCCLCHECK(ncclTopoSetXgmi(system));
+  // [/RCCL]
 
   // Set direct paths from/to GPUs.
   for (int g=0; g<system->nodes[GPU].count; g++) {

--- a/src/graph/search.cc
+++ b/src/graph/search.cc
@@ -371,7 +371,6 @@ ncclResult_t ncclTopoSearchRecGpu(struct ncclTopoSystem* system, struct ncclTopo
     } else { // Normal search
       NCCLCHECK(ncclTopoSearchNextGpuSort(system, graph, gpu, next, &count, backToNet == -1 ? 0 : backToNet == step+1 ? 1 : -1 ));
     }
-
     for (int i=0; i<count; i++) {
       NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, step+1, backToNet, backToFirstRank, forcedOrder, time, GPU, g, next[i]));
     }
@@ -380,7 +379,6 @@ ncclResult_t ncclTopoSearchRecGpu(struct ncclTopoSystem* system, struct ncclTopo
     int p;
     NCCLCHECK(getGpuIndex(system, graph->intra[graph->nChannels*ngpus], &p));
     struct ncclTopoNode* firstGpu;
-
     NCCLCHECK(ncclTopoFollowPath(system, graph, GPU, g, GPU, p, 1, &firstGpu));
     if (firstGpu) {
       NCCLCHECK(ncclTopoSearchRecGpu(system, graph, saveGraph, firstGpu, step+1, backToNet, -1, forcedOrder, time));

--- a/src/graph/topo.h
+++ b/src/graph/topo.h
@@ -21,7 +21,7 @@
 #define P9_WIDTH 32.0
 #define ARM_WIDTH 6.0
 #define NET_WIDTH 12.0           // 100Gbit
-#define VEGA_XGMI_WIDTH 24.0
+#define VEGA_XGMI_WIDTH 20.0
 
 // Intel CPU convert GPU P2P traffic into 64B PCI TLPs, so GPU
 // to GPU traffic consumes more PCI bandwidth.


### PR DESCRIPTION
Modifies the existing topology search code to better model how XGMI links work
Notable changes:
- XGMI speed workaround removed
- Previous XGMI count tie-break heuristic removed
- Multi-hop XGMI paths now detected, and preserved even if faster PCIe pathways present
- Sorting algorithm prefers XGMI linked GPUs over other candidate GPUs during search
- No longer short-cuts early if forced-order PCIe solution found
- Skips forced-order PCIe search for intra-node jobs

```
Differences from XGMI=24 workaround:
In some of the previous workaround, some 2-hop XGMI links were utilized. 
With these changes, 2-hop XGMI links are never selected.
Most of the differences are either clearly better, or at least on par.

====================================
Model 13 - single node 8 VEGA20 Rome
- OLD: Tree2/4: 0 3 5 6 7 4 2 1				   Identical after rotation
- NEW: Tree2/4: 1 0 3 5 6 7 4 2

Model 21 - single node 8 VEGA20 Rome NPS=2
- OLD: Tree2/4: 0 5 4 7 3 6 2 1
- NEW: Tree2/4: 5 4 7 3 6 2 1 0				   Identical after rotation

Model 24 - single node 8 VEGA20 TS1  (0-1-2-3-0), (4-5-7-6-4)
- OLD: Tree2/5: 0 3 2 1 5 7 6 4
- NEW: Tree2/5: 1 0 3 2 5 4 6 7                            Almost identical (each ring of 4 rotated) 				

- OLD: Tree3/6: 1 0 2 7 5 4 6 3                            1 [X1] 0 [P4] 2 [P4] 7 [X1] 5 [X1] 4 [X1] 6 [P4] 3    3 P4 links, 4 X1 links
- NEW: Tree3/6: 2 1 6 4 3 0 7 5                            2 [X1] 1 [P4] 6 [X1] 4 [P4] 3 [X1] 0 [P4] 7 [X1] 5    3 P4 links, 4 X1 links 

- OLD: Ring1/3: 0 1 2 3 4 5 6 7 0                          5-6 is a P4 link, not X1
- NEW: Ring1/3: 0 1 2 3 4 5 7 6 0                          5-7 is a an X1 link.  New result is better

- OLD: Ring2/4: 0 3 2 5 7 6 4 1 0
- NEW: Ring2/4: 0 3 2 5 4 6 7 1 0                          Almost identical (2nd half of loop is reversed) 

- OLD: Ring3/6: 0 7 5 4 6 2 1 3 0                          0 [P4] 7 [X1] 5 [X1] 4 [X1] 6 [P4] 2 [X1] 1 [X2] 3 [X1] 0    2 P4 links, 5 X1 links, 1 X2 link (1-3)
- NEW: Ring3/6: 0 6 4 2 1 7 5 3 0                          0 [P4] 6 [X1] 4 [P4] 2 [X1] 1 [P4] 7 [X1] 5 [P4] 3 [X1] 0	4 P4 links, 4 X1 links. (Note that P4 is rated at 24GB/s, X1 only 20GB/s)

Model 28 - single node 8 gfx908 Rome   (0,1,2,3 fully connected), (4,5,6,7) fully connected
- OLD: Tree3/7: 0 3 2 6 4 7 5 1                            0 [X1] 3 [X1] 2 [P4] 6 [X1] 4 [X1] 7 [X1] 5 [P4] 1   	2 P4 links, 5 X1 links
- NEW: Tree3/7: 0 6 4 7 5 1 3 2                            0 [P4] 6 [X1] 4 [X1] 7 [X1] 5 [P4] 1 [X1] 3 [X1] 2   	2 P4 links, 5 X1 links

- OLD: Tree4/8: 1 3 0 7 6 5 4 2                            0 [X1] 3 [X1] 0 [P4] 7 [X1] 6 [X1] 5 [X1] 4 [P4] 2   	2 P4 links, 5 X1 links
- NEW: Tree4/8: 7 6 5 4 2 0 3 1                            7 [X1] 6 [X1] 5 [X1] 4 [P4] 2 [X1] 0 [X1] 3 [X1] 1   	1 P4 link, 6 X1 links. New result is better

Model 30 - single node 8 VEGA20 TS1 NPS=4  (0-1-2-3-0) (4-5-7-6) 
- OLD: Tree2/5: 0 3 2 1 5 7 6 4    		           0 [X1] 3 [X1] 2 [X1] 1 [P4] 5 [X1] 7 [X1] 6 [X1] 4   	1 P4, 6 X1
- NEW: Tree2/5: 1 0 3 2 5 4 6 7                            1 [X1] 0 [X1] 3 [X1] 2 [P4] 5 [X1] 4 [X1] 6 [X1] 7   	1 P4, 6 X1. Identical

- OLD: Tree3/6: 1 0 2 7 5 4 6 3                            1 [X1] 0 [X2] 2 [P4] 7 [X1] 5 [X1] 4 [X1] 6 [P4] 3   	2 P4, 4 X1, 1 X2
- NEW: Tree3/6: 2 1 6 4 3 0 7 5                            2 [X1] 1 [P4] 6 [X1] 4 [P4] 3 [X1] 0 [P4] 7 [X1] 5   	3 P4, 4 X1

- OLD: Ring1: 0 1 2 3 4 5 6 7                              0 [X1] 1 [X1] 2 [X1] 3 [P4] 4 [X1] 5 [X2] 6 [X1] 7 [P4] 0  	2 P4, 5 X1, 1 X2
- NEW: Ring1: 0 1 2 3 4 5 7 6                              0 [X1] 1 [X1] 2 [X1] 3 [P4] 4 [X1] 5 [X1] 7 [X1] 6 [P4] 0  	2 P4, 6 X1. New Result is better because no X2 link

Model 32 - single node 8 VEGA20 TS1 NPS=4 Alt. Model (0-3-2-6-0) (1-4-5-7-1)
- OLD: Tree: 0 1 2 3 4 5 6 7				   0 [P4] 1 [P4] 2 [X1] 3 [P4] 4 [X1] 5 [P4] 6 [P4] 7		5 P4, 2 X1
- NEW: Tree: 0 3 2 6 5 7 1 4				   0 [X1] 3 [X1] 2 [X1] 6 [P4] 5 [X1] 7 [X1] 1 [X1] 4		1 P4, 6 X1 Better?

- OLD: Tree: 0 6 2 5 7 1 4 3				   0 [X1] 6 [X1] 2 [P4] 5 [X1] 7 [X1] 1 [X1] 4 [P4] 3		2 P4, 5 X1
- NEW: Tree: 0 6 2 3 7 5 4 1				   0 [X1] 6 [X1] 2 [X1] 3 [P4] 7 [X1] 5 [X1] 4 [X1] 1           1 P4, 6 X1 Better

- OLD: Tree: 5 4 1 7 0 3 2 6				   5 [X1] 4 [X1] 1 [X1] 7 [P4] 0 [X1] 3 [X1] 2 [X1] 6           1 P4, 6 X1
- NEW: Tree: 2 1 7 3 0 4 5 6                               2 [P4] 1 [X1] 7 [P4] 3 [X1] 0 [P4] 4 [P4] 5 [P4] 6           5 P4, 2 X1 Worse?

- OLD: Ring: 0 6 2 1 7 4 5 3 0				   0 [X1] 6 [X1] 2 [P4] 1 [X1] 7 [X2] 4 [X1] 5 [P4] 3 [X1] 0    2 P4, 5 X1, 1 X2
- NEW: Ring: 0 6 2 7 5 4 1 3 0                             0 [X1] 6 [X1] 2 [P4] 7 [X1] 5 [X1] 4 [X1] 1 [P4] 3 [X1] 0    2 P4, 6X1  Better?

- OLD: Ring: 0 7 5 4 1 2 3 6 0                             0 [P4] 7 [X1] 5 [X1] 4 [X1] 1 [P4] 2 [X1] 3 [X2] 6 [X1] 0    2 P4, 5 X1, 1 X2
- NEW: Ring: 0 1 7 2 3 4 5 6 0                             0 [P4] 1 [X1] 7 [P4] 2 [X1] 3 [P4] 4 [X1] 5 [P4] 6 [X1] 0    4 P4, 4 X1. Different.  Not sure if better?

```