### PR TITLE
Avoid potential out-of-bound reads

### DIFF
--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -848,11 +848,16 @@ ncclResult_t getLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int *c
 ncclResult_t ncclTopoGetLocalNet(struct ncclTopoSystem* system, int rank, int channelId, int* id) {
   int gpu;
   NCCLCHECK(ncclTopoRankToIndex(system, rank, &gpu));
-  int* localNets;
+  int* localNets = NULL;
   int localNetCount;
   NCCLCHECK(ncclTopoGetLocal(system, GPU, gpu, NET, &localNets, &localNetCount, NULL));
-  int* localGpus;
+  int* localGpus = NULL;
   int localGpuCount;
+  if (localNetCount == 0) {
+    *id = -1;
+    free(localNets);
+    return ncclSuccess;
+  }
   NCCLCHECK(ncclTopoGetLocal(system, NET, localNets[0], GPU, &localGpus, &localGpuCount, NULL));
   int net = 0;
   for (int i = 0; i < localGpuCount; i++) {

--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -668,14 +668,16 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
     CUDACHECK(hipGetDeviceProperties(&devProp, 0));
     //extract only the releveant info from the gcnArchName attribute
     //e.g.: convert "gfx908:sramecc+:xnack-" to "gfx908"
-    char gcnArchNameSubstr[6];
+    char gcnArchNameSubstr[128];
     GcnArchNameFormat(devProp.gcnArchName, gcnArchNameSubstr);
     gcn = gcnArchNameSubstr;
     NCCLCHECK(xmlSetAttr(gpuNode, "gcn", gcn));
   }
   NCCLCHECK(xmlGetAttr(gpuNode, "gcn", &gcn));
   convertGcnArchToGcnArchName(gcn, &gcnArchName);
-  NCCLCHECK(xmlSetAttr(gpuNode, "gcn", gcnArchName));
+  if (gcn != gcnArchName) {
+     NCCLCHECK(xmlSetAttr(gpuNode, "gcn", gcnArchName));
+  }
 
   rcclHipDeviceArch_t arch;
   NCCLCHECK(xmlGetAttrIndex(gpuNode, "arch", &index));


### PR DESCRIPTION
Do not mention proprietary info or link to internal work items in this PR.

Work item: "Internal", or link to GitHub issue (if applicable).

What were the changes?
Avoid potential out-of-bound reads that is cached by ASAN

Why were the changes made?
In-place rccl crashed when gcnArchName has a long name.

How was the outcome achieved?
It fixed the crashes.

Additional Documentation:


Approval Checklist
Do not approve until these items are satisfied.

 Verify the CHANGELOG has been updated, if
there are any NCCL API version changes,
any changes impact library users, and/or
any changes impact any other ROCm library.

