### PR TITLE
Fixing setting of GPUs to 2 when 1 or less GPUs on system for unit tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,7 +70,7 @@ if(BUILD_TESTS)
   find_program( rocminfo_executable rocminfo )
   execute_process(COMMAND bash "-c" "${rocminfo_executable} | grep 'Device Type' | grep GPU | wc -l | tr -d '\n'" OUTPUT_VARIABLE gtest_num_gpus)
   if(${gtest_num_gpus} MATCHES "0" OR ${gtest_num_gpus} MATCHES "1")
-    set(gtest_num_gpus,"2")
+    set(gtest_num_gpus "2")
   endif()
   target_compile_options(UnitTests PRIVATE -DGTESTS_NUM_GPUS=${gtest_num_gpus})
 


### PR DESCRIPTION
Small syntax error meant gtest_num_gpus wasn't getting set to 2 at all, leading to weird GTest error messages instead of skipping tests.