### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,6 @@ function display_help()
 # #################################################
 # global variables
 # #################################################
-ROCM_PATH=$ROCM_PATH
 build_package=false
 install_prefix=$ROCM_PATH
 build_tests=false

--- a/install.sh
+++ b/install.sh
@@ -23,9 +23,9 @@ function display_help()
 # #################################################
 # global variables
 # #################################################
-default_path=/opt/rocm
+ROCM_PATH=$ROCM_PATH
 build_package=false
-install_prefix=$default_path
+install_prefix=$ROCM_PATH
 build_tests=false
 run_tests=false
 run_tests_all=false
@@ -103,7 +103,7 @@ while true; do
     esac
     done
 
-rocm_path=/opt/rocm/bin
+ROCM_BIN_PATH=$ROCM_PATH/bin
 
 # /etc/*-release files describe the system
 if [[ -e "/etc/os-release" ]]; then
@@ -177,9 +177,9 @@ fi
 check_exit_code "$?"
 
 if ($build_tests) || (($run_tests) && [[ ! -f ./test/UnitTests ]]); then
-    CXX=$rocm_path/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=$install_prefix ../../.
+    CXX=$ROCM_BIN_PATH/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=$install_prefix ../../.
 else
-    CXX=$rocm_path/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$install_prefix ../../.
+    CXX=$ROCM_BIN_PATH/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$install_prefix ../../.
 fi
 check_exit_code "$?"
 

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ function display_help()
 # global variables
 # #################################################
 build_package=false
-install_prefix=$ROCM_PATH
+ROCM_PATH=${ROCM_PATH:="/opt/rocm"}
 build_tests=false
 run_tests=false
 run_tests_all=false
@@ -176,9 +176,9 @@ fi
 check_exit_code "$?"
 
 if ($build_tests) || (($run_tests) && [[ ! -f ./test/UnitTests ]]); then
-    CXX=$ROCM_BIN_PATH/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=$install_prefix ../../.
+    CXX=$ROCM_BIN_PATH/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=$ROCM_PATH ../../.
 else
-    CXX=$ROCM_BIN_PATH/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$install_prefix ../../.
+    CXX=$ROCM_BIN_PATH/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$ROCM_PATH ../../.
 fi
 check_exit_code "$?"
 


### PR DESCRIPTION
Install.sh having hard code like /opt/rocm/bin/hipcc for rocm_path and default_path=/opt/rocm
This will work only when we have standalone rocm installed. If anyone has installed, side-by-side, they will face below error.

Can we keep like ROCM_PATH=$ROCM_PATH  instead of default_path as variable name and 
ROCM_BIN_PATH=$ROCM_PATH/bin ,rocm_path can be replaced with ROCM_BIN_PATH.

This way, we will have option to export ROCM_PATH as env variable as per need and use the script. 
I have also tried locally, it is working.  ROCM_PATH is common variable name, we are having.


Error when side-by-side install is done for driver.
# ./install.sh -dtr 2>&1 | tee /dockerx/6519_rccl-test.log
CMake Error at /usr/share/cmake/Modules/CMakeDetermineCXXCompiler.cmake:48 (message):
Could not find compiler set in environment variable CXX:
/opt/rocm/bin/hipcc.
Call Stack (most recent call first):
CMakeLists.txt:12 (project)

CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
See also "/root/driver/rccl/build/release/CMakeFiles/CMakeOutput.log".