### PR TITLE
Removing init_nvtx.cc from source list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ set(SRC_FILES
   src/include/trees.h
   src/include/utils.h
   src/init.cc
-  src/init_nvtx.cc
+#  src/init_nvtx.cc
   src/misc/argcheck.cc
 # src/misc/cudawrap.cc
 # src/misc/gdrwrap.cc


### PR DESCRIPTION
- To fix undefined symbol: nvtxPayloadEnumRegister 