### PR TITLE
[GRAPH] Disable MSCCL override of no. of channels

### DIFF
--- a/src/graph/connect.cc
+++ b/src/graph/connect.cc
@@ -700,7 +700,7 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   }
 
   if (mscclEnabled() && (comm->topo->mscclEnabled || mscclForceEnabled())) {
-    int mscclNumChannelsRequired = 0;
+    int mscclNumChannelsRequired = maxNchannels;
     mscclSchedulerInit(comm, &mscclNumChannelsRequired);
     minNchannels = std::max(minNchannels, mscclNumChannelsRequired);
   }


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Disable MSCCL algorithm(s) if the number of channels required for that algorithm exceeds `NCCL_MAX_NCHANNELS`.

**Why were the changes made?**  
MSCCL algorithms have different channel requirements (specified in their XML files).\
Before this PR, if `NCCL_MAX_NCHANNELS` is set to less than the channels requirement of any MSCCL algorithm in the `msccl-algorithms` directory, MSCCL would override this limit and set minNchannels to the maximum number of channels required for any of the MSCCL algorithms.

**How was the outcome achieved?**  
Check if the number of channels required for each MSCCL algorithm exceeds the `NCCL_MAX_NCHANNELS` limit.\
If yes, skip that MSCCL algorithm and fall back to RCCL.

**Additional Documentation:**  
This can be verified using `NCCL_DEBUG=INFO`.\
With this PR, `NCCL WARN` messages are printed about the specifics (algorithm name, minBytes/maxBytes limits, and the file name) of the MSCCL algorithm(s) being turned off.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
