### PR TITLE
Re-enable use of chrpath to manually set rpath for unit tests.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,11 @@ if(BUILD_TESTS)
 
   message("Going to build unit tests (Installed in /test/UnitTests)")
 
+  find_program(CHRPATH chrpath)
+  if(NOT CHRPATH)
+      message(FATAL_ERROR "chrpath is required for UnitTests. Please install (e.g. sudo apt-get install chrpath)")
+  endif()
+
   include_directories(${GTEST_INCLUDE_DIRS})
 
   # Collect source files for tests


### PR DESCRIPTION
Looks like in ROCm 4.5, hipcc sets rpath to /opt/rocm/lib again, and unfortunately it sets it before any user-specified rpath value, so it always takes priority over the user choice.  We need to call chrpath again to set it on the executable ourselves afterwards.

If we don't specify an install_prefix, then the tests and RCCL lib will be located in build/release; the first branch deals with that situation.  2nd branch is when we specify an install_prefix meaning the lib will be located somewhere else.

I also switched to add_custom_command to run chrpath.  The previous install command didn't seem to work.  add_custom_command pretty much does the exact same thing for our purposes.