### PR TITLE
Adding explicit request for coarse-grained host memory

### DIFF
--- a/tools/TransferBench/TransferBench.cpp
+++ b/tools/TransferBench/TransferBench.cpp
@@ -884,7 +884,7 @@ void AllocateMemory(MemType memType, int devIndex, size_t numBytes, float** memP
     }
 
     // Allocate host-pinned memory (should respect NUMA mem policy)
-    HIP_CALL(hipHostMalloc((void **)memPtr, numBytes, hipHostMallocNumaUser));
+    HIP_CALL(hipHostMalloc((void **)memPtr, numBytes, hipHostMallocNumaUser | hipHostMallocNonCoherent));
 
     // Check that the allocated pages are actually on the correct NUMA node
     CheckPages((char*)*memPtr, numBytes, numaIdx);


### PR DESCRIPTION
- hipHostMalloc now allows fine-grained host memory so explicit request for non-coherent coarse grained host memory is requested