### PR TITLE
Disabling env var caching for all unit tests

### DIFF
--- a/test/CorrectnessTest.hpp
+++ b/test/CorrectnessTest.hpp
@@ -803,9 +803,9 @@ dropback:
 
             envString = 0;
             numTokens = 0;
+            setenv("RCCL_TEST_ENV_VARS", "ENABLE", 1);
             if (strcmp(envVals, "")) {
                 // enable RCCL env vars testing
-                setenv("RCCL_TEST_ENV_VARS", "ENABLE", 1);
                 envString = strdup(envVals);
                 tokens[numTokens] = strtok(envString, "=, ");
                 numTokens++;

--- a/test/CorrectnessTest.hpp
+++ b/test/CorrectnessTest.hpp
@@ -553,9 +553,10 @@ dropback:
 
             envString = 0;
             numTokens = 0;
+            setenv("RCCL_TEST_ENV_VARS", "ENABLE", 1);
             if (strcmp(envVals, "")) {
                 // enable RCCL env vars testing
-                setenv("RCCL_TEST_ENV_VARS", "ENABLE", 1);
+
                 envString = strdup(envVals);
                 tokens[numTokens] = strtok(envString, "=, ");
                 numTokens++;


### PR DESCRIPTION
Fix for 'sticky' env-vars in cases when env vars aren't been testing.