### PR TITLE
Standardize documentation for ReadtheDocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,3 @@
 # Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
 *.gcov
 /coverage/
-
-# documentation artifacts
-build/
-_build/
-_images/
-_static/
-_templates/
-_toc.yml
-docBin/
-_doxygen/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,5 @@
+_build/
+_doxygen/
+doxygen/html
+doxygen/xml
+sphinx/_toc.yml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,9 +8,6 @@ import subprocess
 
 from rocm_docs import ROCmDocs
 
-
-external_projects_current_project = "rccl"
-
 name = "RCCL"
 get_major = r'sed -n -e "s/^NCCL_MAJOR.*\([0-9]\+\).*/\1/p" ../makefiles/version.mk'
 get_minor = r'sed -n -e "s/^NCCL_MINOR.*\([0-9]\{2,\}\).*/\1/p" ../makefiles/version.mk'
@@ -18,12 +15,22 @@ get_patch = r'sed -n -e "s/^NCCL_PATCH.*\([0-9]\+\).*/\1/p" ../makefiles/version
 major = subprocess.getoutput(get_major)
 minor = subprocess.getoutput(get_minor)
 patch = subprocess.getoutput(get_patch)
+version_number = f"{major}.{minor}.{patch}"
+
+# for PDF output on Read the Docs
+project = f"{name} Documentation"
+author = "Advanced Micro Devices, Inc."
+copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
+version = version_number
+release = version_number
 
 external_toc_path = "./sphinx/_toc.yml"
 
-docs_core = ROCmDocs(f"{name} {major}.{minor}.{patch} Documentation")
-docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/docBin/xml")
+docs_core = ROCmDocs(f"{name} {version_number} Documentation")
+docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/xml")
 docs_core.setup()
+
+external_projects_current_project = "rccl"
 
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docBin
+OUTPUT_DIRECTORY       = .
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,4 @@
+License
+=======
+
+.. include:: ../LICENSE.txt

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -4,5 +4,7 @@ subtrees:
   - file: api
   - file: allapi
   - file: attributions
-
+- caption: About
+  entries:
+  - file: license
 

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core>=0.24.0
+rocm-docs-core==0.30.3

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -84,9 +84,7 @@ pygments==2.15.0
     #   pydata-sphinx-theme
     #   sphinx
 pyjwt[crypto]==2.6.0
-    # via
-    #   pygithub
-    #   pyjwt
+    # via pygithub
 pynacl==1.5.0
     # via pygithub
 pytz==2023.3.post1


### PR DESCRIPTION
Apply the following changes to project documentation for ReadtheDocs:

add an "About" section with a license page
set pdf title, author, copyright, and version
remove docBin from URL
update rocm-docs-core dependency

Relates to https://github.com/RadeonOpenCompute/rocm-docs-core/issues/330