### PR TITLE
Disable Colltrace for --fast option

### DIFF
--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -17,7 +17,7 @@ def runCI =
     def prj  = new rocProject('rccl', 'Extended')
 
     prj.timeout.test = 600
-    prj.paths.build_command = './install.sh -t --npkit-enable '
+    prj.paths.build_command = './install.sh -t --npkit-enable --limit-nprocs'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -18,7 +18,7 @@ def runCI =
     def prj  = new rocProject('rccl', 'PreCheckin')
 
     prj.timeout.test = 300
-    prj.paths.build_command = './install.sh -t --fast'
+    prj.paths.build_command = './install.sh -t --fast --limit-nprocs'
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -12,7 +12,7 @@ def runCI =
     def prj = new rocProject('rccl', 'Static Library PreCheckin')
 
     prj.timeout.test = 1440
-    prj.paths.build_command = './install.sh -t --static'
+    prj.paths.build_command = './install.sh -t --static --limit-nprocs'
 
     def nodes = new dockerNodes(nodeDetails, jobName, prj)
 

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,7 @@ ROCM_PATH=${ROCM_PATH:="/opt/rocm"}
 
 build_address_sanitizer=false
 build_allreduce_only=false
+collective_trace=true
 install_dependencies=false
 build_release=true
 build_bfd=true
@@ -78,27 +79,27 @@ eval set -- "${GETOPT_PARSE}"
 
 while true; do
     case "${1}" in
-         --address-sanitizer)        build_address_sanitizer=true;               shift ;;
-         --build_allreduce_only)     build_allreduce_only=true;                  shift ;;
-    -d | --dependencies)             install_dependencies=true;                  shift ;;
-         --debug)                    build_release=false;                        shift ;;
-         --disable_backtrace)        build_bfd=false;                            shift ;;
-         --fast)                     build_bfd=false; build_local_gpu_only=true; shift ;;
-    -h | --help)                     display_help;                               exit 0 ;;
-    -i | --install)                  install_library=true;                       shift ;;
-    -l | --limit-nprocs)             enable_all_jobs=false;                      shift ;;
-         --local_gpu_only)           build_local_gpu_only=true;                  shift ;;
-         --no_clean)                 clean_build=false;                          shift ;;
-         --npkit-enable)             npkit_enabled=true;                         shift ;;
-    -p | --package_build)            build_package=true;                         shift ;;
-         --prefix)                   install_prefix=${2}                         shift 2 ;;
-         --rm-legacy-include-dir)    build_freorg_bkwdcomp=false;                shift ;;
-    -r | --run_tests_quick)          run_tests=true;                             shift ;;
-         --run_tests_all)            run_tests=true; run_tests_all=true;         shift ;;
-         --static)                   build_static=true;                          shift ;;
-    -t | --tests_build)              build_tests=true;                           shift ;;
-         --time-trace)               time_trace=true;                            shift ;;
-         --verbose)                  build_verbose=1;                            shift ;;
+         --address-sanitizer)        build_address_sanitizer=true;                                       shift ;;
+         --build_allreduce_only)     build_allreduce_only=true;                                          shift ;;
+    -d | --dependencies)             install_dependencies=true;                                          shift ;;
+         --debug)                    build_release=false;                                                shift ;;
+         --disable_backtrace)        build_bfd=false;                                                    shift ;;
+         --fast)                     build_bfd=false; build_local_gpu_only=true; collective_trace=false; shift ;;
+    -h | --help)                     display_help;                                                       exit 0 ;;
+    -i | --install)                  install_library=true;                                               shift ;;
+    -l | --limit-nprocs)             enable_all_jobs=false;                                              shift ;;
+         --local_gpu_only)           build_local_gpu_only=true;                                          shift ;;
+         --no_clean)                 clean_build=false;                                                  shift ;;
+         --npkit-enable)             npkit_enabled=true;                                                 shift ;;
+    -p | --package_build)            build_package=true;                                                 shift ;;
+         --prefix)                   install_prefix=${2}                                                 shift 2 ;;
+         --rm-legacy-include-dir)    build_freorg_bkwdcomp=false;                                        shift ;;
+    -r | --run_tests_quick)          run_tests=true;                                                     shift ;;
+         --run_tests_all)            run_tests=true; run_tests_all=true;                                 shift ;;
+         --static)                   build_static=true;                                                  shift ;;
+    -t | --tests_build)              build_tests=true;                                                   shift ;;
+         --time-trace)               time_trace=true;                                                    shift ;;
+         --verbose)                  build_verbose=1;                                                    shift ;;
     --) shift ; break ;;
     *)  echo "Unexpected command line parameter received; aborting";
         exit 1
@@ -192,7 +193,6 @@ fi
 # Build local GPU arch only
 if [[ "$build_local_gpu_only" == true ]]; then
     cmake_common_options="${cmake_common_options} -DBUILD_LOCAL_GPU_TARGET_ONLY=ON"
-    cmake_common_options="${cmake_common_options} -DCOLLTRACE=OFF"
 fi
 
 # shared vs static
@@ -200,6 +200,10 @@ if [[ "${build_static}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DBUILD_SHARED_LIBS=OFF"
 fi
 
+# Disable collective trace
+if [[ "${collective_trace}" == false ]]; then
+    cmake_common_options="${cmake_common_options} -DCOLLTRACE=OFF"
+fi
 
 # Install dependencies
 if ($install_dependencies); then

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,8 @@ function display_help()
     echo "    -d|--dependencies          Install RCCL depdencencies"
     echo "       --debug                 Build debug library"
     echo "       --disable_backtrace     Build without custom backtrace support"
-    echo "       --fast                  Quick-build RCCL (local gpu arch only, no backtrace support)"
+    echo "       --disable-colltrace     Build without collective trace"
+    echo "       --fast                  Quick-build RCCL (local gpu arch only, no backtrace, and collective trace support)"
     echo "    -h|--help                  Prints this help message"
     echo "    -i|--install               Install RCCL library (see --prefix argument below)"
     echo "    -l|--limit-nprocs          Limit the number of procs to 16 while building"
@@ -64,7 +65,7 @@ enable_ninja=""
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --longoptions address-sanitizer,build_allreduce_only,dependencies,debug,disable_backtrace,fast,help,install,limit-nprocs,local_gpu_only,no_clean,npkit-enable,package_build,prefix:,rm-legacy-include-dir,run_tests_all,run_tests_quick,tests_build,time-trace,verbose --options hidptrs -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --longoptions address-sanitizer,build_allreduce_only,dependencies,debug,disable_backtrace,disable-colltrace,fast,help,install,limit-nprocs,local_gpu_only,no_clean,npkit-enable,package_build,prefix:,rm-legacy-include-dir,run_tests_all,run_tests_quick,tests_build,time-trace,verbose --options hidptrs -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -84,6 +85,7 @@ while true; do
     -d | --dependencies)             install_dependencies=true;                                          shift ;;
          --debug)                    build_release=false;                                                shift ;;
          --disable_backtrace)        build_bfd=false;                                                    shift ;;
+         --disable-colltrace)        collective_trace=false;                                             shift ;;
          --fast)                     build_bfd=false; build_local_gpu_only=true; collective_trace=false; shift ;;
     -h | --help)                     display_help;                                                       exit 0 ;;
     -i | --install)                  install_library=true;                                               shift ;;

--- a/src/collectives/device/common.h
+++ b/src/collectives/device/common.h
@@ -341,11 +341,11 @@ class ncclFunction {
     collTrace->type = ncclCollTraceDataType; \
   }
 #else
-#define traceData(data2, data4, data8_0, data8_1)
+#define traceColl(launch_type)
 #define traceKernelLaunch(firstLaunch)
 #define traceKernelEnd()
 #define traceAbort()
-#define traceColl(launch_type)
+#define traceData(data2, data4, data8_0, data8_1)
 #endif
 
 struct ncclShmemGroup {

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -28,11 +28,18 @@ struct ncclKernelMatch {
 };
 
 typedef void(*ncclKern_t)(struct ncclDevComm* comm, uint64_t channelMask, struct ncclWork* workHead);
+
 // Must be consistent with the ncclFuncSet enum
+#ifdef ENABLE_COLLTRACE
 static ncclKernelMatch const ncclKerns[2] = {
   {(void *)NCCL_KERN_NAME(SendRecv, RING, SIMPLE, Sum, int8_t), true},
   {(void *)NCCL_KERN_NAME_DEBUG(SendRecv, RING, SIMPLE, Sum, int8_t), true},
 };
+#else
+static ncclKernelMatch const ncclKerns[1] = {
+  {(void*)NCCL_KERN_NAME(SendRecv, RING, SIMPLE, Sum, int8_t), true}
+};
+#endif
 
 static ncclResult_t computeColl(struct ncclInfo* info /* input */, int* workFuncIndex, struct ncclWorkElem* work, struct ncclProxyOp* proxyOp /* output */);
 

--- a/src/graph/topo.h
+++ b/src/graph/topo.h
@@ -224,7 +224,10 @@ static float ncclTopoXGMISpeed(int gcn) {
   return gcn == 910 ? MI200_XGMI_WIDTH : VEGA_XGMI_WIDTH;
 }
 
-#define ncclGetKernelIndex(p_comm) \
-  ((p_comm)->collTraceThread ? 1 : 0)
+#if ENABLE_COLLTRACE
+  #define ncclGetKernelIndex(p_comm) ((p_comm)->collTraceThread ? 1 : 0)
+#else
+  #define ncclGetKernelIndex(p_comm) (0)
+#endif
 
 #endif

--- a/tools/time-trace/rccl-TimeTrace.sh
+++ b/tools/time-trace/rccl-TimeTrace.sh
@@ -47,4 +47,4 @@ mv temp_file.txt "$directory/.ninja_log"
 mv "$directory/.ninja_log" "$directory/time_trace.log"
 
 # Run the python program
-python3 time_trace_generator.py --min_val 5 --include_linking
+python3 time_trace_generator.py --min_val 5 --include_linking --log_file_path ../../build/release/time_trace.log

--- a/tools/time-trace/rccl-TimeTrace.sh
+++ b/tools/time-trace/rccl-TimeTrace.sh
@@ -47,4 +47,4 @@ mv temp_file.txt "$directory/.ninja_log"
 mv "$directory/.ninja_log" "$directory/time_trace.log"
 
 # Run the python program
-python3 time_trace_generator.py --min_val 5 --include_linking --log_file_path ../../build/release/time_trace.log
+python3 time_trace_generator.py --min_val 5 --include_linking

--- a/tools/time-trace/time_trace_generator.py
+++ b/tools/time-trace/time_trace_generator.py
@@ -4,9 +4,6 @@ import pandas as pd
 import plotly.graph_objects as go
 import argparse
 
-# Specify the path to the .log file
-log_file = '../../build/release/time_trace.log'
-
 def generateRandomColors(df, colorList):
 
     for _ in range(len(df)):
@@ -102,8 +99,9 @@ def plotCompileTime(log_file, minVal):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--min_val", nargs='?', default='5', type=int, help="Ignore any if it's less than the value provided.")
-    parser.add_argument("--include_linking", action='store_true', help="Include linking when plotting.")
+    parser.add_argument("--min_val", nargs='?', default='5', type=int, help="Ignore any if it's less than the value provided")
+    parser.add_argument("--include_linking", action='store_true', help="Include linking when plotting")
+    parser.add_argument("--log_file_path", type=str, help="Location of the log file generated with --time-trace flag")
     args = parser.parse_args()
-    
-    plotCompileTime(log_file, args.min_val)
+
+    plotCompileTime(args.log_file_path, args.min_val)

--- a/tools/time-trace/time_trace_generator.py
+++ b/tools/time-trace/time_trace_generator.py
@@ -104,4 +104,9 @@ if __name__ == "__main__":
     parser.add_argument("--log_file_path", type=str, help="Location of the log file generated with --time-trace flag")
     args = parser.parse_args()
 
-    plotCompileTime(args.log_file_path, args.min_val)
+    if args.log_file_path is not None:
+        log_file_path = args.log_file_path
+    else:
+        log_file_path = '../../build/release/time_trace.log'
+
+    plotCompileTime(log_file_path, args.min_val)


### PR DESCRIPTION
* Disabled generating additional debug kernels when using the fast option in install.sh.
* Removed the --max-jobs flag and added the --limit-nprocs flag. The default value is now set to the maximum number of processors. The limiting functionality is intended for use in the CI environment.
* Modified time_trace_generator.py and rccl-TimeTrace.sh to avoid specifying static paths to folder and file locations.
* Modified topo.h, common.h, and enqueue.cc to resolve compiler errors when colltrace is disabled.