### PR TITLE
Fixes the copyright comment block on each of `topo_expl/models/*.xml`…

### DIFF
--- a/tools/topo_expl/models/topo_16p1h.xml
+++ b/tools/topo_expl/models/topo_16p1h.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,ffffffff,00000000,00000000,00000000,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" vendor="0x1000" device="0xc010" subsystem_vendor="0x1000" subsystem_device="0xa096" link_speed="16.0 GT/s PCIe" link_width="16">

--- a/tools/topo_expl/models/topo_16p1h_vm.xml
+++ b/tools/topo_expl/models/topo_16p1h_vm.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="3436:00:00.0" class="0x038000" vendor="0x1002" device="0x740c" subsystem_vendor="0x1002" subsystem_device="0x0b0c" link_speed="32.0 GT/s PCIe" link_width="16">

--- a/tools/topo_expl/models/topo_3p_pcie.xml
+++ b/tools/topo_expl/models/topo_3p_pcie.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="0000ffff,0000ffff" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="1">
     <pci busid="0000:21:00.0" class="0x060400" vendor="0x1022" device="0x14c7" subsystem_vendor="0x0000" subsystem_device="0x0000" link_speed="16.0 GT/s PCIe" link_width="16">

--- a/tools/topo_expl/models/topo_3p_pcie_1.xml
+++ b/tools/topo_expl/models/topo_3p_pcie_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="0000ffff,0000ffff" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="1">
     <pci busid="0000:21:00.0" class="0x060400" vendor="0x1022" device="0x14c7" subsystem_vendor="0x0000" subsystem_device="0x0000" link_speed="16.0 GT/s PCIe" link_width="16">

--- a/tools/topo_expl/models/topo_4p1h.xml
+++ b/tools/topo_expl/models/topo_4p1h.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="0003ff,f0003fff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
     <pci busid="0000:18:00.0" class="0x060400" link_speed="8 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_4p1h_1.xml
+++ b/tools/topo_expl/models/topo_4p1h_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="0003ff,f0003fff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
     <pci busid="0000:18:00.0" class="0x060400" link_speed="8 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_4p2h.xml
+++ b/tools/topo_expl/models/topo_4p2h.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="0003ff,f0003fff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
     <pci busid="0000:18:00.0" class="0x060400" link_speed="8 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_4p2h_1.xml
+++ b/tools/topo_expl/models/topo_4p2h_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="0003ff,f0003fff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
     <pci busid="0000:18:00.0" class="0x060400" link_speed="8 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_4p2h_2nic.xml
+++ b/tools/topo_expl/models/topo_4p2h_2nic.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="0003ff,f0003fff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
     <pci busid="0000:18:00.0" class="0x060400" link_speed="8 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_4p3l.xml
+++ b/tools/topo_expl/models/topo_4p3l.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="0000ffff,0000ffff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
     <pci busid="0000:18:00.0" class="0x060400" link_speed="8 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_4p3l_2h.xml
+++ b/tools/topo_expl/models/topo_4p3l_2h.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_4p3l_ia.xml
+++ b/tools/topo_expl/models/topo_4p3l_ia.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="0003ff,f0003fff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
     <pci busid="0000:18:00.0" class="0x060400" link_speed="8 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_4p3l_n2.xml
+++ b/tools/topo_expl/models/topo_4p3l_n2.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_4p3l_n2_1.xml
+++ b/tools/topo_expl/models/topo_4p3l_n2_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00ffffff,00000000,00000000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:61:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_4p3l_n4.xml
+++ b/tools/topo_expl/models/topo_4p3l_n4.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="00000000,00000000,00000000,ffff0000" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_4p4h.xml
+++ b/tools/topo_expl/models/topo_4p4h.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="ffffffff,00000000,ffffffff,00000000" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:c1:00.0" class="0x060400" vendor="0x1000" device="0xc010" subsystem_vendor="0x1000" subsystem_device="0xa032" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p1h.xml
+++ b/tools/topo_expl/models/topo_8p1h.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="00000000,0000ffff,ff000000" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="1">
     <pci busid="0000:19:00.0" class="0x060400" vendor="0x1000" device="0xc010" subsystem_vendor="0x1000" subsystem_device="0xa096" link_speed="16.0 GT/s PCIe" link_width="16">

--- a/tools/topo_expl/models/topo_8p1h_1.xml
+++ b/tools/topo_expl/models/topo_8p1h_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="000000ff,ffff0000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="1">
     <pci busid="0000:22:00.0" class="0x060400" vendor="0x1000" device="0xc010" subsystem_vendor="0x1000" subsystem_device="0xa096" link_speed="16.0 GT/s PCIe" link_width="16">

--- a/tools/topo_expl/models/topo_8p1h_2.xml
+++ b/tools/topo_expl/models/topo_8p1h_2.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="3" affinity="ffff0000,00000000,ffff0000,00000000" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="48">
     <pci busid="0000:c1:00.0" class="0x038000" vendor="0x1002" device="0x7408" subsystem_vendor="0x1002" subsystem_device="0x0b0c" link_speed="16.0 GT/s PCIe" link_width="16">

--- a/tools/topo_expl/models/topo_8p1h_3.xml
+++ b/tools/topo_expl/models/topo_8p1h_3.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="3" affinity="ffff0000,00000000,ffff0000,00000000" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="48">
     <pci busid="0000:c1:00.0" class="0x038000" vendor="0x1002" device="0x7408" subsystem_vendor="0x1002" subsystem_device="0x0b0c" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p1h_4.xml
+++ b/tools/topo_expl/models/topo_8p1h_4.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="00000000,00000000,00000000,00000000,00000000,00000000,ffffffff,00000000" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="1">
     <pci busid="0000:22:00.0" class="0x060400" vendor="0x1000" device="0xc010" subsystem_vendor="0x1000" subsystem_device="0xa096" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p1h_5.xml
+++ b/tools/topo_expl/models/topo_8p1h_5.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,ffffffff,ffffffff,00000000,00000000,ffffffff,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="1">
     <pci busid="0000:22:00.0" class="0x060400" vendor="0x1000" device="0xc010" subsystem_vendor="0x1000" subsystem_device="0xa096" link_speed="16.0 GT/s PCIe" link_width="16">

--- a/tools/topo_expl/models/topo_8p1h_n1.xml
+++ b/tools/topo_expl/models/topo_8p1h_n1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,ffffffff,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:19:00.0" class="0x060400" vendor="0x1000" device="0xc010" subsystem_vendor="0x1000" subsystem_device="0xa096" link_speed="16.0 GT/s PCIe" link_width="16">

--- a/tools/topo_expl/models/topo_8p6l.xml
+++ b/tools/topo_expl/models/topo_8p6l.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,00000000,00000000,000000ff,ffff0000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:61:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p6l_1nic.xml
+++ b/tools/topo_expl/models/topo_8p6l_1nic.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,00000000,00000000,000000ff,ffff0000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:61:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p6l_2nic.xml
+++ b/tools/topo_expl/models/topo_8p6l_2nic.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,00000000,00000000,000000ff,ffff0000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:61:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p6l_3nic.xml
+++ b/tools/topo_expl/models/topo_8p6l_3nic.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,00000000,00000000,000000ff,ffff0000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:61:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p6l_4nic.xml
+++ b/tools/topo_expl/models/topo_8p6l_4nic.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,00000000,00000000,000000ff,ffff0000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:61:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p6l_5nic.xml
+++ b/tools/topo_expl/models/topo_8p6l_5nic.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,00000000,00000000,000000ff,ffff0000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:61:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p6l_6nic.xml
+++ b/tools/topo_expl/models/topo_8p6l_6nic.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,00000000,00000000,000000ff,ffff0000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:61:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_4nics.xml
+++ b/tools/topo_expl/models/topo_8p_4nics.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,ffffffff,00000000,00000000,00000000,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:43:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_90a.xml
+++ b/tools/topo_expl/models/topo_8p_90a.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="ffffffff,ffffffff,ffffffff,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="48">
     <pci busid="0000:c1:00.0" class="0x038000" link_speed="16.0 GT/s PCIe" link_width="16">

--- a/tools/topo_expl/models/topo_8p_90a_1.xml
+++ b/tools/topo_expl/models/topo_8p_90a_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="3" affinity="ffff0000,00000000,ffff0000,00000000" arch="x86_64" vendor="AuthenticAMD" familyid="175" modelid="48">
     <pci busid="0000:c1:00.0" class="0x038000" vendor="0x1002" device="0x7408" subsystem_vendor="0x1002" subsystem_device="0x0b0c" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_pcie.xml
+++ b/tools/topo_expl/models/topo_8p_pcie.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00ff00ff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
     <pci busid="0000:18:00.0" class="0x060400" link_speed="8 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_pcie_1.xml
+++ b/tools/topo_expl/models/topo_8p_pcie_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00ff00ff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
     <pci busid="0000:18:00.0" class="0x060400" link_speed="8 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_pcie_2nic.xml
+++ b/tools/topo_expl/models/topo_8p_pcie_2nic.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00ff00ff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
     <pci busid="0000:18:00.0" class="0x060400" link_speed="8 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_rome.xml
+++ b/tools/topo_expl/models/topo_8p_rome.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,ffffffff,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_rome_4n_1.xml
+++ b/tools/topo_expl/models/topo_8p_rome_4n_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="00000000,00000000,00000000,ffff0000" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:43:00.0" class="0x060400" vendor="0x11f8" device="0x4000" subsystem_vendor="0x11f8" subsystem_device="0xbeef" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_rome_4n_2.xml
+++ b/tools/topo_expl/models/topo_8p_rome_4n_2.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="00000000,00000000,00000000,ffff0000,00000000,00000000,00000000,ffff0000" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:43:00.0" class="0x060400" vendor="0x11f8" device="0x4000" subsystem_vendor="0x11f8" subsystem_device="0xbeef" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_rome_4nics.xml
+++ b/tools/topo_expl/models/topo_8p_rome_4nics.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,ffffffff,00000000,00000000,00000000,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:43:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_rome_n2.xml
+++ b/tools/topo_expl/models/topo_8p_rome_n2.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="00000000,00000000,ffffffff,00000000" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:01:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_rome_n2_1.xml
+++ b/tools/topo_expl/models/topo_8p_rome_n2_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_rome_n2_2.xml
+++ b/tools/topo_expl/models/topo_8p_rome_n2_2.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 
 <system version="2">
   <cpu numaid="1" affinity="00000000,00000000,ffffffff,00000000" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">

--- a/tools/topo_expl/models/topo_8p_rome_n4.xml
+++ b/tools/topo_expl/models/topo_8p_rome_n4.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="00000000,00000000,00000000,ffff0000" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_rome_n4_1.xml
+++ b/tools/topo_expl/models/topo_8p_rome_n4_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="00000000,00000000,00000000,ffff0000" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_rome_pcie.xml
+++ b/tools/topo_expl/models/topo_8p_rome_pcie.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,ffffffff,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_rome_vm1.xml
+++ b/tools/topo_expl/models/topo_8p_rome_vm1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="000000,00000000,00000000,3fffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0001:00:00.0" class="0x038000" vendor="0x1002" device="0x738c" subsystem_vendor="0x1002" subsystem_device="0x0c34" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_ts1.xml
+++ b/tools/topo_expl/models/topo_8p_ts1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_ts1_1.xml
+++ b/tools/topo_expl/models/topo_8p_ts1_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_ts1_n4.xml
+++ b/tools/topo_expl/models/topo_8p_ts1_n4.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="00000000,00000000,00000000,ffff0000" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_ts1_n4_1.xml
+++ b/tools/topo_expl/models/topo_8p_ts1_n4_1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="00000000,00000000,00000000,ffff0000" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_8p_ts1_n4_2.xml
+++ b/tools/topo_expl/models/topo_8p_ts1_n4_2.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="1" affinity="00000000,00000000,00000000,ffff0000" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:41:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_collnet_n1.xml
+++ b/tools/topo_expl/models/topo_collnet_n1.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00ffffff,00000000,00000000,00ffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:61:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">

--- a/tools/topo_expl/models/topo_collnet_n4.xml
+++ b/tools/topo_expl/models/topo_collnet_n4.xml
@@ -1,7 +1,7 @@
-<!-------------------------------------------------------------------------
+<!--
  - Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
  - See LICENSE.txt for license information
- ------------------------------------------------------------------------->
+ -->
 <system version="2">
   <cpu numaid="0" affinity="00000000,00000000,00000000,ffffffff,00000000,00000000,00000000,ffffffff" arch="x86_64" vendor="AuthenticAMD" familyid="143" modelid="49">
     <pci busid="0000:43:00.0" class="0x060400" link_speed="16 GT/s" link_width="16">


### PR DESCRIPTION
…. The format was not valid XML.

This is a non-functional change that requires no testing.