### PR TITLE
msccl: enable basic collective trace

### DIFF
--- a/src/include/msccl/msccl_scheduler.h
+++ b/src/include/msccl/msccl_scheduler.h
@@ -36,6 +36,7 @@ struct mscclSchedulerParam {
   int nRanks;
   bool scheduled;
   mscclAlgoHandle_t handle;
+  uint64_t opCount;
 };
 
 typedef struct {

--- a/src/include/msccl/msccl_struct.h
+++ b/src/include/msccl/msccl_struct.h
@@ -239,7 +239,7 @@ struct mscclWork {
   int nChunksPerLoop;
   bool hasReduce;
   bool redOpArgIsPtr;
-  uint32_t pad[1];
+  uint32_t fnIndex;
 };
 static_assert(sizeof(struct mscclWork) % 16 == 0, "mscclWork needs to be 16B aligned");
 


### PR DESCRIPTION
To avoid increasing number of kernels, colltrace is only enabled with RCCL_MSCCL_FORCE_FULLOPS=1