### PR TITLE
[BUILD] Add unique files to source list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,25 +415,6 @@ set(SRC_FILES
   src/include/nvtx3/nvtxExtDetail/nvtxExtInit.h
   src/include/nvtx3/nvtxExtDetail/nvtxExtPayloadTypeInfo.h
   src/include/nvtx3/nvtxExtDetail/nvtxExtTypes.h
-  src/include/nvtx.h
-  src/include/nvtx_stub.h
-  src/include/p2p.h
-  src/include/param.h
-  src/include/profiler.h
-  src/include/proxy.h
-  src/include/rccl_vars.h
-  src/include/rocm_smi_wrap.h
-  src/include/rocmwrap.h
-  src/include/shm.h
-  src/include/signals.h
-  src/include/socket.h
-  src/include/strongstream.h
-  src/include/timer.h
-  src/include/transport.h
-  src/include/trees.h
-  src/include/utils.h
-  src/init.cc
-  src/init_nvtx.cc
   src/misc/archinfo.cc
   src/misc/argcheck.cc
 # src/misc/cudawrap.cc
@@ -491,6 +472,9 @@ foreach(SRC_FILE ${SRC_FILES})
   # Establish hipified copy of the source file
   set(HIP_FILE "${HIPIFY_DIR}/${SRC_FILE}")
   get_filename_component(HIP_FILE_DIR ${HIP_FILE} DIRECTORY)
+
+  # Make sure the file name is unique and there is no duplicate
+  add_file_unique(HIP_SOURCES ${HIP_FILE})
 
   # Convert .cu files to .cpp so that they get processed properly
   string(REPLACE "\.cu" "\.cu.cpp" HIP_FILE ${HIP_FILE})

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -133,6 +133,27 @@ function(rocm_local_targets VARIABLE)
   endif()
 endfunction()
 
+# Iterate over the "source" list and check if there is a duplicate file name
+# NOTE: This is due to compiler bug '--save-temps' and can be removed when fix availabe
+function(add_file_unique FILE_LIST FILE)
+  get_filename_component(FILE_NAME "${FILE}" NAME)
+
+  # Iterate over whatever is in the list so far
+  foreach(curr_file IN LISTS ${FILE_LIST})
+    get_filename_component(curr_file_name ${curr_file} NAME)
+
+    # Check if duplicate
+    if(${FILE_NAME} STREQUAL ${curr_file_name})
+      get_filename_component(DIR_PATH "${FILE}" DIRECTORY)
+      get_filename_component(FILE_NAME_WE "${FILE}" NAME_WE)
+      get_filename_component(FILE_EXT "${FILE}" EXT)
+
+      # Construct a new file name by adding _tmp
+      set(HIP_FILE "${DIR_PATH}/${FILE_NAME_WE}_tmp${FILE_EXT}" PARENT_SCOPE)
+    endif()
+  endforeach()
+endfunction()
+
 include(ROCMSetupVersion)
 include(ROCMCreatePackage)
 include(ROCMInstallTargets)


### PR DESCRIPTION
When building RCCL with flag '--save-temps', duplicate symbol errors are observed during linking. This is due to /src/net.cc and /src/transport/net.cc share the same file name. Despite the fact that this shouldn't matter since the full paths are different,  this is a compiler bug and fix can take some time.

Note: Deleted files in the source list were duplicates that were found during testing.