### PR TITLE
modifying the tuning table to improve the performance of broadcast

### DIFF
--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -379,6 +379,7 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
           busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[0][a][p];
         else
           busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[1][a][p];
+        if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL && coll == ncclFuncBroadcast && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx94") && comm->topo->nodes[GPU].count == comm->topo->nRanks) { busBw = busBw * 2.33; }
 #else
         if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL) { busBw = std::min(llMaxBw, busBw * ((nNodes > 1 || coll == ncclFuncAllReduce || coll == ncclFuncReduce) ? 1.0/4.0 : 1.0/3.0)); }
         if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL128) busBw = std::min(busBw * (ppn < 2 ? 0.7 : 0.92 /*120.0/128.0*/), graphs[a]->nChannels*perChMaxRingLL128Bw);


### PR DESCRIPTION
modifying the tuning table to improve the performance of broadcast for 1MB to 64MB for single-node MI300X

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
SWDEV-460243
**What were the changes?**  
_One sentence describing the work done._
for 1MB to 64MB RingLL performs better than RingSimple. So, the tuning table was modified to choose RingLL for this message range for single-node MI300
**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._
To improve the broadcast performance for MI300
**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._
by modifying the tuning table parameters in favor of RingLL
**Additional Documentation:**  
_What else should the reviewer know?_
The data demonstrating the improvement in performance is provided in the ticket
## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
