### PR TITLE
[TransferBench] Adding #CUs / RRLW mode to p2p benchmark

### DIFF
--- a/tools/TransferBench/TransferBench.hpp
+++ b/tools/TransferBench/TransferBench.hpp
@@ -122,10 +122,11 @@ void DeallocateMemory(MemType memType, int devIndex, float* memPtr);
 void CheckPages(char* byteArray, size_t numBytes, int targetId);
 void CheckOrFill(ModeType mode, int N, bool isMemset, bool isHipCall, std::vector<float> const& fillPattern, float* ptr);
 void RunLink(EnvVars const& ev, size_t const N, int const iteration, Link& link);
-void RunPeerToPeerBenchmarks(EnvVars const& ev, size_t N);
+void RunPeerToPeerBenchmarks(EnvVars const& ev, size_t N, int numBlocksToUse);
 double GetPeakBandwidth(EnvVars const& ev, size_t N, int isBidirectional,
                         MemType srcMemType, int srcIndex,
-                        MemType dstMemType, int dstIndex);
+                        MemType dstMemType, int dstIndex,
+                        int readMode);
 
 std::string GetLinkTypeDesc(uint32_t linkType, uint32_t hopCount);
 std::string GetDesc(MemType srcMemType, int srcIndex,


### PR DESCRIPTION
- Adding argument to p2p benchmark mode to specify number of CUs to use (default is still max available on device)
- Adding tables for remote read / local write transfers