### PR TITLE
Enable kernarg preloading for ROCm 6.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,7 +635,7 @@ else()
   message(STATUS "Building shared RCCL library")
 endif()
 if (HAVE_KERNARG_PRELOAD)
-  target_link_options(rccl PRIVATE -mllvm --amdgpu-kernarg-preload-count=16)
+  target_link_options(rccl PRIVATE -Xoffload-linker -mllvm=-amdgpu-kernarg-preload-count=16)
 endif()
 
 target_link_libraries(rccl PRIVATE   Threads::Threads)


### PR DESCRIPTION
Fixes performance regression for smaller msg sizes (up to 8MB) in rccl-tests with ROCm 6.1.