### PR TITLE
optimizing COLL_UNROLL for MI100 machines

### DIFF
--- a/src/collectives/device/common.h
+++ b/src/collectives/device/common.h
@@ -11,7 +11,11 @@
 #include "collectives.h"
 #include "devcomm.h"
 
+#if defined(__gfx908__)
+#define COLL_UNROLL 2
+#else
 #define COLL_UNROLL 4
+#endif
 
 #define NCCL_MAX_DEV_ARITY (NCCL_MAX_TREE_ARITY-1)  // Using balanced tree instead of split tree
 

--- a/src/collectives/device/sendrecv.h
+++ b/src/collectives/device/sendrecv.h
@@ -204,6 +204,8 @@ struct RunWork<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
       } else {
 #if defined(__gfx90a__)
         runRecv<ProtoSimple<1,1,8>>(tid, nthreads, group, args);
+#elif defined(__gfx908__)
+        runRecv<ProtoSimple<1,1,4>>(tid, nthreads, group, args);
 #else
         runRecv<ProtoSimple<1,1>>(tid, nthreads, group, args);
 #endif
@@ -214,6 +216,8 @@ struct RunWork<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
       } else {
 #if defined(__gfx90a__)
         runSend<ProtoSimple<1,1,8>>(tid, nthreads, group, args);
+#elif defined(__gfx908__)
+        runSend<ProtoSimple<1,1,4>>(tid, nthreads, group, args);
 #else
         runSend<ProtoSimple<1,1>>(tid, nthreads, group, args);
 #endif


### PR DESCRIPTION
This commit optimizes the unrolling factor for collectives for MI100 machines.
The default value for COLL_UNROLL is 2 which delivers better performance for most of the collective operations.
For sendrecv, gather, and scatter collectives COLL_UNROLL 4 is used because delivers better performance compared to COLL_UNROLL=2.
Link to the corresponding Jira tasks:
https://ontrack-internal.amd.com/browse/SWDEV-412970:
[ROCm QA][IV][QR][G][MI100]~6% Performance drop in RCCL " broadcast_perf-bench"
https://ontrack-internal.amd.com/browse/LWPCOMMLIBS-76:
Experiment with RCCL Simple Protocol on MI100