### PR TITLE
Prevent segfault from npkit-enabled rccl build

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -1208,6 +1208,13 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       ret = ncclInternalError;
       goto fail;
     }
+    #if defined(ENABLE_NPKIT)
+    if (intraProcRanks != 1) {
+      WARN("NPKit currently does not support more than 1 device per process");
+      ret = ncclInternalError;
+      goto fail;
+    }
+    #endif
     struct ncclComm* comm0 = comm->peerInfo[intraProcRank0].comm;
     assert(intraProcRank==0 ? comm==comm0 : true);
     comm->intraComm0 = comm0;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** Internal

**What were the changes?**  
Added abort during RCCL init if NPKit enabled and more than 1 device per process

**Why were the changes made?**  
NPKit (src/misc/npkit.cc) currently don't support more than 1 GPU per process, certain memory address (`NpKit::gpu_collect_contexts_`) is global and not thread safe. If RCCL is compiled with --npkit-enable, multiple device under 1 process will each call `NpKit::Init()` and results in segmentation fault.

**How was the outcome achieved?**  
By adding an abort we prevent this.



## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
