### PR TITLE
TransferBench p2p benchmark mode

### DIFF
--- a/tools/TransferBench/EnvVars.hpp
+++ b/tools/TransferBench/EnvVars.hpp
@@ -40,7 +40,7 @@ public:
 
     useHipCall      = GetEnvVar("USE_HIP_CALL"     , 0);
     useMemset       = GetEnvVar("USE_MEMSET"       , 0);
-    useSingleSync   = GetEnvVar("USE_SINGLE_SYNC"  , 0);
+    useSingleSync   = GetEnvVar("USE_SINGLE_SYNC"  , 1);
     useInteractive  = GetEnvVar("USE_INTERACTIVE"  , 0);
     combineTiming   = GetEnvVar("COMBINE_TIMING"   , 0);
     showAddr        = GetEnvVar("SHOW_ADDR"        , 0);

--- a/tools/TransferBench/TransferBench.cpp
+++ b/tools/TransferBench/TransferBench.cpp
@@ -1119,9 +1119,9 @@ void RunPeerToPeerBenchmarks(EnvVars const& ev, size_t N)
     printf("%sdirectional copy peak bandwidth GB/s\n", isBidirectional ? "Bi" : "Uni");
     printf("%10s", "D/D");
     for (int i = 0; i < numCpus; i++)
-      printf("%8s%02d", "CPU", i);
+      printf("%7s %02d", "CPU", i);
     for (int i = 0; i < numGpus; i++)
-      printf("%8s%02d", "GPU", i);
+      printf("%7s %02d", "GPU", i);
     printf("\n");
 
     // Loop over all possible src/dst pairs
@@ -1129,7 +1129,7 @@ void RunPeerToPeerBenchmarks(EnvVars const& ev, size_t N)
     {
       MemType const& srcMemType = (src < numCpus ? MEM_CPU : MEM_GPU);
       int srcIndex = (srcMemType == MEM_CPU ? src : src - numCpus);
-      printf("%8s%02d", (srcMemType == MEM_CPU) ? "CPU" : "GPU", srcIndex);
+      printf("%7s %02d", (srcMemType == MEM_CPU) ? "CPU" : "GPU", srcIndex);
 
       for (int dst = 0; dst < numDevices; dst++)
       {
@@ -1140,7 +1140,7 @@ void RunPeerToPeerBenchmarks(EnvVars const& ev, size_t N)
         if (bandwidth == 0)
           printf("%10s", "N/A");
         else
-          printf("%10.3f", bandwidth);
+          printf("%10.2f", bandwidth);
         fflush(stdout);
       }
       printf("\n");
@@ -1156,6 +1156,9 @@ double GetPeakBandwidth(EnvVars const& ev, size_t N, int isBidirectional,
   Link links[2];
   int const initOffset = ev.byteOffset / sizeof(float);
 
+  // Skip bidirectional on same device
+  if (isBidirectional && srcMemType == dstMemType && srcIndex == dstIndex) return 0.0f;
+  
   // Prepare Links
   links[0].srcMemType = links[0].exeMemType = links[1].dstMemType = srcMemType;
   links[0].srcIndex   = links[0].exeIndex   = links[1].dstIndex   = srcIndex;

--- a/tools/TransferBench/TransferBench.cpp
+++ b/tools/TransferBench/TransferBench.cpp
@@ -389,6 +389,7 @@ void DisplayUsage(char const* cmdName)
   printf("Usage: %s configFile <N>\n", cmdName);
 
   printf("  configFile: File containing Links to execute (see below for format)\n");
+  printf("              Specifying \"p2p\" as the configFile will execute a peer to peer benchmark\n");
   printf("  N         : (Optional) Number of bytes to transfer per link.\n");
   printf("              If not specified, defaults to %lu bytes. Must be a multiple of 4 bytes\n", DEFAULT_BYTES_PER_LINK);
   printf("              If 0 is specified, a range of Ns will be benchmarked\n");
@@ -888,8 +889,8 @@ void CheckPages(char* array, size_t numBytes, int targetId)
   if (mistakeCount > 0)
   {
     printf("[ERROR] %lu out of %lu pages for memory allocation were not on NUMA node %d\n", mistakeCount, numPages, targetId);
-    // NOTE: Some older versions of HIP do not properly respect NUMA policy so avoid failing for now
-    // exit(1);
+    printf("[ERROR] Ensure up-to-date ROCm is installed\n");
+    exit(1);
   }
 }
 

--- a/tools/TransferBench/TransferBench.hpp
+++ b/tools/TransferBench/TransferBench.hpp
@@ -122,7 +122,10 @@ void DeallocateMemory(MemType memType, int devIndex, float* memPtr);
 void CheckPages(char* byteArray, size_t numBytes, int targetId);
 void CheckOrFill(ModeType mode, int N, bool isMemset, bool isHipCall, std::vector<float> const& fillPattern, float* ptr);
 void RunLink(EnvVars const& ev, size_t const N, int const iteration, Link& link);
-
+void RunPeerToPeerBenchmarks(EnvVars const& ev, size_t N);
+double GetPeakBandwidth(EnvVars const& ev, size_t N, int isBidirectional,
+                        MemType srcMemType, int srcIndex,
+                        MemType dstMemType, int dstIndex);
 
 std::string GetLinkTypeDesc(uint32_t linkType, uint32_t hopCount);
 std::string GetDesc(MemType srcMemType, int srcIndex,


### PR DESCRIPTION
- Adding a p2p benchmark mode to TransferBench (activated via specifying "p2p") as configFile
- Setting USE_SINGLE_SYNC=1 by default