### PR TITLE
[WIP] Add APIs to export flow information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ _templates/
 _toc.yml
 docBin/
 _doxygen/
+/tools/topo_expl/hipify_rccl/
+/tools/topo_expl/topo_expl

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
 *.gcov
 /coverage/
+/.vscode/
 
 # documentation artifacts
 build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,7 @@ set(SRC_FILES
   src/debug.cc
   src/enhcompat.cc
   src/enqueue.cc
+  src/flow_export.cc
   src/graph/connect.cc
   src/graph/paths.cc
   src/graph/rings.cc
@@ -348,6 +349,7 @@ set(SRC_FILES
   src/include/debug.h
   src/include/devcomm.h
   src/include/enqueue.h
+  src/include/flow_export.h
   src/include/gdrwrap.h
   src/include/git_version.h
   src/include/graph.h

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -6,6 +6,7 @@ Contains contributions from NVIDIA.
 Copyright (c) 2015-2020, NVIDIA CORPORATION. All rights reserved.
 Modifications Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 Modifications Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+Modifications Copyright (c) Arista Networks, Inc. Licensed under the MIT License.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ INCEXPORTS  := nccl.h nccl_net.h
 LIBSRCFILES := init.cc init_nvtx.cc channel.cc bootstrap.cc transport.cc enqueue.cc group.cc debug.cc proxy.cc net.cc \
 		misc/cudawrap.cc misc/nvmlwrap.cc misc/ibvsymbols.cc misc/ibvwrap.cc misc/gdrwrap.cc \
 		misc/utils.cc misc/argcheck.cc misc/socket.cc misc/shmutils.cc misc/profiler.cc misc/param.cc misc/strongstream.cc \
-		misc/ipcsocket.cc \
+		misc/ipcsocket.cc flow_export.cc \
 		transport/p2p.cc transport/shm.cc transport/net.cc transport/net_socket.cc transport/net_ib.cc transport/coll_net.cc transport/nvls.cc \
                 collectives/sendrecv.cc collectives/all_reduce.cc collectives/all_gather.cc collectives/broadcast.cc collectives/reduce.cc collectives/reduce_scatter.cc \
                 graph/topo.cc graph/paths.cc graph/search.cc graph/connect.cc graph/rings.cc graph/trees.cc graph/tuning.cc graph/xml.cc

--- a/src/flow_export.cc
+++ b/src/flow_export.cc
@@ -34,6 +34,11 @@ initFlowV1( const connectionMetaData_t & cmd, Flow_v1 & flow ) {
 
 inline void
 gidToIpAddr( const union ibv_gid & gid, IpGenAddr & genAddr ) {
+   // A gid.raw is 16 bytes, the size of an IPv6 address. If the address has a
+   // prefix of ::ffff:0:0/96 (i.e., the first 10 bytes are zero, followed by
+   // two 0xff bytes) bytes), then it actually represents an IPv4 address, which
+   // is held in the last 4 bytes.
+   // See: https://en.wikipedia.org/wiki/IPv6_address#Transition_from_IPv4
    static const uint8_t ipv4Prefix[ 12 ] = {
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff
    };

--- a/src/flow_export.cc
+++ b/src/flow_export.cc
@@ -13,7 +13,7 @@ NCCL_PARAM( FlowExport, "FLOW_EXPORT", 0 );
 
 // Make visible for tests.
 __attribute__ ((visibility("default"))) FlowExport_v1 * flowExport_v1 = nullptr;
-std::atomic< uint64_t > * currCommHash = nullptr;
+__attribute__ ((visibility("default"))) std::atomic< uint64_t > * currCommHash = nullptr;
 
 namespace {
 

--- a/src/flow_export.cc
+++ b/src/flow_export.cc
@@ -190,6 +190,8 @@ ncclExportDone( struct ncclComm & comm ) {
          WARN( "flowExport_v1.exportDone() failed: code %d", result );
       }
    }
-   currCommHash[ tpLocalRank ] = 0;
+   if ( currCommHash ) {
+     currCommHash[ tpLocalRank ] = 0;
+   }
    return result;
 }

--- a/src/flow_export.cc
+++ b/src/flow_export.cc
@@ -11,7 +11,8 @@
 
 NCCL_PARAM( FlowExport, "FLOW_EXPORT", 0 );
 
-FlowExport_v1 * flowExport_v1 = nullptr;
+// Make visible for tests.
+__attribute__ ((visibility("default"))) FlowExport_v1 * flowExport_v1 = nullptr;
 std::atomic< uint64_t > * currCommHash = nullptr;
 
 namespace {

--- a/src/flow_export.cc
+++ b/src/flow_export.cc
@@ -1,0 +1,195 @@
+// Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+// Licensed under the MIT License.
+
+#include "flow_export.h"
+
+#include "net.h"
+
+#include <atomic>
+#include <dlfcn.h>
+
+NCCL_PARAM( FlowExport, "FLOW_EXPORT", 0 );
+
+FlowExport_v1 * flowExport_v1 = nullptr;
+std::atomic< uint64_t > * currCommHash = nullptr;
+
+namespace {
+
+inline uint32_t
+tpRank( struct ncclComm & comm, int rank ) {
+   return rank == -1 ? UINT32_MAX : comm.topParentRanks[ rank ];
+}
+
+} // namespace
+
+ncclResult_t
+ncclInitFlowExport() {
+   if ( !ncclParamFlowExport() ) {
+      INFO( NCCL_INIT, "flow export disabled" );
+      return ncclSuccess;
+   }
+
+   if ( flowExport_v1 ) {
+      INFO( NCCL_INIT, "flow export already initialized" );
+      return ncclSuccess;
+   }
+
+   const char * pluginName = getenv( "FLOW_EXPORT_PLUGIN_LIB" );
+   if ( !pluginName || !pluginName[ 0 ] ) {
+      pluginName = "libnccl_flow_export_v1.so";
+   }
+   void * lib = dlopen( pluginName, RTLD_NOW | RTLD_LOCAL );
+   if ( !lib ) {
+      std::string err = dlerror();
+      WARN( "failed to load flow export plugin %s: %s", pluginName, err.c_str() );
+      return ncclSystemError;
+   }
+   INFO( NCCL_INIT, "loaded flow export plugin %s", pluginName );
+
+   flowExport_v1 =
+      reinterpret_cast< FlowExport_v1 * >( dlsym( lib, "flowExport_v1" ) );
+   if ( !flowExport_v1 ) {
+      std::string err = dlerror();
+      WARN( "failed to find flowExport_v1 struct: %s", err.c_str() );
+      return ncclSystemError;
+   }
+
+   currCommHash = new std::atomic< uint64_t >[ NCCL_MAX_LOCAL_RANKS ]();
+
+   if ( !flowExport_v1->init ) {
+      INFO( NCCL_INIT, "flowExport_v1.init not defined, skipping" );
+      return ncclSuccess;
+   }
+
+   ncclResult_t result = flowExport_v1->init();
+   if ( result != ncclSuccess ) {
+      WARN( "flowExport_v1.init() failed: code %d", result );
+   }
+   return result;
+}
+
+ncclResult_t
+ncclExitFlowExport() {
+   ncclResult_t result = ncclSuccess;
+
+   if ( flowExport_v1 && flowExport_v1->exit ) {
+      result = flowExport_v1->exit();
+      if ( result == ncclSuccess ) {
+         INFO( NCCL_INIT, "unloaded flow export plugin" );
+      } else {
+         WARN( "flowExport_v1.exit() failed: code %d", result );
+      }
+   }
+
+   flowExport_v1 = nullptr;
+   delete[] currCommHash;
+   currCommHash = nullptr;
+
+   return result;
+}
+
+ncclResult_t
+ncclExportFlow( const connectionMetaData_t & cmd,
+                struct ncclSocket & ctrlSock,
+                struct ncclSocket socks[],
+                int nSocks ) {
+   if ( !flowExport_v1 || !flowExport_v1->exportFlow ) {
+      return ncclSuccess;
+   }
+
+   Flow_v1 flow;
+
+   flow.commHash = currCommHash[ cmd.tpLocalRank ];
+   flow.direction = cmd.send ? SEND : RECEIVE;
+   flow.srcRank = cmd.tpRank;
+   flow.srcLocalRank = cmd.tpLocalRank;
+   flow.dstRank = cmd.tpRemoteRank;
+   flow.channel = cmd.channelId;
+   flow.topology = cmd.connIndex == 0 ? COLLECTIVE : P2P;
+
+   for ( int i = 0; i <= nSocks; ++i ) {
+      struct ncclSocket & sock = ( i == nSocks ) ? ctrlSock : socks[ i ];
+      flow.trafficType = UDP; // TODO
+      flow.qPair = 0; // TODO
+
+      // This assumes v4 :(
+      struct sockaddr_in srcAddr;
+      bzero( &srcAddr, sizeof( srcAddr ) );
+      socklen_t len = sizeof( srcAddr );
+      if ( getsockname(
+              sock.fd, reinterpret_cast< struct sockaddr * >( &srcAddr ), &len ) ) {
+         perror( "getsockname() failed" );
+         return ncclSystemError;
+      }
+      flow.srcIp = ntohl( srcAddr.sin_addr.s_addr );
+      flow.srcPort = ntohs( srcAddr.sin_port );
+      flow.dstIp = ntohl( sock.addr.sin.sin_addr.s_addr );
+      flow.dstPort = ntohs( sock.addr.sin.sin_port );
+
+      ncclResult_t result = flowExport_v1->exportFlow( &flow );
+      if ( result != ncclSuccess ) {
+         WARN( "flowExport_v1.exportFlow() failed: code %d", result );
+         return result;
+      }
+   }
+
+   return ncclSuccess;
+}
+
+ncclResult_t
+ncclExportComm( struct ncclComm & comm ) {
+   if ( !flowExport_v1 || !flowExport_v1->exportComm ) {
+      return ncclSuccess;
+   }
+
+   uint32_t tpLocalRank = comm.topParentLocalRanks[ comm.localRank ];
+   currCommHash[ tpLocalRank ] = comm.commHash;
+
+   Comm_v1 commExport;
+   commExport.commHash = comm.commHash;
+
+   commExport.nRanks = comm.nRanks;
+   commExport.rank = comm.rank;
+   commExport.tpRank = tpRank( comm, comm.rank );
+
+   commExport.nLocalRanks = comm.localRanks;
+   commExport.localRank = comm.localRank;
+   commExport.tpLocalRank = tpLocalRank;
+
+   commExport.nNodes = comm.nNodes;
+   commExport.node = comm.node;
+
+   commExport.nChannels = comm.nChannels;
+
+   for ( int c = 0; c < comm.nChannels; ++c ) {
+      struct ncclChannel & channel = comm.channels[ c ];
+      commExport.ring[ c ].tpPrev = tpRank( comm, channel.ring.prev );
+      commExport.ring[ c ].tpNext = tpRank( comm, channel.ring.next );
+      commExport.tree[ c ].tpUp = tpRank( comm, channel.tree.up );
+      for ( int n = 0; n < NCCL_MAX_TREE_ARITY; ++n ) {
+         commExport.tree[ c ].tpDown[ n ] = tpRank( comm, channel.tree.down[ n ] );
+      }
+   }
+
+   ncclResult_t result = flowExport_v1->exportComm( &commExport );
+   if ( result != ncclSuccess ) {
+      WARN( "flowExport_v1.exportComm() failed: code %d", result );
+   }
+
+   return result;
+}
+
+ncclResult_t
+ncclExportDone( struct ncclComm & comm ) {
+   int tpLocalRank = comm.topParentLocalRanks[ comm.localRank ];
+   ncclResult_t result = ncclSuccess;
+   if ( flowExport_v1 && flowExport_v1->exportDone ) {
+      result = flowExport_v1->exportDone( currCommHash[ tpLocalRank ],
+                                          tpRank( comm, comm.rank ) );
+      if ( result != ncclSuccess ) {
+         WARN( "flowExport_v1.exportDone() failed: code %d", result );
+      }
+   }
+   currCommHash[ tpLocalRank ] = 0;
+   return result;
+}

--- a/src/include/flow_export.h
+++ b/src/include/flow_export.h
@@ -1,0 +1,97 @@
+// Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef NCCL_FLOW_EXPORT_H
+#define NCCL_FLOW_EXPORT_H
+
+#include "comm.h"
+#include "devcomm.h"
+#include "nccl.h"
+#include "net.h"
+#include "socket.h"
+
+#include <cstdint>
+
+ncclResult_t ncclInitFlowExport();
+ncclResult_t ncclExitFlowExport();
+ncclResult_t ncclExportFlow( const connectionMetaData_t & cmd,
+                             struct ncclSocket & ctrlSock,
+                             struct ncclSocket socks[],
+                             int nSocks );
+ncclResult_t ncclExportComm( struct ncclComm & ncclComm );
+ncclResult_t ncclExportDone( struct ncclComm & ncclComm );
+
+// -------------------------------------------------------
+// Plugin API
+
+enum FlowDirection_v1 {
+   SEND,
+   RECEIVE,
+};
+
+enum FlowTopology_v1 {
+   COLLECTIVE,
+   P2P,
+};
+
+enum FlowTrafficType_v1 {
+   UDP,
+   TCP,
+   ROCEv2,
+};
+
+struct Flow_v1 {
+   uint64_t commHash;
+   FlowDirection_v1 direction;
+   uint32_t srcRank;
+   uint32_t srcLocalRank;
+   uint32_t dstRank;
+   uint32_t channel;
+   FlowTopology_v1 topology;
+   FlowTrafficType_v1 trafficType;
+   uint32_t srcIp;
+   uint32_t dstIp;
+   uint16_t srcPort;
+   uint16_t dstPort;
+   uint32_t qPair;
+};
+
+struct RingNode_v1 {
+   uint32_t tpPrev;
+   uint32_t tpNext;
+};
+
+struct TreeNode_v1 {
+   uint32_t tpUp;
+   uint32_t tpDown[ NCCL_MAX_TREE_ARITY ];
+};
+
+struct Comm_v1 {
+   uint64_t commHash;
+
+   uint32_t nRanks;
+   uint32_t rank;
+   uint32_t tpRank;
+
+   uint32_t nLocalRanks;
+   uint32_t localRank;
+   uint32_t tpLocalRank;
+
+   uint32_t nNodes;
+   uint32_t node;
+
+   uint32_t nChannels;
+   RingNode_v1 ring[ MAXCHANNELS ];
+   TreeNode_v1 tree[ MAXCHANNELS ];
+};
+
+// Plugin should define a global symbol: FlowExport_v1 flowExport_v1;
+struct FlowExport_v1 {
+   ncclResult_t ( *init )();
+   ncclResult_t ( *exit )();
+   ncclResult_t ( *exportFlow )( const Flow_v1 * flow );
+   ncclResult_t ( *exportComm )( const Comm_v1 * comm );
+   ncclResult_t ( *exportDone )( uint64_t commHash, uint32_t tpRank );
+};
+
+#endif // NCCL_FLOW_EXPORT_H

--- a/src/include/flow_export.h
+++ b/src/include/flow_export.h
@@ -14,10 +14,17 @@
 
 ncclResult_t ncclInitFlowExport();
 ncclResult_t ncclExitFlowExport();
-ncclResult_t ncclExportFlow( const connectionMetaData_t & cmd,
-                             struct ncclSocket & ctrlSock,
-                             struct ncclSocket socks[],
-                             int nSocks );
+ncclResult_t ncclExportSocketFlow( const connectionMetaData_t & cmd,
+                                   struct ncclSocket & ctrlSock,
+                                   struct ncclSocket socks[],
+                                   int nSocks );
+ncclResult_t ncclExportIbFlow( const connectionMetaData_t & cmd,
+                               const union ibv_gid & localGid,
+                               const union ibv_gid & remoteGid,
+                               struct ibv_qp ** srcQPairs,
+                               const uint32_t * dstQPairs,
+                               int nQPairs );
+
 ncclResult_t ncclExportComm( struct ncclComm & ncclComm );
 ncclResult_t ncclExportDone( struct ncclComm & ncclComm );
 
@@ -40,6 +47,14 @@ enum FlowTrafficType_v1 {
    ROCEv2,
 };
 
+struct IpGenAddr {
+   union {
+      struct in_addr ipv4Addr;
+      struct in6_addr ipv6Addr;
+   } addr;
+   bool isIpv4;
+};
+
 struct Flow_v1 {
    uint64_t commHash;
    FlowDirection_v1 direction;
@@ -49,11 +64,12 @@ struct Flow_v1 {
    uint32_t channel;
    FlowTopology_v1 topology;
    FlowTrafficType_v1 trafficType;
-   uint32_t srcIp;
-   uint32_t dstIp;
+   struct IpGenAddr srcIp;
+   struct IpGenAddr dstIp;
    uint16_t srcPort;
    uint16_t dstPort;
-   uint32_t qPair;
+   uint32_t srcQPair;
+   uint32_t dstQPair;
 };
 
 struct RingNode_v1 {

--- a/src/include/net.h
+++ b/src/include/net.h
@@ -21,6 +21,16 @@ int ncclNetVersion(struct ncclComm* comm);
 // Test whether the current GPU support GPU Direct RDMA.
 ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport);
 
+struct connectionMetaData_t {
+   bool send;
+   int tpRank;
+   int tpLocalRank;
+   int tpRemoteRank;
+   int channelId;
+   int connIndex;
+};
+extern __thread connectionMetaData_t connectionMetaData;
+
 extern ncclNet_t ncclNetIb;
 extern ncclNet_t ncclNetSocket;
 

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -12,6 +12,7 @@
 #include "graph.h"
 #include "utils.h"
 #include "param.h"
+#include "flow_export.h"
 
 #include <assert.h>
 #include <pthread.h>
@@ -742,6 +743,8 @@ ib_connect:
   stage->state = ncclIbCommStateConnected;
   stage->offset = 0;
 
+  NCCLCHECK(ncclExportIbFlow(connectionMetaData, comm->gidInfo.localGid, comm->gidInfo.remoteGid, comm->qps, remQpInfo.qpn, comm->nqps));
+
 ib_send_ready:
   NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->sock, &comm->ready, sizeof(int), &stage->offset));
   if (stage->offset != sizeof(int)) return ncclSuccess;
@@ -864,6 +867,8 @@ ib_recv:
   if (stage->buffer) free(stage->buffer);
   NCCLCHECK(ncclIbMalloc((void**)&stage->buffer, sizeof(struct ncclIbQpInfo)));
   memcpy(stage->buffer, &qpInfo, sizeof(struct ncclIbQpInfo));
+
+  NCCLCHECK(ncclExportIbFlow(connectionMetaData, rComm->gidInfo.localGid, rComm->gidInfo.remoteGid, rComm->qps, remQpInfo.qpn, rComm->nqps));
 
 ib_send:
   NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &rComm->sock, stage->buffer, sizeof(struct ncclIbQpInfo), &stage->offset));

--- a/src/transport/net_socket.cc
+++ b/src/transport/net_socket.cc
@@ -343,7 +343,7 @@ socket_send:
     NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, sock, &i, sizeof(uint8_t), &done));
     if (done == 0) return ncclSuccess;
   }
-  NCCLCHECK(ncclExportFlow(connectionMetaData, comm->ctrlSock, comm->socks, comm->nSocks));
+  NCCLCHECK(ncclExportSocketFlow(connectionMetaData, comm->ctrlSock, comm->socks, comm->nSocks));
   *sendComm = comm;
   return ncclSuccess;
 }
@@ -394,7 +394,7 @@ socket_recv:
   }
   *recvComm = rComm;
 
-  NCCLCHECK(ncclExportFlow(connectionMetaData, rComm->ctrlSock, rComm->socks, rComm->nSocks));
+  NCCLCHECK(ncclExportSocketFlow(connectionMetaData, rComm->ctrlSock, rComm->socks, rComm->nSocks));
 
   /* reset lComm state */
   stage->state = ncclNetSocketCommStateStart;

--- a/src/transport/net_socket.cc
+++ b/src/transport/net_socket.cc
@@ -9,6 +9,7 @@
 #include "socket.h"
 #include "net.h"
 #include "param.h"
+#include "flow_export.h"
 
 #include <pthread.h>
 #include <stdlib.h>
@@ -342,6 +343,7 @@ socket_send:
     NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, sock, &i, sizeof(uint8_t), &done));
     if (done == 0) return ncclSuccess;
   }
+  NCCLCHECK(ncclExportFlow(connectionMetaData, comm->ctrlSock, comm->socks, comm->nSocks));
   *sendComm = comm;
   return ncclSuccess;
 }
@@ -391,6 +393,8 @@ socket_recv:
     free(sock);
   }
   *recvComm = rComm;
+
+  NCCLCHECK(ncclExportFlow(connectionMetaData, rComm->ctrlSock, rComm->socks, rComm->nSocks));
 
   /* reset lComm state */
   stage->state = ncclNetSocketCommStateStart;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ if(BUILD_TESTS)
       AllToAllTests.cpp
       AllToAllVTests.cpp
       BroadcastTests.cpp
+      FlowExportTests.cpp
       GatherTests.cpp
       GroupCallTests.cpp
       NonBlockingTests.cpp
@@ -73,7 +74,7 @@ if(BUILD_TESTS)
     add_dependencies(rccl-UnitTests rccl)
     target_link_libraries(rccl-UnitTests PRIVATE dl rt numa -lrccl -L${CMAKE_BINARY_DIR} -lrocm_smi64 -L${ROCM_PATH}/lib -L${ROCM_PATH}/rocm_smi/lib)
   else()
-    target_link_libraries(rccl-UnitTests PRIVATE rccl)
+    target_link_libraries(rccl-UnitTests PRIVATE rccl dl)
   endif()
   set_property(TARGET rccl-UnitTests PROPERTY INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${ROCM_PATH}/lib;${CMAKE_BINARY_DIR}")
   set_property(TARGET rccl-UnitTests PROPERTY BUILD_RPATH "${CMAKE_BINARY_DIR};${ROCM_PATH}/lib")

--- a/test/FlowExportTests.cpp
+++ b/test/FlowExportTests.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
+// Licensed under the MIT License.
+
+#include "TestBed.hpp"
+
+#include "flow_export.h"
+
+ncclResult_t
+testExportComm( const Comm_v1 * comm ) {
+   // TODO: Capture the comm info and assert in the test that this matches what
+   // we expect.
+   return ncclSuccess;
+}
+
+extern FlowExport_v1 * flowExport_v1;
+
+FlowExport_v1 testFlowExport{
+   .exportComm = testExportComm,
+};
+
+namespace RcclUnitTesting {
+
+TEST( FlowExport, CommExport ) {
+   // Fake the plugin setup without actually dynamically loading a shared lib.
+   flowExport_v1 = &testFlowExport;
+
+   TestBed testBed;
+
+   // Configuration
+   std::vector< ncclFunc_t > const funcTypes = { ncclCollAllReduce };
+   std::vector< ncclDataType_t > const dataTypes = { ncclFloat32 };
+   std::vector< ncclRedOp_t > const redOps = { ncclSum };
+   std::vector< int > const roots = { 0 };
+   std::vector< int > const numElements = { 393216, 384 };
+   std::vector< bool > const inPlaceList = { false };
+   std::vector< bool > const managedMemList = { false };
+   std::vector< bool > const useHipGraphList = { false };
+
+   testBed.RunSimpleSweep( funcTypes,
+                           dataTypes,
+                           redOps,
+                           roots,
+                           numElements,
+                           inPlaceList,
+                           managedMemList,
+                           useHipGraphList );
+   testBed.Finalize();
+
+   flowExport_v1 = nullptr;
+}
+
+} // namespace RcclUnitTesting


### PR DESCRIPTION
Define APIs that can be implemented by a dynamic plugin to export flow info.

Co-authored with Tom Emmons <tom@[redacted]>.

Export flow information for ring and tree topologies currently, covering both
IPv4 and IPv6, as well as TCP and ROCEv2. We'll add support for P2P
topology later.

The idea is that the flow information can be used by network devices to do
better load-balancing.

Such a plugin will be used if the env var NCCL_FLOW_EXPORT is set to a non-zero
value. An example plugin that simply writes the flow info to stdout can be
seen here: https://github.com/sreeram-arista/ai-flow-lb

Currently still a WIP because:
1. Need to flesh out unit-tests.
2. Want to get feedback on the approach before going too deep.