### PR TITLE
Revert "Remove 2H4P condition from P2P channels adjustment (#890)"

### DIFF
--- a/src/graph/paths.cc
+++ b/src/graph/paths.cc
@@ -812,7 +812,7 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
     // Adjust P2P channels on Intel platform
     comm->p2pnChannelsPerPeer = 1;
     comm->p2pnChannels = 2;
-  } else if (comm->topo->nodes[GPU].count == comm->topo->nRanks && !(comm->topo->type & RCCL_TOPO_GDR_ALL) && !(comm->topo->type & RCCL_TOPO_XGMI_ALL)) {
+  } else if (comm->topo->nodes[GPU].count == comm->topo->nRanks && (comm->topo->type & RCCL_TOPO_4P2H_ROME) && !(comm->topo->type & RCCL_TOPO_GDR_ALL) && !(comm->topo->type & RCCL_TOPO_XGMI_ALL)) {
     // Adjust P2P channels on Rome
     comm->p2pnChannelsPerPeer = 2;
     comm->p2pnChannels = 2;


### PR DESCRIPTION
This reverts commit 16dd05a58a948eeb3de9c484dbe5e5ffb4e7295e.

This revert resolves the ~19% performance drop with gather and ~40% with sendrecv tests.
The hang for alltoallv is not observed with develop branch for both 4 and 8 gpus.
Performance drop observed for alltoallv with this revert, but there is a workaround for now (NCCL_MAX_P2P_NCHANNELS=2).
