### PR TITLE
Adding git hash info to version output line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,14 @@ include_directories(src/include)
 include_directories(src/collectives)
 include_directories(src/collectives/device)
 
+# Create git version file
+# _git_version.cpp is a dummy output to force re-run prior to build
+ADD_CUSTOM_COMMAND(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp
+           ${CMAKE_CURRENT_BINARY_DIR}/_git_version.cpp
+    COMMAND ${CMAKE_COMMAND} -P
+            ${CMAKE_CURRENT_SOURCE_DIR}/cmake/git_version.cmake)
+
 if (BUILD_ALLREDUCE_ONLY)
   add_definitions(-DBUILD_ALLREDUCE_ONLY)
   set(CU_SOURCES
@@ -205,7 +213,9 @@ set(CC_SOURCES
     src/bootstrap.cc
     src/proxy.cc
     src/net.cc
-    src/enqueue.cc)
+    src/enqueue.cc
+    ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp)
+
 
 foreach(filename ${CC_SOURCES})
   list(APPEND CPP_SOURCES ${filename})

--- a/cmake/git_version.cmake
+++ b/cmake/git_version.cmake
@@ -1,0 +1,37 @@
+# Attempt to collect the latest git hash
+execute_process(COMMAND git log --pretty=format:'%h' -n 1
+                OUTPUT_VARIABLE GIT_REV
+                ERROR_QUIET)
+
+# Check if git information was found
+if ("${GIT_REV}" STREQUAL "")
+  set(GIT_VERSION "const char *rcclGitHash =\"Unknown \";")
+else()
+  # Check for changes (denote with a '+') after hash
+  execute_process(
+    COMMAND bash -c "git diff --quiet --exit-code || echo +"
+    OUTPUT_VARIABLE GIT_DIFF)
+  # Collect branch information
+  execute_process(
+    COMMAND git rev-parse --abbrev-ref HEAD
+    OUTPUT_VARIABLE GIT_BRANCH)
+
+  string(STRIP "${GIT_REV}" GIT_REV)
+  string(SUBSTRING "${GIT_REV}" 1 7 GIT_REV)
+  string(STRIP "${GIT_DIFF}" GIT_DIFF)
+  string(STRIP "${GIT_BRANCH}" GIT_BRANCH)
+
+  set(GIT_VERSION "const char *rcclGitHash =\"${GIT_BRANCH}:${GIT_REV}${GIT_DIFF}\";")
+endif()
+
+# Compare file with existing file (if any)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/git_version.cpp)
+  file(READ ${CMAKE_CURRENT_SOURCE_DIR}/git_version.cpp GIT_VERSION_)
+else()
+  set(GIT_VERSION_ "")
+endif()
+
+# Write updated file
+if (NOT "${GIT_VERSION}" STREQUAL "${GIT_VERSION_}")
+  file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/git_version.cpp "${GIT_VERSION}")
+endif()

--- a/src/include/git_version.h
+++ b/src/include/git_version.h
@@ -1,0 +1,12 @@
+/*************************************************************************
+ * Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_GIT_VERSION_H_
+#define RCCL_GIT_VERSION_H_
+
+extern const char *rcclGitHash;
+
+#endif

--- a/src/init.cc
+++ b/src/init.cc
@@ -33,6 +33,7 @@
 #include "graph/topo.h"
 
 // [RCCL]
+#include "git_version.h"
 //#include "clique/CliqueManager.h"
 //#include <hsa/hsa_ext_amd.h>
 // [/RCCL]
@@ -525,10 +526,10 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
 static void showVersion() {
   static int shown = 0;
   if (shown == 0 && ncclDebugLevel >= NCCL_LOG_VERSION) {
-    printf("%s\n", VERSION_STRING);
+    printf("%s %s\n", VERSION_STRING, rcclGitHash);
     fflush(stdout);
     if (ncclDebugFile != stdout)
-      INFO(NCCL_ALL,"%s", VERSION_STRING); // Also log NCCL version in one of the files
+      INFO(NCCL_ALL,"%s %s", VERSION_STRING, rcclGitHash); // Also log NCCL version in one of the files
     shown = 1;
   }
 }


### PR DESCRIPTION
Adding git information (if available) to RCCL info line display.
A plus sign is added to hash to denote local changes
Version file is updated during build (does not require CMake reconfigure)

e.g: RCCL version 2.12.12+hip5.2 develop:b630976+
