### PR TITLE
device: fine tune MI200/MI250 simple protocol performance

### DIFF
--- a/src/collectives/device/common.h
+++ b/src/collectives/device/common.h
@@ -11,11 +11,7 @@
 #include "collectives.h"
 #include "devcomm.h"
 
-#if defined(__gfx940__)
 #define COLL_UNROLL 4
-#else
-#define COLL_UNROLL 2
-#endif
 
 #define NCCL_MAX_DEV_ARITY (NCCL_MAX_TREE_ARITY-1)  // Using balanced tree instead of split tree
 


### PR DESCRIPTION
With Simple protocol, unroll factor of 4 offers better performance for most of the collectives (on MI200. MI250, and MI300) except large message allreduce with Ring algorithm on MI250 and MI200). This PR changes the default unroll factor to 4 while adding fine tuning for reduction operations.