### PR TITLE
Reduce AlltoAll port usage in send/recv proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
     refer to the interface documentation for details.
   - To avoid potential deadlocks, user might have to set an environment variables increasing
     the number of hardware queues (e.g. export GPU_MAX_HW_QUEUES=16)
+- Adding support for reusing ports in NET/IB channels
+  - Opt-in with NCCL_IB_SOCK_CLIENT_PORT_REUSE=1 and NCCL_IB_SOCK_SERVER_PORT_REUSE=1
+  - When "Call to bind failed : Address already in use" error happens in large-scale AlltoAll
+    (e.g., >=64 MI200 nodes), users are suggested to opt-in either one or both of the options
+    to resolve the massive port usage issue
+  - Avoid using NCCL_IB_SOCK_SERVER_PORT_REUSE when NCCL_NCHANNELS_PER_NET_PEER is tuned >1
 ### Removed
 - Removed experimental clique-based kernels
 

--- a/src/include/socket.h
+++ b/src/include/socket.h
@@ -51,7 +51,7 @@ int ncclFindInterfaces(char* ifNames, union ncclSocketAddress *ifAddrs, int ifNa
 // Create a listening socket. sock->addr can be pre-filled with IP & port info. sock->fd is set after a successful call
 ncclResult_t ncclSocketListen(struct ncclSocket* sock);
 // Connect to sock->addr. sock->fd is set after a successful call.
-ncclResult_t ncclSocketConnect(struct ncclSocket* sock);
+ncclResult_t ncclSocketConnect(struct ncclSocket* sock, int portReuse = 0);
 // Return socket connection state.
 ncclResult_t ncclGetSocketState(struct ncclSocket* sock, enum ncclSocketState* state);
 // Accept an incoming connection from listenSocket->fd and keep the file descriptor in sock->fd, with the remote side IP/port in sock->addr.

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -83,6 +83,11 @@ NCCL_PARAM(IbTc, "IB_TC", 0);
 NCCL_PARAM(IbArThreshold, "IB_AR_THRESHOLD", 8192);
 NCCL_PARAM(IbPciRelaxedOrdering, "IB_PCI_RELAXED_ORDERING", 2);
 
+NCCL_PARAM(IbSockClientPortReuse, "IB_SOCK_CLIENT_PORT_REUSE", 0);
+NCCL_PARAM(IbSockServerPortReuse, "IB_SOCK_SERVER_PORT_REUSE", 0);
+static thread_local union ncclSocketAddress reusedAddr;
+static thread_local int reusedSockfd = -1;
+
 pthread_t ncclIbAsyncThread;
 static void* ncclIbAsyncThreadMain(void* args) {
   struct ibv_context* context = (struct ibv_context*)args;
@@ -555,7 +560,19 @@ ncclResult_t ncclIbListen(int dev, void* opaqueHandle, void** listenComm) {
   memset(handle, 0, sizeof(struct ncclIbHandle));
   comm->dev = dev;
   NCCLCHECK(GetSocketAddr(&comm->sock.addr));
-  NCCLCHECK(ncclSocketListen(&comm->sock));
+  if (ncclParamIbSockServerPortReuse()) {
+    // reuse the socket address and fd for listen system call
+    if (reusedSockfd == -1) {
+      NCCLCHECK(ncclSocketListen(&comm->sock));
+      memcpy(&reusedAddr, &comm->sock.addr, sizeof(union ncclSocketAddress));
+      reusedSockfd = comm->sock.fd;
+    } else {
+      memcpy(&comm->sock.addr, &reusedAddr, sizeof(union ncclSocketAddress));
+      comm->sock.fd = reusedSockfd;
+    }
+  } else {
+    NCCLCHECK(ncclSocketListen(&comm->sock));
+  }
   memcpy(&handle->connectAddr, &comm->sock.addr, sizeof(union ncclSocketAddress));
   *listenComm = comm;
   return ncclSuccess;
@@ -579,7 +596,7 @@ ncclResult_t ncclIbConnect(int dev, void* opaqueHandle, void** sendComm) {
   NCCLCHECK(ncclSocketInit(&comm->sock, &handle->connectAddr, NULL, 1));
   stage->comm = comm;
   stage->state = ncclIbCommStateConnect;
-  NCCLCHECK(ncclSocketConnect(&comm->sock));
+  NCCLCHECK(ncclSocketConnect(&comm->sock, ncclParamIbSockClientPortReuse()));
 
 ib_connect_check:
   /* since ncclSocketConnect is async, we must check if connection is complete */
@@ -1268,7 +1285,7 @@ ncclResult_t ncclIbCloseRecv(void* recvComm) {
 ncclResult_t ncclIbCloseListen(void* listenComm) {
   struct ncclIbListenComm* comm = (struct ncclIbListenComm*)listenComm;
   if (comm) {
-    close(comm->sock.fd);
+    if (!ncclParamIbSockServerPortReuse() || reusedSockfd != comm->sock.fd) close(comm->sock.fd);
     free(comm);
   }
   return ncclSuccess;


### PR DESCRIPTION
Reduce AlltoAll port usage by reusing socket ports when connect/accept in send/recv proxy.

Existing issue
--------------
Running AlltoAll on >=64 MI200 nodes (16 GPUs per node) will suffer `Call to bind failed : Address already in use` error, because it requires >32k free ports but by default Linux only has ~28k ephemeral ports.

Root cause
----------
In AlltoAll, each rank needs to establish `p2pnChannelsPerPeer` channels with any other ranks. Cross node NET/IB channels will use TCP sockets to initialize IB connection, for these channels:
* in send proxy, current rank needs to connect (`ncclNetConnect`) to remote rank in `sendProxyConnect`, a new port will be allocated by `connect` system call in net plugin
* in recv proxy, current rank needs to accept (`ncclNetAccept`) from remote rank in `recvProxyConnect`, which uses the port allocated by `listen` system call (in `ncclNetListen`, which is also new for different channels)

Therefore, the port usage of AlltoAll NET/IB channels for `N`-node (`G`-gpu per node) AlltoAll equals to `(N-1) * G * p2pnChannelsPerPeer * 2 * G`, which is `O(N)` and easy to reach Linux port limit when `G` is large.

Current Solution
----------------
Because TCP socket only requires unique 4-tuple (src ip, src port, dst ip, dst port), the `connect` and `listen` ports could be reused among different channels as long as not both of the source rank and destination rank are same.
* in send proxy, current rank will try to use existing pre-defined ports to `connect` when dst ip and port are different, the reusing option is enabled by `NCCL_IB_SOCK_CLIENT_PORT_REUSE=1` env
* in recv proxy, current rank will listen to only one port and all other ranks connect this port, the reusing option is enabled by `NCCL_IB_SOCK_SERVER_PORT_REUSE=1` env (may not work when tuning `NCCL_NCHANNELS_PER_NET_PEER` to >1 at the same time)

When `Address already in use` error is observed for AlltoAll in rccl-tests or Mixture-of-Experts (MoE) model, it's suggested to enable above two envs to resolve the issue.