### PR TITLE
Fix build error when roctracer-dev package is not installed

### DIFF
--- a/src/include/roctx.h
+++ b/src/include/roctx.h
@@ -11,7 +11,9 @@
 #include <string.h>
 #include <map>
 
+#ifndef ROCTX_NO_IMPL
 #include <roctracer/roctx.h>
+#endif
 #include "nvtx3/nvtx3.hpp"
 #include "device.h"
 


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Fix build error when roctracer-dev package is not installed

**Why were the changes made?**  
User reported build error on ROCm 5.7.1 when missing roctx header file

**How was the outcome achieved?**  
Remove dependency to roctx header file when feature is not enabled

**Additional Documentation:**  

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
