### PR TITLE
Do not search for existing GTest install if we're force installing it into build directory

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -32,7 +32,9 @@
 # For downloading, building, and installing required dependencies
 include(cmake/DownloadProject.cmake)
 
-find_package(GTest 1.10)
+if(NOT INSTALL_DEPENDENCIES)
+    find_package(GTest 1.10)
+endif()
 
 if(NOT GTest_FOUND AND BUILD_TESTS OR INSTALL_DEPENDENCIES)
     if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
@@ -45,6 +47,7 @@ if(NOT GTest_FOUND AND BUILD_TESTS OR INSTALL_DEPENDENCIES)
     message(STATUS "GTest not found. Downloading and building GTest.")
     # Download, build and install googletest library
     set(GTEST_ROOT ${CMAKE_CURRENT_BINARY_DIR}/gtest CACHE PATH "")
+
     download_project(PROJ                googletest
                      GIT_REPOSITORY      https://github.com/google/googletest.git
                      GIT_TAG             release-1.10.0


### PR DESCRIPTION
Prevents a double inclusion error in CMake when force installing GTest with the -d flag in the install script.  We don't need to search for an existing install of GTest in /usr/lib if we're force installing it into our build folder anyway.  This error is being seen in some combination of newer CMake versions and/or newer ROCm builds.