### PR TITLE
Minor fix for some msccl installations

### DIFF
--- a/src/misc/msccl/msccl_lifecycle.cc
+++ b/src/misc/msccl/msccl_lifecycle.cc
@@ -98,7 +98,7 @@ static ncclResult_t mscclInternalSchedulerInit() {
     mscclAlgoDirStr += (mscclUnitTestMode && mscclUnitTestMode()) ? mscclUnitTestAlgoDefaultDir : mscclAlgoDefaultDir;
     mscclAlgoDir = mscclAlgoDirStr.c_str();
     // Get share Directory Paths
-    mscclAlgoShareDirStr = selfLibPath.substr(0, selfLibPath.find("lib"));
+    mscclAlgoShareDirStr = selfLibPath.substr(0, selfLibPath.rfind("lib"));
     mscclAlgoShareDirStr += (mscclUnitTestMode && mscclUnitTestMode()) ? mscclUnitTestAlgoShareDirPath : mscclAlgoShareDirPath;
     mscclAlgoShareDir = mscclAlgoShareDirStr.c_str();
   }


### PR DESCRIPTION
Switching to finding the "last" lib in string, rather than first "lib".
Causing an issue with some pytorch installations.