### PR TITLE
Replace hardcoded /opt/rocm with ROCM_PATH env var

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -72,7 +72,7 @@ endif()
 
 
 # Find or download/install rocm-cmake project
-find_package(ROCM QUIET CONFIG PATHS /opt/rocm)
+find_package(ROCM QUIET CONFIG PATHS $ENV{ROCM_PATH})
 if(NOT ROCM_FOUND)
     set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
     file(

--- a/tools/HelloRccl/Makefile
+++ b/tools/HelloRccl/Makefile
@@ -3,7 +3,7 @@
 # Set to where RCCL is installed
 RCCL_INSTALL=../../build/release
 
-HIP_PATH?= $(wildcard /opt/rocm/hip)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
 ifeq (,$(HIP_PATH))
 HIP_PATH=../../..
 endif

--- a/tools/TransferBench/Makefile
+++ b/tools/TransferBench/Makefile
@@ -1,5 +1,5 @@
 # Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
-HIP_PATH?= $(wildcard /opt/rocm/hip)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
 ifeq (,$(HIP_PATH))
 HIP_PATH=../../..
 endif

--- a/tools/ib-test/Makefile
+++ b/tools/ib-test/Makefile
@@ -1,5 +1,5 @@
 # Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
-HIP_PATH ?= $(wildcard /opt/rocm/hip)
+HIP_PATH ?= $(wildcard $(ROCM_PATH)/hip)
 ifeq (,$(HIP_PATH))
 HIP_PATH = ../../..
 endif

--- a/tools/rccl-prim-test/Makefile
+++ b/tools/rccl-prim-test/Makefile
@@ -1,12 +1,12 @@
 # Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
-HIP_PATH?= $(wildcard /opt/rocm/hip)
+HIP_PATH?= $(wildcard $(ROCM_PATH)/hip)
 ifeq (,$(HIP_PATH))
 	HIP_PATH=../../..
 endif
 HIPCC=$(HIP_PATH)/bin/hipcc
 
 EXE=rccl_prim_test
-CXXFLAGS = -O3 -g -I/opt/rocm/rocrand/include
+CXXFLAGS = -O3 -g -I$(ROCM_PATH)/rocrand/include
 
 all: $(EXE)
 

--- a/tools/topo_expl/Makefile
+++ b/tools/topo_expl/Makefile
@@ -1,5 +1,5 @@
 # Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
-HIP_PATH ?= $(wildcard /opt/rocm/hip)
+HIP_PATH ?= $(wildcard $(ROCM_PATH)/hip)
 ifeq (,$(HIP_PATH))
 HIP_PATH = ../../..
 endif


### PR DESCRIPTION
We install the ROCM package under home directory so that multiple staffs can share the same machine with different ROCM version.  However, several places in RCCL hardcode /opt/rocm. This patch tries to fix it.