### PR TITLE
msccl algorithms tuning for allreduce on MI300

### DIFF
--- a/tools/msccl-algorithms/allreduce-allpairs-8n-ll-1pass.xml
+++ b/tools/msccl-algorithms/allreduce-allpairs-8n-ll-1pass.xml
@@ -1,4 +1,4 @@
-<algo name="allreduce_pairs" proto="LL" nchannels="4" nchunksperloop="32" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="0" maxBytes="20480">
+<algo name="allreduce_pairs" proto="LL" nchannels="4" nchunksperloop="32" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="0" maxBytes="25599">
   <gpu id="0" i_chunks="32" o_chunks="0" s_chunks="224">
     <tb id="0" send="-1" recv="-1" chan="0">
       <step s="0" type="nop" srcbuf="i" srcoff="-1" dstbuf="o" dstoff="-1" cnt="0" depid="8" deps="0" hasdep="0"/>

--- a/tools/msccl-algorithms/allreduce-allpairs-8n-ll-32tb.xml
+++ b/tools/msccl-algorithms/allreduce-allpairs-8n-ll-32tb.xml
@@ -1,4 +1,4 @@
-<algo name="allreduce_pairs" proto="LL" nchannels="4" nchunksperloop="256" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="20481" maxBytes="81919">
+<algo name="allreduce_pairs" proto="LL" nchannels="4" nchunksperloop="256" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="25600" maxBytes="65536">
   <gpu id="0" i_chunks="256" o_chunks="0" s_chunks="224">
     <tb id="0" send="-1" recv="-1" chan="0">
       <step s="0" type="nop" srcbuf="i" srcoff="-1" dstbuf="o" dstoff="-1" cnt="0" depid="8" deps="1" hasdep="0"/>

--- a/tools/msccl-algorithms/allreduce-allpairs-8n-simple.xml
+++ b/tools/msccl-algorithms/allreduce-allpairs-8n-simple.xml
@@ -1,4 +1,4 @@
-<algo name="allreduce_pairs" proto="Simple" nchannels="8" nchunksperloop="512" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="1048576" maxBytes="11534336">
+<algo name="allreduce_pairs" proto="Simple" nchannels="8" nchunksperloop="512" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="524288" maxBytes="11534336">
   <gpu id="0" i_chunks="512" o_chunks="0" s_chunks="448">
     <tb id="0" send="-1" recv="-1" chan="0">
       <step s="0" type="nop" srcbuf="i" srcoff="-1" dstbuf="o" dstoff="-1" cnt="0" depid="16" deps="1" hasdep="0"/>

--- a/tools/msccl-algorithms/allreduce-allpairs-8n-simple_2.xml
+++ b/tools/msccl-algorithms/allreduce-allpairs-8n-simple_2.xml
@@ -1,4 +1,4 @@
-<algo name="allreduce_pairs" proto="LL" nchannels="8" nchunksperloop="512" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="65537" maxBytes="524287">
+<algo name="allreduce_pairs" proto="Simple" nchannels="8" nchunksperloop="512" ngpus="8" coll="allreduce" inplace="1" outofplace="0" minBytes="14680065" maxBytes="16777216">
   <gpu id="0" i_chunks="512" o_chunks="0" s_chunks="448">
     <tb id="0" send="-1" recv="-1" chan="0">
       <step s="0" type="nop" srcbuf="i" srcoff="-1" dstbuf="o" dstoff="-1" cnt="0" depid="16" deps="1" hasdep="0"/>


### PR DESCRIPTION
This PR tunes the performance of msccl for allreduce on MI300X with 8 GPUs. The message range for msccl algorithms is fine-tuned in a way that for each message size the best performing algorithm (xml file) is picked.