### PR TITLE
Fixing message queue leak

### DIFF
--- a/src/clique/CliqueManager.h
+++ b/src/clique/CliqueManager.h
@@ -95,6 +95,7 @@ protected:
 
   int                          m_rank;                               // Associated rank
   int                          m_numRanks;                           // Total number of ranks
+  unsigned long                m_hash;                               // Hash used for identifying message queues & shared memory
   cliqueMode_t                 m_cliqueMode;                         // Clique mode (off/single process/single node)
   bool                         m_init;                               // Whether CliqueManager has been initialized
   cliqueDevicePtrs_t*          m_pinnedCliquePtrs;                   // Pinned-host-memory (device accessible) containing device pointers

--- a/src/clique/MsgQueue.cc
+++ b/src/clique/MsgQueue.cc
@@ -32,7 +32,6 @@ ncclResult_t MsgQueueGetId(std::string name, int projid, bool exclusive, int& ms
   key_t key;
   SYSCHECKVAL(ftok(name.c_str(), projid), "ftok", key);
   int flag = (exclusive == true ? IPC_CREAT | IPC_EXCL : IPC_CREAT);
-
   msgid = msgget(key, MSG_QUEUE_PERM | flag);
   // Check if we're trying to create message queue and it already exists; if so, delete existing queue
   if (msgid == -1 && exclusive == true && errno == EEXIST)
@@ -66,7 +65,7 @@ ncclResult_t MsgQueueClose(std::string name, int projid)
   key_t key;
   int msgid;
   key = ftok(name.c_str(), projid);
-  SYSCHECKVAL(msgget(key, IPC_CREAT), "msgget", msgid);
+  SYSCHECKVAL(msgget(key, 0), "msgget", msgid);
   SYSCHECK(msgctl(msgid, IPC_RMID, NULL), "msgctl");
   return ncclSuccess;
 }

--- a/src/clique/ShmObject.h
+++ b/src/clique/ShmObject.h
@@ -136,6 +136,7 @@ ncclResult_t ShmObject<T>::Open()
     int msgid;
     std::string tmpFileName = "/tmp/" + m_shmName;
     NCCLCHECK(MsgQueueGetId(tmpFileName, m_projid, false, msgid));
+
     if (m_rank == 0)
     {
       ncclResult_t resultSetup = shmSetupExclusive(m_shmName.c_str(), m_shmSize, &shmFd, (void**)&m_shmPtr, 1);


### PR DESCRIPTION
Message queues previously weren't being closed properly for CliqueManager upon clean up.  This can lead to rare problems when a subsequent RCCL run tries to initialize a message queue with the same suffix from a previous run.