### PR TITLE
Updated CHANGELOG for next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,52 +2,20 @@
 
 Full documentation for RCCL is available at [https://rccl.readthedocs.io](https://rccl.readthedocs.io)
 
-## Unreleased - RCCL 2.18.6 for ROCm 6.1.0
-### Changed
-- Compatibility with NCCL 2.18.6
-### Added
-### Fixed
-### Removed
-
-## RCCL 2.18.3 for ROCm 6.0.0
-### Changed
-- Compatibility with NCCL 2.18.3
-### Added
-### Fixed
-### Removed
-
-## RCCL 2.17.1-1 for ROCm 5.7.0
-### Changed
-- Compatibility with NCCL 2.17.1-1
-- Performance tuning for some collective operations
-### Added
-- Minor improvements to MSCCL codepath
-- NCCL_NCHANNELS_PER_PEER support
-- Improved compilation performance
-- Support for gfx94x
-### Fixed
-- Potential race-condition during ncclSocketClose()
-
-## RCCL 2.16.2 for ROCm 5.6.0
+## Unreleased
 ### Changed
 - Modifying rings to be rail-optimized topology friendly
 ### Added
 ### Fixed
 ### Removed
 
-## Unreleased - RCCL 2.18.6 for ROCm 6.1.0
+## RCCL 2.18.6 for ROCm 6.1.0
 ### Changed
 - Compatibility with NCCL 2.18.6
-### Added
-### Fixed
-### Removed
 
 ## RCCL 2.18.3 for ROCm 6.0.0
 ### Changed
 - Compatibility with NCCL 2.18.3
-### Added
-### Fixed
-### Removed
 
 ## RCCL 2.17.1-1 for ROCm 5.7.0
 ### Changed
@@ -64,10 +32,8 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 ## RCCL 2.16.2 for ROCm 5.6.0
 ### Changed
 - Compatibility with NCCL 2.16.2
-### Added
 ### Fixed
 - Remove workaround and use indirect function call
-### Removed
 
 ## RCCL 2.15.5 for ROCm 5.5.0
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 ### Fixed
 ### Removed
 
-## RCCL 2.18.6 for ROCm 6.1.0
+## Unreleased - RCCL 2.18.6 for ROCm 6.1.0
 ### Changed
 - Compatibility with NCCL 2.18.6
 


### PR DESCRIPTION
Cherry-picked the updated CHANGELOG from `release/rocm-rel-6.1` branch.
Also, fixed the bad update from a recent PR merge.