### PR TITLE
[GRAPH] Reduce NCCL_TOPO_MAX_NODES to 64

### DIFF
--- a/src/include/graph.h
+++ b/src/include/graph.h
@@ -66,7 +66,7 @@ ncclResult_t ncclTopoGetLocalNet(struct ncclTopoSystem* system, int rank, int ch
 ncclResult_t ncclTopoGetLocalGpu(struct ncclTopoSystem* system, int net, int* gpuIndex);
 ncclResult_t getLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int *count);
 
-#define NCCL_TOPO_MAX_NODES 256
+#define NCCL_TOPO_MAX_NODES 64
 
 // Init search. Needs to be done before calling ncclTopoCompute
 ncclResult_t ncclTopoSearchInit(struct ncclTopoSystem* system);


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:**
Internal

**What were the changes?**  
Reduce NCCL_TOPO_MAX_NODES from 256 to 64

**Why were the changes made?**  
Reduce stack usage and potential overflow.
Before PR (i.e. NCCL_TOPO_MAX_NODES=256) => `sizeof ncclTopoSystem: 1333360, sizeof ncclTopoGraph: 459324`
After PR (i.e. NCCL_TOPO_MAX_NODES=64) => `sizeof ncclTopoSystem: 333424, sizeof ncclTopoGraph: 66108`

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
