### PR TITLE
Fix static_assert string literal that contains a "\%".

### DIFF
--- a/src/include/msccl/msccl_struct.h
+++ b/src/include/msccl/msccl_struct.h
@@ -64,7 +64,7 @@ struct mscclThreadBlock {
   int16_t channelId; // associated channel. -1 indicates a thread block with only local copies
 }; // 5384 bytes
 
-static_assert(sizeof(struct mscclThreadBlock) % sizeof(uint64_t) == 0, "Sanity check: sizeof(struct mscclThreadBlock) \% sizeof(uint64_t) != 0");
+static_assert(sizeof(struct mscclThreadBlock) % sizeof(uint64_t) == 0, "Sanity check: sizeof(struct mscclThreadBlock) % sizeof(uint64_t) != 0");
 
 struct mscclFlag {
   uint64_t flag;


### PR DESCRIPTION
This is no longer valid. They can only be simple escape sequences. Removing '\' fixes issue. Assert message now compiles and emits the '%' as expected.