### PR TITLE
Updated CHANGELOG to release for ROCm 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,10 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 ## RCCL 2.18.6 for ROCm 6.1.0
 ### Changed
 - Compatibility with NCCL 2.18.6
-### Added
-### Fixed
-### Removed
 
 ## RCCL 2.18.3 for ROCm 6.0.0
 ### Changed
 - Compatibility with NCCL 2.18.3
-### Added
-### Fixed
-### Removed
 
 ## RCCL 2.17.1-1 for ROCm 5.7.0
 ### Changed
@@ -31,10 +25,8 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 ## RCCL 2.16.2 for ROCm 5.6.0
 ### Changed
 - Compatibility with NCCL 2.16.2
-### Added
 ### Fixed
 - Remove workaround and use indirect function call
-### Removed
 
 ## RCCL 2.15.5 for ROCm 5.5.0
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,33 @@
 
 Full documentation for RCCL is available at [https://rccl.readthedocs.io](https://rccl.readthedocs.io)
 
-## Unreleased
+## Unreleased - RCCL 2.18.6 for ROCm 6.1.0
+### Changed
+- Compatibility with NCCL 2.18.6
+### Added
+### Fixed
+### Removed
+
+## RCCL 2.18.3 for ROCm 6.0.0
+### Changed
+- Compatibility with NCCL 2.18.3
+### Added
+### Fixed
+### Removed
+
+## RCCL 2.17.1-1 for ROCm 5.7.0
+### Changed
+- Compatibility with NCCL 2.17.1-1
+- Performance tuning for some collective operations
+### Added
+- Minor improvements to MSCCL codepath
+- NCCL_NCHANNELS_PER_PEER support
+- Improved compilation performance
+- Support for gfx94x
+### Fixed
+- Potential race-condition during ncclSocketClose()
+
+## RCCL 2.16.2 for ROCm 5.6.0
 ### Changed
 - Compatibility with NCCL 2.16.2
 ### Added
@@ -10,7 +36,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 - Remove workaround and use indirect function call
 ### Removed
 
-## Unreleased - RCCL 2.15.5 for ROCm 5.5.0
+## RCCL 2.15.5 for ROCm 5.5.0
 ### Changed
 - Compatibility with NCCL 2.15.5
 - Unit test executable renamed to rccl-UnitTests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for RCCL is available at [https://rccl.readthedocs.io](https://rccl.readthedocs.io)
 
-## Unreleased - RCCL 2.18.6 for ROCm 6.1.0
+## RCCL 2.18.6 for ROCm 6.1.0
 ### Changed
 - Compatibility with NCCL 2.18.6
 ### Added


### PR DESCRIPTION
This also imports the fixes to the CHANGELOG for previous versions that were not properly updated.