### PR TITLE
HOTFIX: Remove backwards compatibility headers on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,7 +361,7 @@ rocm_export_targets(NAMESPACE
                     rccl
                     DEPENDS
                     hip)
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   #Create wrapper files
   rocm_wrap_header_dir( "${PROJECT_BINARY_DIR}/include/rccl"
             PATTERNS "rccl.h"


### PR DESCRIPTION
The backwards compatibility headers should not be generated or installed on Windows.