### PR TITLE
Fixing IPC handle memory leak for CliqueKernels

### DIFF
--- a/src/clique/CliqueManager.cc
+++ b/src/clique/CliqueManager.cc
@@ -81,7 +81,11 @@ void CliqueManager::CleanUp()
   {
     // Release caches
     if (m_ipcHandleSendCache) delete m_ipcHandleSendCache;
-    if (m_ipcHandleSendCache) delete m_ipcHandleRecvCache;
+    if (m_ipcHandleRecvCache)
+    {
+        m_ipcHandleRecvCache->close();
+        delete m_ipcHandleRecvCache;
+    }
 
     // Close shared memory
     m_shmHandles.Close();


### PR DESCRIPTION
Adding explicit hipIpcCloseMemHandle to the receive cache upon cache eviction, and adding a close() call to close all memory mapped with handles in the cache.