### PR TITLE
TransferBench: Adding ability to reindex GPUs based on PCIe address

### DIFF
--- a/tools/TransferBench/EnvVars.hpp
+++ b/tools/TransferBench/EnvVars.hpp
@@ -51,6 +51,7 @@ public:
   int numCpuPerLink;   // Number of CPU child threads to use per CPU link
   int sharedMemBytes;  // Amount of shared memory to use per threadblock
   int blockBytes;      // Each CU, except the last, gets a multiple of this many bytes to copy
+  int usePcieIndexing; // Base GPU indexing on PCIe address instead of HIP device
 
   std::vector<float> fillPattern; // Pattern of floats used to fill source data
 
@@ -75,6 +76,7 @@ public:
     numCpuPerLink   = GetEnvVar("NUM_CPU_PER_LINK" , DEFAULT_NUM_CPU_PER_LINK);
     sharedMemBytes  = GetEnvVar("SHARED_MEM_BYTES" , maxSharedMemBytes / 2 + 1);
     blockBytes      = GetEnvVar("BLOCK_BYTES"      , 256);
+    usePcieIndexing = GetEnvVar("USE_PCIE_INDEX"   , 0);
 
     // Check for fill pattern
     char* pattern = getenv("FILL_PATTERN");
@@ -192,6 +194,7 @@ public:
     printf(" FILL_PATTERN=STR   - Fill input buffer with pattern specified in hex digits (0-9,a-f,A-F).  Must be even number of digits, (byte-level big-endian)\n");
     printf(" SHARED_MEM_BYTES=X - Use X shared mem bytes per threadblock, potentially to avoid multiple threadblocks per CU\n");
     printf(" BLOCK_BYTES=B      - Each CU (except the last) receives a multiple of BLOCK_BYTES to copy\n");
+    printf(" USE_PCIE_INDEX     - Index GPUs by PCIe address-ordering instead of HIP-provided indexing\n");
   }
 
   // Display env var settings
@@ -238,6 +241,7 @@ public:
       printf("%-20s = %12s : Using %d shared mem per threadblock\n", "SHARED_MEM_BYTES",
              getenv("SHARED_MEM_BYTES") ? "(specified)" : "(unset)", sharedMemBytes);
       printf("%-20s = %12d : Each CU gets a multiple of %d bytes to copy\n", "BLOCK_BYTES", blockBytes, blockBytes);
+      printf("%-20s = %12d : Using %s-based GPU indexing\n", "USE_PCIE_INDEX", usePcieIndexing, (usePcieIndexing ? "PCIe" : "HIP"));
       printf("\n");
     }
   };

--- a/tools/TransferBench/TransferBench.hpp
+++ b/tools/TransferBench/TransferBench.hpp
@@ -105,7 +105,7 @@ void ParseMemType(std::string const& token, int const numCpus, int const numGpus
 void ParseLinks(char* line, int numCpus, int numGpus, std::vector<Link>& links);       // Parse Link information
 void EnablePeerAccess(int const deviceId, int const peerDeviceId);
 void AllocateMemory(MemType memType, int devIndex, size_t numBytes, float** memPtr);
-void DeallocateMemory(MemType memType, int devIndex, float* memPtr);
+void DeallocateMemory(MemType memType, float* memPtr);
 void CheckPages(char* byteArray, size_t numBytes, int targetId);
 void CheckOrFill(ModeType mode, int N, bool isMemset, bool isHipCall, std::vector<float> const& fillPattern, float* ptr);
 void RunLink(EnvVars const& ev, size_t const N, int const iteration, Link& link);
@@ -119,3 +119,4 @@ std::string GetLinkTypeDesc(uint32_t linkType, uint32_t hopCount);
 std::string GetDesc(MemType srcMemType, int srcIndex,
                     MemType dstMemType, int dstIndex);
 std::string GetLinkDesc(Link const& link);
+int RemappedIndex(int const origIdx, MemType const memType);


### PR DESCRIPTION
Adding new GPU indexing mode based on PCIe bus address, instead of ROCr/HIP device numbers
