### PR TITLE
Changing initialization method for UnitTests

### DIFF
--- a/test/AllReduce_GroupCall.cpp
+++ b/test/AllReduce_GroupCall.cpp
@@ -36,8 +36,8 @@ namespace RcclUnitTesting
       for (int dataIdx = 0; dataIdx < dataTypes.size() && isCorrect; ++dataIdx)
       {
         if (testBed.ev.showNames)
-          INFO("%s process %2d-ranks AllReduce %d Grouped Calls (%s-%s)\n",
-               isMultiProcess ? "Multi " : "Single",
+          INFO("%s %d-ranks AllReduce %d Grouped Calls (%s-%s)\n",
+               isMultiProcess ? "MP" : "SP",
                totalRanks, numCollPerGroup,
                ncclRedOpNames[redOps[redOpIdx]], ncclDataTypeNames[dataTypes[dataIdx]]);
 

--- a/test/AllReduce_PreMultScalar.cpp
+++ b/test/AllReduce_PreMultScalar.cpp
@@ -48,8 +48,8 @@ namespace RcclUnitTesting
         for (int scalarMode = 0; scalarMode <= 1 && isCorrect; ++scalarMode)
         {
           if (testBed.ev.showNames)
-            INFO("%s process %2d-ranks AllReduce (custom-scalar Mode %d %s)\n",
-                 isMultiProcess ? "Multi " : "Single",
+            INFO("%s %d-ranks AllReduce (custom-scalar Mode %d %s)\n",
+                 isMultiProcess ? "MP" : "SP",
                  totalRanks, scalarMode, ncclDataTypeNames[dataType]);
 
           for (int i = 0; i < numElements.size() && isCorrect; ++i)

--- a/test/SendRecv_SinglePairs.cpp
+++ b/test/SendRecv_SinglePairs.cpp
@@ -48,8 +48,8 @@ namespace RcclUnitTesting
           if (recvRank  != sendRank)
           {
             if (testBed.ev.showNames) // Show test names
-              INFO("%s process Datatype: %s SendReceive test Rank %d -> Rank %d for %d Elements\n",
-                  isMultiProcess ? "Multi " : "Single",
+              INFO("%s Datatype: %s SendReceive test Rank %d -> Rank %d for %d Elements\n",
+                  isMultiProcess ? "MP" : "SP",
                   ncclDataTypeNames[dataTypes[dataIdx]],
                   sendRank,
                   recvRank,

--- a/test/common/TestBedChild.hpp
+++ b/test/common/TestBedChild.hpp
@@ -20,20 +20,22 @@ namespace RcclUnitTesting
     // These are commands that can be given to the child process
     enum
     {
-      CHILD_INIT_COMMS       = 0,  // InitComms()
-      CHILD_SET_COLL_ARGS    = 1,  // SetCollectiveArgs()
-      CHILD_ALLOCATE_MEM     = 2,  // AllocateMem()
-      CHILD_PREPARE_DATA     = 3,  // PrepareData()
-      CHILD_EXECUTE_COLL     = 4,  // ExecuteCollectives()
-      CHILD_VALIDATE_RESULTS = 5,  // ValidateResults()
-      CHILD_DEALLOCATE_MEM   = 6,  // DeallocateMem()
-      CHILD_DESTROY_COMMS    = 7,  // DestroyComms()
-      CHILD_STOP             = 8,  // Stop()
-      NUM_CHILD_COMMANDS     = 9
+      CHILD_GET_UNIQUE_ID    = 0,  // GetUniqueId()
+      CHILD_INIT_COMMS       = 1,  // InitComms()
+      CHILD_SET_COLL_ARGS    = 2,  // SetCollectiveArgs()
+      CHILD_ALLOCATE_MEM     = 3,  // AllocateMem()
+      CHILD_PREPARE_DATA     = 4,  // PrepareData()
+      CHILD_EXECUTE_COLL     = 5,  // ExecuteCollectives()
+      CHILD_VALIDATE_RESULTS = 6,  // ValidateResults()
+      CHILD_DEALLOCATE_MEM   = 7,  // DeallocateMem()
+      CHILD_DESTROY_COMMS    = 8,  // DestroyComms()
+      CHILD_STOP             = 9,  // Stop()
+      NUM_CHILD_COMMANDS     = 10
     };
 
     char const ChildCommandNames[NUM_CHILD_COMMANDS][20] =
     {
+      "GET_UNIQUE_ID",
       "INIT_COMMS",
       "SET_COLL_ARGS",
       "ALLOCATE_MEM",
@@ -76,6 +78,9 @@ namespace RcclUnitTesting
     void StartExecutionLoop();
 
   protected:
+    // Calls ncclGetUniqueId and returns it to parent
+    ErrCode GetUniqueId();
+
     // Initialize RCCL communicators
     ErrCode InitComms();
 


### PR DESCRIPTION
- Switching from NCCL_COMM_ID to passing ncclUniqueId from first rank to all other ranks via parent process.
- Minor test name renaming for consistency