### PR TITLE
Set ROCM_PATH CMake variable in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -205,9 +205,9 @@ fi
 check_exit_code "$?"
 
 if ($build_tests) || (($run_tests) && [[ ! -f ./test/UnitTests ]]); then
-    CXX=$ROCM_BIN_PATH/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=$ROCM_PATH ../../.
+    CXX=$ROCM_BIN_PATH/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=$ROCM_PATH -DROCM_PATH=$ROCM_PATH ../../.
 else
-    CXX=$ROCM_BIN_PATH/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$ROCM_PATH ../../.
+    CXX=$ROCM_BIN_PATH/$compiler $cmake_executable $cmake_common_options -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$ROCM_PATH -DROCM_PATH=$ROCM_PATH ../../.
 fi
 check_exit_code "$?"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,7 +81,7 @@ if(BUILD_TESTS)
   # HIPCC adds /opt/rocm/lib as RPATH, even though the install process is supposed to
   # remove RPATH.  It also occurs before any user-specified rpath, which effectively overrides the user rpath.
   #  As a work-around, set the correct RPATH for the unit test executable as a post-install step
-  if (CMAKE_INSTALL_PREFIX STREQUAL "/opt/rocm")
+  if (CMAKE_INSTALL_PREFIX MATCHES "/opt/rocm*")
     # install_prefix/CMAKE_INSTALL_PREFIX was not explicitly specified, so look in build/release
     add_custom_command( TARGET UnitTests POST_BUILD COMMAND chrpath ARGS -r ${CMAKE_BINARY_DIR}:/opt/rocm/lib ${CMAKE_BINARY_DIR}/test/UnitTests)
     add_custom_command( TARGET UnitTestsMultiProcess POST_BUILD COMMAND chrpath ARGS -r ${CMAKE_BINARY_DIR}:/opt/rocm/lib ${CMAKE_BINARY_DIR}/test/UnitTestsMultiProcess)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,13 +81,13 @@ if(BUILD_TESTS)
   # HIPCC adds /opt/rocm/lib as RPATH, even though the install process is supposed to
   # remove RPATH.  It also occurs before any user-specified rpath, which effectively overrides the user rpath.
   #  As a work-around, set the correct RPATH for the unit test executable as a post-install step
-  if (CMAKE_INSTALL_PREFIX MATCHES "/opt/rocm*")
+  if (CMAKE_INSTALL_PREFIX MATCHES "${ROCM_PATH}")
     # install_prefix/CMAKE_INSTALL_PREFIX was not explicitly specified, so look in build/release
-    add_custom_command( TARGET UnitTests POST_BUILD COMMAND chrpath ARGS -r ${CMAKE_BINARY_DIR}:/opt/rocm/lib ${CMAKE_BINARY_DIR}/test/UnitTests)
-    add_custom_command( TARGET UnitTestsMultiProcess POST_BUILD COMMAND chrpath ARGS -r ${CMAKE_BINARY_DIR}:/opt/rocm/lib ${CMAKE_BINARY_DIR}/test/UnitTestsMultiProcess)
+    add_custom_command( TARGET UnitTests POST_BUILD COMMAND chrpath ARGS -r ${CMAKE_BINARY_DIR}:${ROCM_PATH}/lib ${CMAKE_BINARY_DIR}/test/UnitTests)
+    add_custom_command( TARGET UnitTestsMultiProcess POST_BUILD COMMAND chrpath ARGS -r ${CMAKE_BINARY_DIR}:${ROCM_PATH}/lib ${CMAKE_BINARY_DIR}/test/UnitTestsMultiProcess)
   else()
-    add_custom_command( TARGET UnitTests POST_BUILD COMMAND chrpath ARGS -r ${CMAKE_INSTALL_PREFIX}/lib:/opt/rocm/lib ${CMAKE_INSTALL_PREFIX}/test/UnitTests)
-    add_custom_command( TARGET UnitTestsMultiProcess POST_BUILD COMMAND chrpath ARGS -r ${CMAKE_INSTALL_PREFIX}/lib:/opt/rocm/lib ${CMAKE_INSTALL_PREFIX}/test/UnitTestsMultiProcess)
+    add_custom_command( TARGET UnitTests POST_BUILD COMMAND chrpath ARGS -r ${CMAKE_INSTALL_PREFIX}/lib:${ROCM_PATH}/lib ${CMAKE_INSTALL_PREFIX}/test/UnitTests)
+    add_custom_command( TARGET UnitTestsMultiProcess POST_BUILD COMMAND chrpath ARGS -r ${CMAKE_INSTALL_PREFIX}/lib:${ROCM_PATH}/lib ${CMAKE_INSTALL_PREFIX}/test/UnitTestsMultiProcess)
   endif()
 else()
   message("Not building unit tests")


### PR DESCRIPTION
In the centos docker images I've encountered, the ROCM_PATH environment variable is set.  In Ubuntu it is not.  This can lead to a mismatch of CMAKE_INSTALL_PREFIX in CMake (https://github.com/ROCmSoftwarePlatform/rccl/blob/develop/CMakeLists.txt#L24), as in the install script we pass in -DCMAKE_INSTALL_PREFIX=ROCM_PATH, where ROCM_PATH is set to /opt/rocm (which can be a symlink), whereas in the CMake code we set ROCM_PATH to /opt/rocm **after** resolving the symlink.

I now set ROCM_PATH in the install script to remove any ambiguity.  This was leading to unit test build failures with my recent chrpath changes.
