### PR TITLE
[TransferBench] Syncing with TransferBench v1.02

### DIFF
--- a/tools/TransferBench/CHANGELOG.md
+++ b/tools/TransferBench/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for TransferBench
 
+## v1.02
+### Added
+- Setting NUM_ITERATIONS to negative number indicates to run for -NUM_ITERATIONS seconds per Test
+### Changed
+- Copies are now refered to as Transfers instead of Links
+- Re-ordering how env vars are displayed (alphabetically now)
+### Removed
+- Combined timing is now always on for kernel-based GPU copies. COMBINED_TIMING env var has been removed
+- Use single sync is no longer supported to facility variable iterations. USE_SINGLE_SYNC env var has been removed
+
 ## v1.01
 ### Added
 - Adding USE_SINGLE_STREAM feature

--- a/tools/TransferBench/EnvVars.hpp
+++ b/tools/TransferBench/EnvVars.hpp
@@ -25,34 +25,32 @@ THE SOFTWARE.
 
 #include <algorithm>
 
-#define TB_VERSION "1.01"
+#define TB_VERSION "1.02"
 
 // This class manages environment variable that affect TransferBench
 class EnvVars
 {
 public:
   // Default configuration values
-  int const DEFAULT_NUM_WARMUPS      =  3;
-  int const DEFAULT_NUM_ITERATIONS   = 10;
-  int const DEFAULT_SAMPLING_FACTOR  =  1;
-  int const DEFAULT_NUM_CPU_PER_LINK =  4;
+  int const DEFAULT_NUM_WARMUPS          =  3;
+  int const DEFAULT_NUM_ITERATIONS       = 10;
+  int const DEFAULT_SAMPLING_FACTOR      =  1;
+  int const DEFAULT_NUM_CPU_PER_TRANSFER =  4;
 
   // Environment variables
-  int useHipCall;      // Use hipMemcpy/hipMemset instead of custom shader kernels
-  int useMemset;       // Perform a memset instead of a copy (ignores source memory)
-  int useSingleSync;   // Perform synchronization only once after all iterations instead of per iteration
-  int useInteractive;  // Pause for user-input before starting transfer loop
-  int combineTiming;   // Combines the timing with kernel launch
-  int outputToCsv;     // Output in CSV format
-  int byteOffset;      // Byte-offset for memory allocations
-  int numWarmups;      // Number of un-timed warmup iterations to perform
-  int numIterations;   // Number of timed iterations to perform
-  int samplingFactor;  // Affects how many different values of N are generated (when N set to 0)
-  int numCpuPerLink;   // Number of CPU child threads to use per CPU link
-  int sharedMemBytes;  // Amount of shared memory to use per threadblock
-  int blockBytes;      // Each CU, except the last, gets a multiple of this many bytes to copy
-  int usePcieIndexing; // Base GPU indexing on PCIe address instead of HIP device
-  int useSingleStream; // Use a single stream per device instead of per Link. Can not be used with USE_HIP_CALL
+  int blockBytes;        // Each CU, except the last, gets a multiple of this many bytes to copy
+  int byteOffset;        // Byte-offset for memory allocations
+  int numCpuPerTransfer; // Number of CPU child threads to use per CPU Transfer
+  int numIterations;     // Number of timed iterations to perform.  If negative, run for -numIterations seconds instead
+  int numWarmups;        // Number of un-timed warmup iterations to perform
+  int outputToCsv;       // Output in CSV format
+  int samplingFactor;    // Affects how many different values of N are generated (when N set to 0)
+  int sharedMemBytes;    // Amount of shared memory to use per threadblock
+  int useHipCall;        // Use hipMemcpy/hipMemset instead of custom shader kernels
+  int useInteractive;    // Pause for user-input before starting transfer loop
+  int useMemset;         // Perform a memset instead of a copy (ignores source memory)
+  int usePcieIndexing;   // Base GPU indexing on PCIe address instead of HIP device
+  int useSingleStream;   // Use a single stream per device instead of per Tink. Can not be used with USE_HIP_CALL
 
   std::vector<float> fillPattern; // Pattern of floats used to fill source data
 
@@ -63,21 +61,19 @@ public:
     hipDeviceGetAttribute(&maxSharedMemBytes,
                           hipDeviceAttributeMaxSharedMemoryPerMultiprocessor, 0);
 
-    useHipCall      = GetEnvVar("USE_HIP_CALL"     , 0);
-    useMemset       = GetEnvVar("USE_MEMSET"       , 0);
-    useSingleSync   = GetEnvVar("USE_SINGLE_SYNC"  , 1);
-    useInteractive  = GetEnvVar("USE_INTERACTIVE"  , 0);
-    combineTiming   = GetEnvVar("COMBINE_TIMING"   , 0);
-    outputToCsv     = GetEnvVar("OUTPUT_TO_CSV"    , 0);
-    byteOffset      = GetEnvVar("BYTE_OFFSET"      , 0);
-    numWarmups      = GetEnvVar("NUM_WARMUPS"      , DEFAULT_NUM_WARMUPS);
-    numIterations   = GetEnvVar("NUM_ITERATIONS"   , DEFAULT_NUM_ITERATIONS);
-    samplingFactor  = GetEnvVar("SAMPLING_FACTOR"  , DEFAULT_SAMPLING_FACTOR);
-    numCpuPerLink   = GetEnvVar("NUM_CPU_PER_LINK" , DEFAULT_NUM_CPU_PER_LINK);
-    sharedMemBytes  = GetEnvVar("SHARED_MEM_BYTES" , maxSharedMemBytes / 2 + 1);
-    blockBytes      = GetEnvVar("BLOCK_BYTES"      , 256);
-    usePcieIndexing = GetEnvVar("USE_PCIE_INDEX"   , 0);
-    useSingleStream = GetEnvVar("USE_SINGLE_STREAM", 0);
+    blockBytes        = GetEnvVar("BLOCK_BYTES"         , 256);
+    byteOffset        = GetEnvVar("BYTE_OFFSET"         , 0);
+    numCpuPerTransfer = GetEnvVar("NUM_CPU_PER_TRANSFER", DEFAULT_NUM_CPU_PER_TRANSFER);
+    numIterations     = GetEnvVar("NUM_ITERATIONS"      , DEFAULT_NUM_ITERATIONS);
+    numWarmups        = GetEnvVar("NUM_WARMUPS"         , DEFAULT_NUM_WARMUPS);
+    outputToCsv       = GetEnvVar("OUTPUT_TO_CSV"       , 0);
+    samplingFactor    = GetEnvVar("SAMPLING_FACTOR"     , DEFAULT_SAMPLING_FACTOR);
+    sharedMemBytes    = GetEnvVar("SHARED_MEM_BYTES"    , maxSharedMemBytes / 2 + 1);
+    useHipCall        = GetEnvVar("USE_HIP_CALL"        , 0);
+    useInteractive    = GetEnvVar("USE_INTERACTIVE"     , 0);
+    useMemset         = GetEnvVar("USE_MEMSET"          , 0);
+    usePcieIndexing   = GetEnvVar("USE_PCIE_INDEX"      , 0);
+    useSingleStream   = GetEnvVar("USE_SINGLE_STREAM"   , 0);
 
     // Check for fill pattern
     char* pattern = getenv("FILL_PATTERN");
@@ -148,19 +144,14 @@ public:
       printf("[ERROR] NUM_WARMUPS must be set to a non-negative number\n");
       exit(1);
     }
-    if (numIterations <= 0)
-    {
-      printf("[ERROR] NUM_ITERATIONS must be set to a positive number\n");
-      exit(1);
-    }
     if (samplingFactor < 1)
     {
       printf("[ERROR] SAMPLING_FACTOR must be greater or equal to 1\n");
       exit(1);
     }
-    if (numCpuPerLink < 1)
+    if (numCpuPerTransfer < 1)
     {
-      printf("[ERROR] NUM_CPU_PER_LINK must be greater or equal to 1\n");
+      printf("[ERROR] NUM_CPU_PER_TRANSFER must be greater or equal to 1\n");
       exit(1);
     }
     if (sharedMemBytes < 0 || sharedMemBytes > maxSharedMemBytes)
@@ -185,22 +176,20 @@ public:
   {
     printf("Environment variables:\n");
     printf("======================\n");
-    printf(" USE_HIP_CALL       - Use hipMemcpy/hipMemset instead of custom shader kernels for GPU-executed copies\n");
-    printf(" USE_MEMSET         - Perform a memset instead of a copy (ignores source memory)\n");
-    printf(" USE_SINGLE_SYNC    - Perform synchronization only once after all iterations instead of per iteration\n");
-    printf(" USE_INTERACTIVE    - Pause for user-input before starting transfer loop\n");
-    printf(" COMBINE_TIMING     - Combines timing with launch (potentially lower timing overhead)\n");
-    printf(" OUTPUT_TO_CSV      - Outputs to CSV format if set\n");
-    printf(" BYTE_OFFSET        - Initial byte-offset for memory allocations.  Must be multiple of 4. Defaults to 0\n");
-    printf(" NUM_WARMUPS=W      - Perform W untimed warmup iteration(s) per test\n");
-    printf(" NUM_ITERATIONS=I   - Perform I timed iteration(s) per test\n");
-    printf(" SAMPLING_FACTOR=F  - Add F samples (when possible) between powers of 2 when auto-generating data sizes\n");
-    printf(" NUM_CPU_PER_LINK=C - Use C threads per Link for CPU-executed copies\n");
-    printf(" FILL_PATTERN=STR   - Fill input buffer with pattern specified in hex digits (0-9,a-f,A-F).  Must be even number of digits, (byte-level big-endian)\n");
-    printf(" SHARED_MEM_BYTES=X - Use X shared mem bytes per threadblock, potentially to avoid multiple threadblocks per CU\n");
     printf(" BLOCK_BYTES=B      - Each CU (except the last) receives a multiple of BLOCK_BYTES to copy\n");
+    printf(" BYTE_OFFSET        - Initial byte-offset for memory allocations.  Must be multiple of 4. Defaults to 0\n");
+    printf(" FILL_PATTERN=STR   - Fill input buffer with pattern specified in hex digits (0-9,a-f,A-F).  Must be even number of digits, (byte-level big-endian)\n");
+    printf(" NUM_CPU_PER_TRANSFER=C - Use C threads per Transfer for CPU-executed copies\n");
+    printf(" NUM_ITERATIONS=I   - Perform I timed iteration(s) per test\n");
+    printf(" NUM_WARMUPS=W      - Perform W untimed warmup iteration(s) per test\n");
+    printf(" OUTPUT_TO_CSV      - Outputs to CSV format if set\n");
+    printf(" SAMPLING_FACTOR=F  - Add F samples (when possible) between powers of 2 when auto-generating data sizes\n");
+    printf(" SHARED_MEM_BYTES=X - Use X shared mem bytes per threadblock, potentially to avoid multiple threadblocks per CU\n");
+    printf(" USE_HIP_CALL       - Use hipMemcpy/hipMemset instead of custom shader kernels for GPU-executed copies\n");
+    printf(" USE_INTERACTIVE    - Pause for user-input before starting transfer loop\n");
+    printf(" USE_MEMSET         - Perform a memset instead of a copy (ignores source memory)\n");
     printf(" USE_PCIE_INDEX     - Index GPUs by PCIe address-ordering instead of HIP-provided indexing\n");
-    printf(" USE_SINGLE_STREAM  - Use single stream per device instead of per link.  Cannot be used with USE_HIP_CALL\n");
+    printf(" USE_SINGLE_STREAM  - Use single stream per device instead of per Transfer.  Cannot be used with USE_HIP_CALL\n");
   }
 
   // Display env var settings
@@ -210,43 +199,39 @@ public:
     {
       printf("Run configuration (TransferBench v%s)\n", TB_VERSION);
       printf("=====================================================\n");
+      printf("%-20s = %12d : Each CU gets a multiple of %d bytes to copy\n", "BLOCK_BYTES", blockBytes, blockBytes);
+      printf("%-20s = %12d : Using byte offset of %d\n", "BYTE_OFFSET", byteOffset, byteOffset);
+      printf("%-20s = %12s : ", "FILL_PATTERN", getenv("FILL_PATTERN") ? "(specified)" : "(unset)");
+      if (fillPattern.size())
+        printf("Pattern: %s", getenv("FILL_PATTERN"));
+      else
+        printf("Pseudo-random: (Element i = i modulo 383 + 31)");
+      printf("\n");
+      printf("%-20s = %12d : Using %d CPU thread(s) per CPU-based-copy Transfer\n", "NUM_CPU_PER_TRANSFER", numCpuPerTransfer, numCpuPerTransfer);
+      printf("%-20s = %12d : Running %d %s per topology\n", "NUM_ITERATIONS", numIterations,
+             numIterations > 0 ? numIterations : -numIterations,
+             numIterations > 0 ? "timed iteration(s)" : "second(s)");
+      printf("%-20s = %12d : Running %d warmup iteration(s) per topology\n", "NUM_WARMUPS", numWarmups, numWarmups);
+      printf("%-20s = %12d : Output to %s\n", "OUTPUT_TO_CSV", outputToCsv,
+             outputToCsv ? "CSV" : "console");
+      printf("%-20s = %12s : Using %d shared mem per threadblock\n", "SHARED_MEM_BYTES",
+             getenv("SHARED_MEM_BYTES") ? "(specified)" : "(unset)", sharedMemBytes);
       printf("%-20s = %12d : Using %s for GPU-executed copies\n", "USE_HIP_CALL", useHipCall,
              useHipCall ? "HIP functions" : "custom kernels");
-      printf("%-20s = %12d : Performing %s\n", "USE_MEMSET", useMemset,
-             useMemset ? "memset" : "memcopy");
       if (useHipCall && !useMemset)
       {
         char* env = getenv("HSA_ENABLE_SDMA");
         printf("%-20s = %12s : %s\n", "HSA_ENABLE_SDMA", env,
                (env && !strcmp(env, "0")) ? "Using blit kernels for hipMemcpy" : "Using DMA copy engines");
       }
-      printf("%-20s = %12d : %s\n", "USE_SINGLE_SYNC", useSingleSync,
-             useSingleSync ? "Synchronizing only once, after all iterations" : "Synchronizing per iteration");
       printf("%-20s = %12d : Running in %s mode\n", "USE_INTERACTIVE", useInteractive,
              useInteractive ? "interactive" : "non-interactive");
-      printf("%-20s = %12d : %s\n", "COMBINE_TIMING", combineTiming,
-             combineTiming ? "Using combined timing+launch" : "Using separate timing / launch");
-      printf("%-20s = %12d : Output to %s\n", "OUTPUT_TO_CSV", outputToCsv,
-             outputToCsv ? "CSV" : "console");
-      printf("%-20s = %12d : Using byte offset of %d\n", "BYTE_OFFSET", byteOffset, byteOffset);
-      printf("%-20s = %12d : Running %d warmup iteration(s) per topology\n", "NUM_WARMUPS", numWarmups, numWarmups);
-      printf("%-20s = %12d : Running %d timed iteration(s) per topology\n", "NUM_ITERATIONS", numIterations, numIterations);
-      printf("%-20s = %12d : Using %d CPU thread(s) per CPU-based-copy Link\n", "NUM_CPU_PER_LINK", numCpuPerLink, numCpuPerLink);
-      printf("%-20s = %12s : ", "FILL_PATTERN", getenv("FILL_PATTERN") ? "(specified)" : "(unset)");
-      if (fillPattern.size())
-      {
-        printf("Pattern: %s", getenv("FILL_PATTERN"));
-      }
-      else
-      {
-        printf("Pseudo-random: (Element i = i modulo 383 + 31)");
-      }
-      printf("\n");
-      printf("%-20s = %12s : Using %d shared mem per threadblock\n", "SHARED_MEM_BYTES",
-             getenv("SHARED_MEM_BYTES") ? "(specified)" : "(unset)", sharedMemBytes);
-      printf("%-20s = %12d : Each CU gets a multiple of %d bytes to copy\n", "BLOCK_BYTES", blockBytes, blockBytes);
-      printf("%-20s = %12d : Using %s-based GPU indexing\n", "USE_PCIE_INDEX", usePcieIndexing, (usePcieIndexing ? "PCIe" : "HIP"));
-      printf("%-20s = %12d : Using single stream per %s\n", "USE_SINGLE_STREAM", useSingleStream, (useSingleStream ? "device" : "Link"));
+      printf("%-20s = %12d : Performing %s\n", "USE_MEMSET", useMemset,
+             useMemset ? "memset" : "memcopy");
+      printf("%-20s = %12d : Using %s-based GPU indexing\n", "USE_PCIE_INDEX",
+             usePcieIndexing, (usePcieIndexing ? "PCIe" : "HIP"));
+      printf("%-20s = %12d : Using single stream per %s\n", "USE_SINGLE_STREAM",
+             useSingleStream, (useSingleStream ? "device" : "Transfer"));
       printf("\n");
     }
   };

--- a/tools/TransferBench/example.cfg
+++ b/tools/TransferBench/example.cfg
@@ -1,47 +1,47 @@
 # ConfigFile Format:
 # ==================
-# A Link is defined as a uni-directional transfer from src memory location to dst memory location
+# A Transfer is defined as a uni-directional transfer from src memory location to dst memory location
 # executed by either CPU or GPU
-# Each single line in the configuration file defines a set of Links to run in parallel
+# Each single line in the configuration file defines a set of Transfers (a Test) to run in parallel
 
 # There are two ways to specify the configuration file:
 
 # 1) Basic
-#    The basic specification assumes the same number of threadblocks/CUs used per GPU-executed Link
-#    A positive number of Links is specified followed by that number of triplets describing each Link
+#    The basic specification assumes the same number of threadblocks/CUs used per GPU-executed Transfer
+#    A positive number of Transfers is specified followed by that number of triplets describing each Transfer
 
-#    #Links #CUs (srcMem1->Executor1->dstMem1) ... (srcMemL->ExecutorL->dstMemL)
+#    #Transfers #CUs (srcMem1->Executor1->dstMem1) ... (srcMemL->ExecutorL->dstMemL)
 
 # 2) Advanced
-#    The advanced specification allows different number of threadblocks/CUs used per GPU-executed Link
-#    A negative number of links is specified, followed by quadruples describing each Link
-#    -#Links (srcMem1->Executor1->dstMem1 #CUs1) ... (srcMemL->ExecutorL->dstMemL #CUsL)
+#    The advanced specification allows different number of threadblocks/CUs used per GPU-executed Transfer
+#    A negative number of Transfers is specified, followed by quadruples describing each Transfer
+#    -#Transfers (srcMem1->Executor1->dstMem1 #CUs1) ... (srcMemL->ExecutorL->dstMemL #CUsL)
 
 # Argument Details:
-#   #Links  :   Number of Links to be run in parallel
-#   #CUs    :   Number of threadblocks/CUs to use for a GPU-executed Link
-#   srcMemL :   Source memory location (Where the data is to be read from). Ignored in memset mode
-#   Executor:   Executor are specified by a character indicating executor type, followed by device index (0-indexed)
-#               - C: CPU-executed  (Indexed from 0 to 1)
-#               - G: GPU-executed  (Indexed from 0 to 3)
-#   dstMemL :   Destination memory location (Where the data is to be written to)
+#   #Transfers:   Number of Transfers to be run in parallel
+#   #CUs      :   Number of threadblocks/CUs to use for a GPU-executed Transfer
+#   srcMemL   :   Source memory location (Where the data is to be read from). Ignored in memset mode
+#   Executor  :   Executor is specified by a character indicating type, followed by device index (0-indexed)
+#                 - C: CPU-executed  (Indexed from 0 to # NUMA nodes - 1)
+#                 - G: GPU-executed  (Indexed from 0 to # GPUs - 1)
+#   dstMemL   :   Destination memory location (Where the data is to be written to)
 
-#               Memory locations are specified by a character indicating memory type,
-#               followed by device index (0-indexed)
-#               Supported memory locations are:
-#               - C:    Pinned host memory       (on NUMA node, indexed from 0 to [# NUMA nodes-1])
-#               - B:    Fine-grain host memory   (on NUMA node, indexed from 0 to [# NUMA nodes-1])
-#               - G:    Global device memory     (on GPU device indexed from 0 to [# GPUs - 1])
-#               - F:    Fine-grain device memory (on GPU device indexed from 0 to [# GPUs - 1])
+#                 Memory locations are specified by a character indicating memory type,
+#                 followed by device index (0-indexed)
+#                 Supported memory locations are:
+#                 - C:    Pinned host memory       (on NUMA node, indexed from 0 to [# NUMA nodes-1])
+#                 - B:    Fine-grain host memory   (on NUMA node, indexed from 0 to [# NUMA nodes-1])
+#                 - G:    Global device memory     (on GPU device indexed from 0 to [# GPUs - 1])
+#                 - F:    Fine-grain device memory (on GPU device indexed from 0 to [# GPUs - 1])
 
 # Examples:
-# 1 4 (G0->G0->G1)             Single link using 4 CUs on GPU0 to copy from GPU0 to GPU1
-# 1 4 (C1->G2->G0)             Single link using 4 CUs on GPU2 to copy from CPU1 to GPU0
-# 2 4 G0->G0->G1 G1->G1->G0    Runs 2 Links in parallel.  GPU0 to GPU1, and GPU1 to GPU0, each with 4 CUs
-# -2 (G0 G0 G1 4) (G1 G1 G0 2) Runs 2 Links in parallel.  GPU0 to GPU1 with 4 CUs, and GPU1 to GPU0 with 2 CUs
+# 1 4 (G0->G0->G1)             Single Transfer using 4 CUs on GPU0 to copy from GPU0 to GPU1
+# 1 4 (C1->G2->G0)             Single Transfer using 4 CUs on GPU2 to copy from CPU1 to GPU0
+# 2 4 G0->G0->G1 G1->G1->G0    Runs 2 Transfers in parallel.  GPU0 to GPU1, and GPU1 to GPU0, each with 4 CUs
+# -2 (G0 G0 G1 4) (G1 G1 G0 2) Runs 2 Transfers in parallel.  GPU0 to GPU1 with 4 CUs, and GPU1 to GPU0 with 2 CUs
 
 # Round brackets and arrows' ->' may be included for human clarity, but will be ignored and are unnecessary
 # Lines starting with # will be ignored. Lines starting with ## will be echoed to output
 
-# Single GPU-executed link between GPUs 0 and 1 using 4 CUs
+# Single GPU-executed Transfer between GPUs 0 and 1 using 4 CUs
 1 4 (G0->G0->G1)


### PR DESCRIPTION
## v1.02
### Added
- Setting NUM_ITERATIONS to negative number indicates to run for -NUM_ITERATIONS seconds per Test
### Changed
- Copies are now refered to as Transfers instead of Links
- Re-ordering how env vars are displayed (alphabetically now)
### Removed
- Combined timing is now always on for kernel-based GPU copies. COMBINED_TIMING env var has been removed
- Use single sync is no longer supported to facility variable iterations. USE_SINGLE_SYNC env var has been removed
