### PR TITLE
Adding support for hipMallocManaged() in unit tests

### DIFF
--- a/test/CorrectnessTest.hpp
+++ b/test/CorrectnessTest.hpp
@@ -115,7 +115,16 @@ namespace CorrectnessTests
         // Check if user has opted-in to use managed memory
         static bool UseHmm()
         {
-            return std::getenv("RCCL_USE_HMM");
+            if (getenv("RCCL_USE_HMM") == nullptr)
+            {
+                return false;
+            }
+
+            if (strcmp(getenv("RCCL_USE_HMM"), "1") == 0)
+            {
+                return true;
+            }
+            return false;
         }
 
         // Helper for HMM allocations: if device supports managedMemory, and HMM is requested through


### PR DESCRIPTION
Unit tests can now optionally be run with the Dataset input and output buffers allocated with hipMallocManaged().  To do so, one must opt-in by setting RCCL_USE_HMM=1 and managed/unified memory must be supported by the GPU/ROCm runtime.  Clique kernels are currently not compatible with managed memory, so we skip those tests accordingly.