### PR TITLE
Use RCCL signal handler in CI tests by default

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -24,7 +24,7 @@ def runTestCommand (platform, project, gfilter, envars)
                 cd ${project.paths.project_build_prefix}/build/release/test
                 ${sudo} ulimit -l unlimited
                 ulimit -a
-                ${sudo} ${envars} RCCL_ENABLE_SIGNALHANDLER=0 NCCL_DEBUG=INFO HSA_FORCE_FINE_GRAIN_PCIE=1 ./rccl-UnitTests --gtest_filter=${gfilter} --gtest_output=xml --gtest_color=yes
+                ${sudo} ${envars} RCCL_ENABLE_SIGNALHANDLER=1 NCCL_DEBUG=INFO HSA_FORCE_FINE_GRAIN_PCIE=1 ./rccl-UnitTests --gtest_filter=${gfilter} --gtest_output=xml --gtest_color=yes
             """
 
    platform.runCommand(this, command)


### PR DESCRIPTION
Enabling RCCL signal handler by default in CI tests. Tested that it output error trace as expected in both debug/release build