### PR TITLE
Use normal permute path when one NIC per GPU

### DIFF
--- a/src/graph/rome_models.cc
+++ b/src/graph/rome_models.cc
@@ -1379,7 +1379,7 @@ ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* 
     // permute GPU IDs
     for (int j = 0; j < ngpus; j++) g[j] = (j+2)%ngpus;
     if (!permuteGpuIds(g, 0, ngpus-1, romeTopoModels+i, &romeTopo, &time, ignore_cpu ? false : match_nbio, ignore_numa)) continue;
-    if (nnetspergpu) {
+    if (nnetspergpu > 1) {
       int found = 0;
       // initialize nics mapping
       for (int j = 0; j < nnets; j++) n[j] = -1;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Use normal permute path when one NIC per GPU

**Why were the changes made?**  
Workaround issue with multiple NICs per GPU path

**How was the outcome achieved?**  
Use permute function

**Additional Documentation:**  


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
