### PR TITLE
[TransferBench] Adding output to CSV, additional changes

### DIFF
--- a/tools/TransferBench/Makefile
+++ b/tools/TransferBench/Makefile
@@ -6,7 +6,7 @@ endif
 HIPCC=$(HIP_PATH)/bin/hipcc
 
 EXE=TransferBench
-CXXFLAGS = -O3 -fopenmp -I../../src/include -I.
+CXXFLAGS = -O3 -I../../src/include -I.
 
 all: $(EXE)
 

--- a/tools/TransferBench/TransferBench.hpp
+++ b/tools/TransferBench/TransferBench.hpp
@@ -81,12 +81,16 @@ struct BlockParam
     float* dst;
 };
 
-void DisplayUsage(char const* cmdName);                // Display usage instructions
-void DisplayTopology();                                // Display GPU topology
-void ParseLinks(char* line, std::vector<Link>& links); // Parse Link information
+void DisplayUsage(char const* cmdName);                      // Display usage instructions
+void GenerateConfigFile(char const* cfgFile, int numBlocks); // Generate a sample config file
+void DisplayTopology();                                      // Display GPU topology
+void ParseLinks(char* line, std::vector<Link>& links);       // Parse Link information
 void AllocateMemory(MemType memType, int devIndex, size_t numBytes, bool useFineGrainMem, float** memPtr);
 void DeallocateMemory(MemType memType, int devIndex, float* memPtr);
 void CheckOrFill(ModeType mode, int N, bool isMemset, bool isHipCall, float* ptr);
+std::string GetLinkTypeDesc(uint32_t linkType, uint32_t hopCount);
+std::string GetLinkDesc(Link const& link);
+
 
 #define MAX_NAME_LEN 64
 #define BLOCKSIZE 256


### PR DESCRIPTION
- Adding OUTPUT_TO_CSV environment variable to generate CSV output
- Changing default number of bytes launched per link to 64MB
- Adding aggregate output information (total bandwidth / total CPU time)
- Display link info (for GPU mem cases) per line instead of at end
- Removed OpenMP
- Adding ability to generate a sample config file by specifying a negative value of N, with variety of tests.