### PR TITLE
Update Depends with correct HIP Runtime package name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -718,7 +718,7 @@ if(BUILD_ADDRESS_SANITIZER)
 else()
   set(DEPENDS_HIP_RUNTIME "hip-runtime-amd" )
 endif()
-rocm_package_add_dependencies(DEPENDS "${DEPENDS_HIP_RUNTIME} >= 3.5.0" "rocm-smi-lib >= 4.0.0")
+rocm_package_add_dependencies(DEPENDS "${DEPENDS_HIP_RUNTIME} >= 4.5.0" "rocm-smi-lib >= 4.0.0")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/opt" "${ROCM_PATH}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -713,7 +713,12 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
 endif()
 
 ## Set package dependencies
-rocm_package_add_dependencies(DEPENDS "hip-rocclr >= 3.5.0" "rocm-smi-lib >= 4.0.0")
+if(BUILD_ADDRESS_SANITIZER)
+  set(DEPENDS_HIP_RUNTIME "hip-runtime-amd-asan" )
+else()
+  set(DEPENDS_HIP_RUNTIME "hip-runtime-amd" )
+endif()
+rocm_package_add_dependencies(DEPENDS "${DEPENDS_HIP_RUNTIME} >= 3.5.0" "rocm-smi-lib >= 4.0.0")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/opt" "${ROCM_PATH}")
 


### PR DESCRIPTION
Proposed Changes:

- hip-rocclr package is deprecated
- This is replaced with latest package hip-runtime-amd.
- This change is to update the package depends of RCCL to the latest package name.