### PR TITLE
Reduce branch.

### DIFF
--- a/src/collectives/device/primitives.h
+++ b/src/collectives/device/primitives.h
@@ -15,9 +15,6 @@
 #define NCCL_SPINS_BEFORE_CHECK_ABORT 1000000
 
 #define barrier_by_group() do { \
-  if (nthreads == NCCL_MAX_NTHREADS) \
-    __syncthreads(); \
-  else { \
     const int w = threadIdx.x/WARP_SIZE; \
     const int wid = threadIdx.x%WARP_SIZE; \
     if (wid == 0) { \
@@ -26,7 +23,6 @@
       while (atomicAdd((unsigned long long *)barriers, 0) < barrier_next[w]) __builtin_amdgcn_s_sleep(8); \
       __asm__ __volatile__("s_wakeup"); \
     } \
-  } \
 } while (0)
 
 /* Protocol classes: ProtoSimple, ProtoLL, ProtoLL128


### PR DESCRIPTION
The true path of group_by_barrier() will never be taken, after studying the call sites of it.