### PR TITLE
Remove quotes causing asan build breakage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,7 +606,7 @@ endif()
 #endforeach()
 
 if(BUILD_ADDRESS_SANITIZER)
-  target_compile_options(rccl PRIVATE "-fsanitize=address -shared-libasan")
+  target_compile_options(rccl PRIVATE -fsanitize=address -shared-libasan)
 endif()
 if(TIMETRACE)
   target_compile_options(rccl PRIVATE -ftime-trace)


### PR DESCRIPTION
The quotes around "-fsanitize=address -shared-libasan" cause the BUILD_ADDRESS_SANITIZER build to fail; remove the quotes