### PR TITLE
Adding the missing roc:: namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,7 @@ rocm_install(FILES ${PROJECT_BINARY_DIR}/include/rccl/rccl.h
 rocm_export_targets(NAMESPACE
                     roc::
                     TARGETS
-                    rccl
+                    roc::rccl
                     DEPENDS
                     hip)
 if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)


### PR DESCRIPTION
Adding the missing roc:: namespace, effectively changing the value of `RCCL_LIBRARY` from rccl to roc::rccl.

The important difference is that rccl is treated as a symbolic "-lrccl" by linker (and fail the linking
due to a missing library search path), while roc::rccl is a target name, which can resolve into an absolute
library path.

This patch corrects the export name as explained by @pfultz2 in #567 , similarly to as in [rocBLAS](https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/library/src/CMakeLists.txt#L596)