### PR TITLE
Fixing bug with combined calls MP unit test; re-enable MP unit tests

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -22,6 +22,7 @@ def runTestCommand (platform, project, gfilter)
                 set -x
                 cd ${project.paths.project_build_prefix}/build/release/test
                 ${sudo} NCCL_DEBUG=INFO HSA_FORCE_FINE_GRAIN_PCIE=1 ./UnitTests --gtest_filter=${gfilter} --gtest_output=xml --gtest_color=yes
+                ${sudo} NCCL_DEBUG=INFO HSA_FORCE_FINE_GRAIN_PCIE=1 ./UnitTestsMultiProcess --gtest_filter=${gfilter} --gtest_output=xml --gtest_color=yes
             """
 
    platform.runCommand(this, command)

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -21,8 +21,7 @@ def runTestCommand (platform, project, gfilter)
     def command = """#!/usr/bin/env bash
                 set -x
                 cd ${project.paths.project_build_prefix}/build/release/test
-                ${sudo} NCCL_DEBUG=INFO HSA_FORCE_FINE_GRAIN_PCIE=1 ./UnitTests --gtest_filter=${gfilter} --gtest_output=xml --gtest_color=yes
-                ${sudo} NCCL_DEBUG=INFO HSA_FORCE_FINE_GRAIN_PCIE=1 ./UnitTestsMultiProcess --gtest_filter=${gfilter} --gtest_output=xml --gtest_color=yes
+                ${sudo} NCCL_DEBUG=INFO HSA_FORCE_FINE_GRAIN_PCIE=1 ./UnitTests --gtest_filter=${gfilter} --gtest_output=xml --gtest_color=yes  
             """
 
    platform.runCommand(this, command)

--- a/install.sh
+++ b/install.sh
@@ -220,8 +220,10 @@ if ($run_tests); then
     if (test -f "./test/UnitTests"); then
         if ($run_tests_all); then
             ./test/UnitTests
+            ./test/UnitTestsMultiProcess
         else
             ./test/UnitTests --gtest_filter="BroadcastCorrectnessSweep*:*float32*"
+            ./test/UnitTestsMultiProcess --gtest_filter="BroadcastMultiProcessCorrectnessSweep*:*float32*"
         fi
     else
         echo "Unit tests have not been built yet; please re-run script with -t to build unit tests."

--- a/install.sh
+++ b/install.sh
@@ -220,10 +220,8 @@ if ($run_tests); then
     if (test -f "./test/UnitTests"); then
         if ($run_tests_all); then
             ./test/UnitTests
-            ./test/UnitTestsMultiProcess
         else
-            ./test/UnitTests --gtest_filter="BroadcastCorrectnessSweep*:*float32*"
-            ./test/UnitTestsMultiProcess --gtest_filter="BroadcastMultiProcessCorrectnessSweep*:*float32*"
+            ./test/UnitTests --gtest_filter="BroadcastCorrectnessSweep*:*float32*" 
         fi
     else
         echo "Unit tests have not been built yet; please re-run script with -t to build unit tests."

--- a/test/test_CombinedCallsMultiProcess.hpp
+++ b/test/test_CombinedCallsMultiProcess.hpp
@@ -32,6 +32,12 @@ namespace CorrectnessTests
 
             Barrier barrier(rank, numDevices, StripPortNumberFromCommId(std::string(getenv("NCCL_COMM_ID"))));
 
+            for (int i = 0; i < datasets.size(); i++)
+            {
+                FillDatasetWithPattern(*datasets[i], rank);
+            }
+            barrier.Wait();
+
             // Compute expected results for each dataset in combined
             int const root = 0;
             std::vector<int> ranks(1, rank);


### PR DESCRIPTION
Previously we were not filling the dataset prior to running the rest of the unit test leading to bad values and failures.

Would like to see if this gets the multiprocess unit tests fully passing again.