### PR TITLE
remove gcnArch support (#920) and Fix gcnArchName bug in topology dump (#937)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,14 +125,6 @@ check_symbol_exists("hipEventDisableSystemFence" "hip/hip_runtime_api.h" HIP_EVE
 ### Check for hipDeviceMallocUncached support
 check_symbol_exists("hipDeviceMallocUncached" "hip/hip_runtime_api.h" HIP_UNCACHED_MEMORY)
 
-message(STATUS "HIP Library version: ${hip_VERSION_MINOR}")
-### Check the version of HIP to see if we can use gcnArchName instead of gcnArch (deprecated)
-if(${hipcc_version_string} VERSION_LESS "5.7.31921")
-    set(HIP_NO_GCNARCHNAME ON)
-  else()
-    set(HIP_NO_GCNARCHNAME OFF)
-endif()
-
 ### Check for indirect function call support
 if(ENABLE_IFC)
   if(${hipcc_version_string} VERSION_GREATER_EQUAL "5.5.30201")
@@ -565,9 +557,6 @@ else()
   if(NOT IFC_ENABLED)
     target_compile_options(rccl PRIVATE --hipcc-func-supp)
   endif()
-endif()
-if(HIP_NO_GCNARCHNAME)
-  target_compile_definitions(rccl PRIVATE HIP_NO_GCNARCHNAME)
 endif()
 if (BUILD_BFD)
   if (HAVE_BFD)

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -369,14 +369,11 @@ ncclResult_t ncclTopoAddNic(struct ncclXmlNode* xmlNic, struct ncclTopoSystem* s
 
 ncclResult_t ncclTopoAddGpu(struct ncclXmlNode* xmlGpu, struct ncclTopoSystem* system, struct ncclTopoNode* gpu) {
   NCCLCHECK(xmlGetAttrInt(xmlGpu, "sm", &gpu->gpu.cudaCompCap));
-  NCCLCHECK(xmlGetAttr(xmlGpu, "gcn", &gpu->gpu.gcn));
-  if (strcmp(gpu->gpu.gcn, "906") == 0) {
-    gpu->gpu.gcn = "gfx906";
-  } else if (strcmp(gpu->gpu.gcn, "908") == 0) {
-    gpu->gpu.gcn = "gfx908";
-  } else if (strcmp(gpu->gpu.gcn, "910") == 0) {
-    gpu->gpu.gcn = "gfx90a";
-  }
+  const char* gcnArch;
+  const char* gcnArchName;
+  NCCLCHECK(xmlGetAttr(xmlGpu, "gcn", &gcnArch));
+  convertGcnArchToGcnArchName(gcnArch, &gcnArchName);
+  gpu->gpu.gcn = strdup(gcnArchName);
   rcclHipDeviceArch_t arch;
   NCCLCHECK(xmlGetAttrInt(xmlGpu, "arch", &arch.value));
   memcpy(&gpu->gpu.arch, &arch.arch, sizeof(hipDeviceArch_t));

--- a/src/include/archinfo.h
+++ b/src/include/archinfo.h
@@ -31,7 +31,7 @@ THE SOFTWARE.
 */
 
 void GcnArchNameFormat(char *gcnArchName, char* out);
-void GcnArchConvertToGcnArchName(int gcnArch, char* out);
+void convertGcnArchToGcnArchName(const char* gcnArch, const char** gcnArchName);
 int GetGcnArchName(int deviceId, char* out);
 double GetDeviceWallClockRateInKhz(int deviceId);
 bool IsArchMatch(char const* arch, char const* target);


### PR DESCRIPTION
Cherry-pick from rccl/develop [PR#920](https://github.com/ROCmSoftwarePlatform/rccl/pull/920) and [PR#937](https://github.com/ROCmSoftwarePlatform/rccl/pull/937) that resolve the gcnArch issue.