### PR TITLE
Tune MSCCL all-reduce algorithm

### DIFF
--- a/tools/msccl-algorithms/allreduce-allpairs-8n-ll-32tb.xml
+++ b/tools/msccl-algorithms/allreduce-allpairs-8n-ll-32tb.xml
@@ -1,4 +1,4 @@
-<algo name="allreduce_pairs" proto="LL" nchannels="4" nchunksperloop="256" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="20481" maxBytes="327680">
+<algo name="allreduce_pairs" proto="LL" nchannels="4" nchunksperloop="256" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="20481" maxBytes="81919">
   <gpu id="0" i_chunks="256" o_chunks="0" s_chunks="224">
     <tb id="0" send="-1" recv="-1" chan="0">
       <step s="0" type="nop" srcbuf="i" srcoff="-1" dstbuf="o" dstoff="-1" cnt="0" depid="8" deps="1" hasdep="0"/>

--- a/tools/msccl-algorithms/allreduce-allpairs-8n-ll-64tb.xml
+++ b/tools/msccl-algorithms/allreduce-allpairs-8n-ll-64tb.xml
@@ -1,4 +1,4 @@
-<algo name="allreduce_pairs" proto="Simple" nchannels="8" nchunksperloop="512" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="1048576" maxBytes="11534336">
+<algo name="allreduce_pairs" proto="LL" nchannels="8" nchunksperloop="512" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="81920" maxBytes="1048575">
   <gpu id="0" i_chunks="512" o_chunks="0" s_chunks="448">
     <tb id="0" send="-1" recv="-1" chan="0">
       <step s="0" type="nop" srcbuf="i" srcoff="-1" dstbuf="o" dstoff="-1" cnt="0" depid="16" deps="1" hasdep="0"/>


### PR DESCRIPTION
Extend to 64 thread blocks for some sizes for better bandwidth utilization. Up to 25% performance improvement observed.