### PR TITLE
Fixing the broken library soft link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,8 +330,6 @@ License: See LICENSE.txt for license information\n")
   Optimized primitives for collective multi-GPU communication")
 endif()
 
-rocm_install_symlink_subdir(rccl)
-
 if(BUILD_TESTS)
   rocm_package_setup_component(clients)
   rocm_package_setup_client_component(tests)


### PR DESCRIPTION
librrcl.so is is having a dead soft link. Which is causing issues with tensor flow build. Fixing it.