### PR TITLE
Adding ROCm Debug Agent support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(BUILD_LOCAL_GPU_TARGET_ONLY             "Build only for GPUs detected on 
 option(BUILD_SHARED_LIBS                       "Build as shared library"                       ON)
 option(BUILD_TESTS                             "Build unit test programs"                      OFF)
 option(COLLTRACE                               "Collective Trace Option"                       ON)
+option(DEBUG_AGENT                             "Build with ROCm Debug Agent support"           OFF)
 option(ENABLE_MSCCL_KERNEL                     "Enable MSCCL while compiling"                  ON)
 option(ENABLE_IFC                              "Enable indirect function call"                 OFF)
 option(INSTALL_DEPENDENCIES                    "Force install dependencies"                    OFF)
@@ -467,7 +468,7 @@ if (ENABLE_MSCCL_KERNEL)
   )
   list(APPEND SRC_FILES ${MSCCL_KERNEL_SOURCES})
 endif()
-  
+
 # Hipify source files (copy of source generated into hipify directory)
 #==================================================================================================
 find_program(hipify-perl_executable hipify-perl)
@@ -604,8 +605,8 @@ if(DEMANGLE_DIR)
 endif()
 if(${hipcc_version_string} VERSION_GREATER_EQUAL "6.1.33591")
   set(LL128_ENABLED ON)
-	target_compile_definitions(rccl PRIVATE ENABLE_LL128)
-	message(STATUS "RCCL LL128 protocol enabled")
+  target_compile_definitions(rccl PRIVATE ENABLE_LL128)
+  message(STATUS "RCCL LL128 protocol enabled")
 endif()
 
 ## Set RCCL compile options
@@ -628,6 +629,9 @@ if(BUILD_ADDRESS_SANITIZER)
 endif()
 if(TIMETRACE)
   target_compile_options(rccl PRIVATE -ftime-trace)
+endif()
+if(DEBUG_AGENT)
+  target_compile_options(rccl PRIVATE -O0 -ggdb)
 endif()
 
 ## Set RCCL linked library directories

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,7 @@ build_tests=false
 build_verbose=0
 clean_build=true
 collective_trace=true
+debug_agent=false
 enable_ninja=""
 install_dependencies=false
 install_library=false
@@ -40,6 +41,7 @@ function display_help()
     echo "       --address-sanitizer     Build with address sanitizer enabled"
     echo "    -d|--dependencies          Install RCCL depdencencies"
     echo "       --debug                 Build debug library"
+    echo "       --debug-agent           Build with ROCm Debug Agent support"
     echo "       --enable_backtrace      Build with custom backtrace support"
     echo "       --disable-colltrace     Build without collective trace"
     echo "       --disable-msccl-kernel  Build without MSCCL kernels"
@@ -70,7 +72,7 @@ function display_help()
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --options dfhij:lprt --longoptions address-sanitizer,dependencies,debug,enable_backtrace,disable-colltrace,disable-msccl-kernel,fast,help,install,jobs:,local_gpu_only,amdgpu_targets:,no_clean,npkit-enable,roctx-enable,package_build,prefix:,rm-legacy-include-dir,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --options dfhij:lprt --longoptions address-sanitizer,dependencies,debug,debug-agent,enable_backtrace,disable-colltrace,disable-msccl-kernel,fast,help,install,jobs:,local_gpu_only,amdgpu_targets:,no_clean,npkit-enable,roctx-enable,package_build,prefix:,rm-legacy-include-dir,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -88,6 +90,7 @@ while true; do
          --address-sanitizer)        build_address_sanitizer=true;                                                                     shift ;;
     -d | --dependencies)             install_dependencies=true;                                                                        shift ;;
          --debug)                    build_release=false;                                                                              shift ;;
+         --debug-agent)              debug_agent=true;                                                                                 shift ;;
          --enable_backtrace)         build_bfd=true;                                                                                   shift ;;
          --disable-colltrace)        collective_trace=false;                                                                           shift ;;
          --disable-msccl-kernel)     msccl_kernel_enabled=false;                                                                       shift ;;
@@ -214,6 +217,12 @@ if [[ "${collective_trace}" == false ]]; then
     cmake_common_options="${cmake_common_options} -DCOLLTRACE=OFF"
 fi
 
+# Enable ROCm Debug agent
+if [[ "${debug_agent}" == true ]]; then
+    cmake_common_options="${cmake_common_options} -DDEBUG_AGENT=ON"
+fi
+
+# Disable MSCCL kernel
 if [[ "${msccl_kernel_enabled}" == false ]]; then
     cmake_common_options="${cmake_common_options} -DENABLE_MSCCL_KERNEL=OFF"
 fi


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Adding CMakefile / install.sh support for enabling [ROCm Debug Agent support](https://github.com/ROCm/rocr_debug_agent)

**Why were the changes made?**  
Make it easier to compile with the flags to support ROCm Debug Agent

**How was the outcome achieved?**  
Modified the CMakefile  and install script to take in a new "--debug-agent" argument

**Additional Documentation:**  
Tested with ./install.sh --debug-agent and confirmed that "-O0 -ggdb" was being added to compilation flags

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
