### PR TITLE
[MSCCL]: Move scratch buffer debug messages to NCCL_DEBUG=TRACE

### DIFF
--- a/src/misc/msccl/msccl_setup.cc
+++ b/src/misc/msccl/msccl_setup.cc
@@ -458,7 +458,7 @@ ncclResult_t mscclSetupKernel(const void* sendBuff, void* recvBuff, size_t count
       NCCLCHECK(ncclCudaMalloc((char**)&scratchBuffer, sizeRounded, hipDeviceMallocFinegrained));
 #endif
       work.scratchBuffer = status.scratchBuffers[sizeRounded] = scratchBuffer;
-      INFO(NCCL_INIT, "MSCCL: Allocated scratch buffer of size %lu on request (%lu)", sizeRounded, sizeNeeded);
+      TRACE(NCCL_INIT, "MSCCL: Allocated scratch buffer of size %lu on request (%lu)", sizeRounded, sizeNeeded);
     } else {
       work.scratchBuffer = itr->second;
     }


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:**
Internal

**What were the changes?**  
Moving MSCCL scratch buffer allocation messages from `NCCL_DEBUG=INFO` to `NCCL_DEBUG=TRACE`

**Why were the changes made?**  
Reduce MSCCL-related messages when using `NCCL_DEBUG=INFO`


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
