### PR TITLE
HIP Path default updated to ROCM_PATH (reorg path)

### DIFF
--- a/tools/HelloRccl/Makefile
+++ b/tools/HelloRccl/Makefile
@@ -3,7 +3,7 @@
 # Set to where RCCL is installed
 RCCL_INSTALL=../../build/release
 
-HIP_PATH?= $(wildcard /opt/rocm/hip)
+HIP_PATH?= $(wildcard /opt/rocm)
 ifeq (,$(HIP_PATH))
 HIP_PATH=../../..
 endif

--- a/tools/MultiRank/Makefile
+++ b/tools/MultiRank/Makefile
@@ -3,7 +3,7 @@
 # Set to where RCCL is installed
 RCCL_INSTALL=../../build/release
 
-HIP_PATH?= $(wildcard /opt/rocm/hip)
+HIP_PATH?= $(wildcard /opt/rocm)
 ifeq (,$(HIP_PATH))
 HIP_PATH=../../..
 endif

--- a/tools/ib-test/Makefile
+++ b/tools/ib-test/Makefile
@@ -1,5 +1,5 @@
 # Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
-HIP_PATH ?= $(wildcard /opt/rocm/hip)
+HIP_PATH ?= $(wildcard /opt/rocm)
 ifeq (,$(HIP_PATH))
 HIP_PATH = ../../..
 endif

--- a/tools/rccl-prim-test/Makefile
+++ b/tools/rccl-prim-test/Makefile
@@ -1,5 +1,5 @@
 # Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
-HIP_PATH?= $(wildcard /opt/rocm/hip)
+HIP_PATH?= $(wildcard /opt/rocm)
 ifeq (,$(HIP_PATH))
 	HIP_PATH=../../..
 endif

--- a/tools/topo_expl/Makefile
+++ b/tools/topo_expl/Makefile
@@ -1,5 +1,5 @@
 # Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
-HIP_PATH ?= $(wildcard /opt/rocm/hip)
+HIP_PATH ?= $(wildcard /opt/rocm)
 ifeq (,$(HIP_PATH))
 HIP_PATH = ../../..
 endif


### PR DESCRIPTION
Proposed Changes:
- Updated default path for hip to ROCM_PATH (/opt/rocm instead of /opt/rocm/hip) as per new/current structure.
