### PR TITLE
Fix MSCCL proxy number of chunks calculation

### DIFF
--- a/src/misc/msccl/msccl_parser.cc
+++ b/src/misc/msccl/msccl_parser.cc
@@ -658,7 +658,7 @@ ncclResult_t mscclGetAlgoFromXmlFile(const char* str, struct mscclAlgo* algo, in
 
             // finish up mscclChannel calculation
 
-            for (int c = 0; c < MSCCL_MAX_COUNT; c++) {
+            for (int c = 1; c <= MSCCL_MAX_COUNT; c++) {
               struct mscclChannelPeerInfo* sendPeer = &mscclChannel->sendPeerInfo[mscclChannel->nSendPeers];
               if (sendPeer->nTransmissionsOfCount[c] > 0) {
                 sendPeer->existingCounts[sendPeer->nExistingCounts] = c;

--- a/src/misc/msccl/msccl_setup.cc
+++ b/src/misc/msccl/msccl_setup.cc
@@ -118,7 +118,7 @@ ncclResult_t mscclSetupProxy(struct mscclAlgo* hostAlgo, ncclComm_t comm) {
       int nRecvs = 0;
       for (int j = 0; j < recvPeer->nExistingCounts; j++){
         int c = recvPeer->existingCounts[j];
-        int nStepsInCount = DIVUP(c+1, status.maxAllowedCount);
+        int nStepsInCount = DIVUP(c, status.maxAllowedCount);
         nRecvs += recvPeer->nTransmissionsOfCount[c] * nStepsInCount;
       }
       proxyOp.nsteps = nLoopsChunkSteps * nRecvs;
@@ -131,7 +131,7 @@ ncclResult_t mscclSetupProxy(struct mscclAlgo* hostAlgo, ncclComm_t comm) {
       int nSends = 0;
       for (int j = 0; j < sendPeer->nExistingCounts; j++){
         int c = sendPeer->existingCounts[j];
-        int nStepsInCount = DIVUP(c+1, status.maxAllowedCount);
+        int nStepsInCount = DIVUP(c, status.maxAllowedCount);
         nSends += sendPeer->nTransmissionsOfCount[c] * nStepsInCount;
       }
       proxyOp.nsteps = nLoopsChunkSteps * nSends;


### PR DESCRIPTION
Current number of transmissions parsed from MSCCL algorithm is 1-based value, but when calculating proxy number of chunks, it's taken as 0-based value. This commit fixes this issue.