### PR TITLE
Correct package name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -741,7 +741,7 @@ endif()
 
 if(BUILD_TESTS)
   rocm_package_setup_component(clients)
-  rocm_package_setup_client_component(tests PACKAGE_NAME rccl-unitTests)
+  rocm_package_setup_client_component(tests PACKAGE_NAME UnitTests)
   add_subdirectory(test)
 endif()
 


### PR DESCRIPTION
'rccl-' is added automatically to the package name.