### PR TITLE
[TransferBench] Removing dependency on hip_fp16 header, CSV header fix

### DIFF
--- a/tools/TransferBench/TransferBench.cpp
+++ b/tools/TransferBench/TransferBench.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
   // Print CSV header
   if (ev.outputToCsv)
   {
-    printf("Test,NumBytes,Executor,SrcMem,DstMem,CUs,BW(GB/s),Time(ms),LinkDesc,SrcAddr,DstAddr,ByteOffset,numWarmups,numIters,useHipCall,useMemSet,useSingleSync,combinedTiming\n");
+    printf("Test,NumBytes,SrcMem,Executor,DstMem,CUs,BW(GB/s),Time(ms),LinkDesc,SrcAddr,DstAddr,ByteOffset,numWarmups,numIters,useHipCall,useMemSet,useSingleSync,combinedTiming\n");
   }
 
   // Loop over each line in the Link configuration file

--- a/tools/TransferBench/TransferBench.hpp
+++ b/tools/TransferBench/TransferBench.hpp
@@ -34,13 +34,12 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 #include <hip/hip_ext.h>
 #include <hsa/hsa_ext_amd.h>
-#include <hip/hcc_detail/hip_fp16.h>
 
 // Include common_kernel.h from RCCL for copy kernel
 // However define some variables to avoid extra includes / missing defines
 #define NCCL_DEVICE_H_   // Avoid loading devcomm.h
 #define WARP_SIZE 64
-
+typedef float half;  // TransferBench doesn't actually operate on half-precision floats
 typedef uint64_t PackType;
 typedef ulong2 Pack128;
 typedef struct


### PR DESCRIPTION
- Removing dependency on hip_fp16 header file, which may be renamed in some versions of ROCm.
- Fixing swapped executor / source header in CSV output
