### PR TITLE
Add codeowners for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,3 @@
 docs/* @ROCm/rocm-documentation
 *.md @ROCm/rocm-documentation
 *.rst @ROCm/rocm-documentation
-# Header directory for Doxygen documentation
-library/include/* @ROCm/rocm-documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
-* @wenkaidu @gilbertlee-amd @akolliasAMD @edgargabriel @PedramAlizadeh @BertanDogancay @nusislam @nileshnegi @KawtharShafie @AtlantaPepsi @mberenjk @haripriya-amd
+* @wenkaidu @gilbertlee-amd @akolliasAMD @edgargabriel @PedramAlizadeh @BertanDogancay @nusislam @nileshnegi @KawtharShafie @AtlantaPepsi @mberenjk @haripriya-amd# Documentation files
+docs/* @ROCm/rocm-documentation
+*.md @ROCm/rocm-documentation
+*.rst @ROCm/rocm-documentation
+# Header directory for Doxygen documentation
+library/include/* @ROCm/rocm-documentation


### PR DESCRIPTION
Relates to https://github.com/ROCm/ROCm/issues/2832
Adding documentation team as codeowners for documentation.
Goal is to make this group of code owners reviewers when merging documentation changes.

**Please note that this requires the team to be added as a role with Write permissions.**