### PR TITLE
Fixing unit test failure when googletest is built in release mode

### DIFF
--- a/test/CorrectnessTest.hpp
+++ b/test/CorrectnessTest.hpp
@@ -268,6 +268,7 @@ namespace CorrectnessTests
             subDataset.numElements = lastElement - startElement + 1;
             subDataset.dataType    = dataType;
             subDataset.inPlace     = inPlace;
+            subDataset.function    = function;
 
             subDataset.inputs.resize(numDevices);
             subDataset.outputs.resize(numDevices);

--- a/test/test_AllGather.cpp
+++ b/test/test_AllGather.cpp
@@ -14,7 +14,7 @@ namespace CorrectnessTests
 
         // Prepare input / output / expected results
         Dataset dataset;
-        dataset.Initialize(numDevices, numElements, dataType, inPlace);
+        dataset.Initialize(numDevices, numElements, dataType, inPlace, ncclCollAllGather);
         FillDatasetWithPattern(dataset);
         ComputeExpectedResults(dataset);
 
@@ -46,7 +46,7 @@ namespace CorrectnessTests
 
         // Allocate dataset
         Dataset dataset;
-        dataset.Initialize(numDevices, numElements, dataType, inPlace);
+        dataset.Initialize(numDevices, numElements, dataType, inPlace, ncclCollAllGather);
 
         // Loop over several offsets (so that device pointers are not aligned)
         for (int firstElement = 1; firstElement <= 11; firstElement += 2)

--- a/test/test_AllReduce.cpp
+++ b/test/test_AllReduce.cpp
@@ -14,7 +14,7 @@ namespace CorrectnessTests
 
     // Prepare input / output / expected results
     Dataset dataset;
-    dataset.Initialize(numDevices, numElements, dataType, inPlace);
+    dataset.Initialize(numDevices, numElements, dataType, inPlace, ncclCollAllReduce);
     FillDatasetWithPattern(dataset);
     ComputeExpectedResults(dataset, op);
 

--- a/test/test_AllReduceAbort.cpp
+++ b/test/test_AllReduceAbort.cpp
@@ -30,7 +30,7 @@ namespace CorrectnessTests
 
         // Prepare input / output / expected results
         Dataset dataset;
-        dataset.Initialize(numDevices, numElements, dataType, inPlace);
+        dataset.Initialize(numDevices, numElements, dataType, inPlace, ncclCollAllReduce);
         FillDatasetWithPattern(dataset);
 
         int gpu = 0; // GPU number to trigger abort

--- a/test/test_AllReduceGroup.cpp
+++ b/test/test_AllReduceGroup.cpp
@@ -15,9 +15,9 @@ namespace CorrectnessTests
 
     // Prepare input / output / expected results
     Dataset dataset1, dataset2, dataset3;
-    dataset1.Initialize(numDevices, numElements, dataType, inPlace);
-    dataset2.Initialize(numDevices, numElements, dataType, inPlace);
-    dataset3.Initialize(numDevices, numElements, dataType, inPlace);
+    dataset1.Initialize(numDevices, numElements, dataType, inPlace, ncclCollAllReduce);
+    dataset2.Initialize(numDevices, numElements, dataType, inPlace, ncclCollAllReduce);
+    dataset3.Initialize(numDevices, numElements, dataType, inPlace, ncclCollAllReduce);
     FillDatasetWithPattern(dataset1);
     FillDatasetWithPattern(dataset2);
     FillDatasetWithPattern(dataset3);

--- a/test/test_Broadcast.cpp
+++ b/test/test_Broadcast.cpp
@@ -14,7 +14,7 @@ namespace CorrectnessTests
 
         // Allocate data
         Dataset dataset;
-        dataset.Initialize(numDevices, numElements, dataType, inPlace);
+        dataset.Initialize(numDevices, numElements, dataType, inPlace, ncclCollBroadcast);
 
         // Test each possible root
         for (int root = 0; root < numDevices; root++)

--- a/test/test_BroadcastAbort.cpp
+++ b/test/test_BroadcastAbort.cpp
@@ -30,7 +30,7 @@ namespace CorrectnessTests
 
         // Prepare input / output / expected results
         Dataset dataset;
-        dataset.Initialize(numDevices, numElements, dataType, inPlace);
+        dataset.Initialize(numDevices, numElements, dataType, inPlace, ncclCollBroadcast);
         FillDatasetWithPattern(dataset);
 
         int root = 0;

--- a/test/test_CombinedCalls.cpp
+++ b/test/test_CombinedCalls.cpp
@@ -20,9 +20,16 @@ namespace CorrectnessTests
 
         // Create multiple datasets for combined operation
         std::vector<Dataset> datasets(5);
+        std::vector<ncclFunc_t> ncclFuncs(5);
+        ncclFuncs.push_back(ncclCollAllGather);
+        ncclFuncs.push_back(ncclCollAllReduce);
+        ncclFuncs.push_back(ncclCollBroadcast);
+        ncclFuncs.push_back(ncclCollReduce);
+        ncclFuncs.push_back(ncclCollReduceScatter);
+
         for (int i = 0; i < datasets.size(); i++)
         {
-            datasets[i].Initialize(numDevices, numElements, dataType, inPlace);
+            datasets[i].Initialize(numDevices, numElements, dataType, inPlace, ncclFuncs[i]);
             FillDatasetWithPattern(datasets[i]);
         }
 

--- a/test/test_GroupCalls.cpp
+++ b/test/test_GroupCalls.cpp
@@ -19,9 +19,16 @@ namespace CorrectnessTests
 
         // Create multiple datasets for group operation
         std::vector<Dataset> datasets(5);
+        std::vector<ncclFunc_t> ncclFuncs(5);
+        ncclFuncs.push_back(ncclCollAllGather);
+        ncclFuncs.push_back(ncclCollAllReduce);
+        ncclFuncs.push_back(ncclCollBroadcast);
+        ncclFuncs.push_back(ncclCollReduce);
+        ncclFuncs.push_back(ncclCollReduceScatter);
+
         for (int i = 0; i < datasets.size(); i++)
         {
-            datasets[i].Initialize(numDevices, numElements, dataType, inPlace);
+            datasets[i].Initialize(numDevices, numElements, dataType, inPlace, ncclFuncs[i]);
             FillDatasetWithPattern(datasets[i]);
         }
 

--- a/test/test_Reduce.cpp
+++ b/test/test_Reduce.cpp
@@ -14,7 +14,7 @@ namespace CorrectnessTests
 
         // Allocate data
         Dataset dataset;
-        dataset.Initialize(numDevices, numElements, dataType, inPlace);
+        dataset.Initialize(numDevices, numElements, dataType, inPlace, ncclCollReduce);
 
         // Test each possible root
         for (int root = 0; root < numDevices; root++)

--- a/test/test_ReduceScatter.cpp
+++ b/test/test_ReduceScatter.cpp
@@ -15,7 +15,7 @@ namespace CorrectnessTests
 
         // Prepare input / output / expected results
         Dataset dataset;
-        dataset.Initialize(numDevices, numElements, dataType, inPlace);
+        dataset.Initialize(numDevices, numElements, dataType, inPlace, ncclCollReduceScatter);
         FillDatasetWithPattern(dataset);
         ComputeExpectedResults(dataset, op);
 


### PR DESCRIPTION
This is due to a bug with the ExtractSubDataset() function not fully initializing subDataset, specifically the function member.  We were getting lucky with the default uninitialized value in non-release mode.  In release mode, the uninitialized value was wrong enough to throw off the Dataset NumBytes() function causing the actual failure.  I don't know why in release mode the default value is different though.  Shouldn't all enum default values be 0?  Oh well.

I also explicitly set the Dataset function for certain unit tests that weren't doing it already.

