### PR TITLE
[BUILD] Update install.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,16 @@
 # Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 # Modifications Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 
+# CMake version minimum requirements
+#==================================================================================================
 cmake_minimum_required(VERSION 3.5)
+
+# CMake Toolchain file to define compilers and path to ROCm
+#==================================================================================================
+if (NOT CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/toolchain-linux.cmake")
+  message(STATUS "CMAKE_TOOLCHAIN_FILE: ${CMAKE_TOOLCHAIN_FILE}")
+endif()
 
 # RCCL project
 #==================================================================================================

--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ The collective operations are implemented using ring and tree algorithms and hav
 RCCL directly depends on HIP runtime plus the HIP-Clang compiler, which are part of the ROCm software stack.
 For ROCm installation instructions, see https://github.com/ROCm/ROCm.
 
-The root of this repository has a helper script 'install.sh' to build and install RCCL on Ubuntu with a single command.  It does not take a lot of options and hard-codes configuration that can be specified through invoking cmake directly, but it's a great way to get started quickly and can serve as an example of how to build/install.
+The root of this repository has a helper script `install.sh` to build and install RCCL with a single command. It hard-codes configurations that can be specified through invoking cmake directly, but it's a great way to get started quickly and can serve as an example of how to build/install RCCL.
+
+### To build the library using the install script:
 
 ```shell
-./install.sh --help
+./install.sh
+```
 
+For more info on build options/flags when using the install script, use `./install.sh --help`
+```shell
+./install.sh --help
+RCCL build & installation helper script
  Options:
        --address-sanitizer     Build with address sanitizer enabled
     -d|--dependencies          Install RCCL depdencencies
@@ -33,37 +40,38 @@ The root of this repository has a helper script 'install.sh' to build and instal
     -f|--fast                  Quick-build RCCL (local gpu arch only, no backtrace, and collective trace support)
     -h|--help                  Prints this help message
     -i|--install               Install RCCL library (see --prefix argument below)
-    -j|--jobs                  Specify how many parallel compilation jobs to run (nproc by default)
+    -j|--jobs                  Specify how many parallel compilation jobs to run ($nproc by default)
     -l|--local_gpu_only        Only compile for local GPU architecture
+       --amdgpu_targets        Only compile for specified GPU architecture(s). For multiple targets, seperate by ';' (builds for all supported GPU architectures by default)
        --no_clean              Don't delete files if they already exist
        --npkit-enable          Compile with npkit enabled
        --roctx-enable          Compile with roctx enabled (example usage: rocprof --roctx-trace ./rccl-program)
     -p|--package_build         Build RCCL package
-       --prefix                Specify custom directory to install RCCL to (default: /opt/rocm)
+       --prefix                Specify custom directory to install RCCL to (default: `/opt/rocm`)
        --rm-legacy-include-dir Remove legacy include dir Packaging added for file/folder reorg backward compatibility
        --run_tests_all         Run all rccl unit tests (must be built already)
     -r|--run_tests_quick       Run small subset of rccl unit tests (must be built already)
        --static                Build RCCL as a static library instead of shared library
     -t|--tests_build           Build rccl unit tests, but do not run
-       --time-trace            Plot the build time of RCCL
+       --time-trace            Plot the build time of RCCL (requires `ninja-build` package installed on the system)
        --verbose               Show compile commands
 ```
 
 ## Manual build
 
-### To build the library :
+### To build the library using CMake:
 
 ```shell
 $ git clone https://github.com/ROCm/rccl.git
 $ cd rccl
 $ mkdir build
 $ cd build
-$ CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_PREFIX_PATH=/opt/rocm/ ..
+$ cmake ..
 $ make -j 16      # Or some other suitable number of parallel jobs
 ```
-You may substitute an installation path of your own choosing by passing CMAKE_INSTALL_PREFIX. For example:
+You may substitute an installation path of your own choosing by passing `CMAKE_INSTALL_PREFIX`. For example:
 ```shell
-$ CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_PREFIX_PATH=/opt/rocm/ -DCMAKE_INSTALL_PREFIX=$PWD/rccl-install ..
+$ cmake -DCMAKE_INSTALL_PREFIX=$PWD/rccl-install ..
 ```
 Note: ensure rocm-cmake is installed, `apt install rocm-cmake`.
 
@@ -123,11 +131,9 @@ Please refer to the [RCCL Documentation Site](https://rocm.docs.amd.com/projects
 
 Run the steps below to build documentation locally.
 
-```
+```shell
 cd docs
-
 pip3 install -r sphinx/requirements.txt
-
 python3 -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html
 ```
 

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -1,0 +1,19 @@
+
+if (DEFINED ENV{ROCM_PATH})
+  set(rocm_bin "$ENV{ROCM_PATH}/bin")
+else()
+  set(ROCM_PATH "/opt/rocm" CACHE PATH "Path to the ROCm installation.")
+  set(rocm_bin "/opt/rocm/bin")
+endif()
+
+if (NOT DEFINED ENV{CXX})
+  set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc" CACHE PATH "Path to the C++ compiler")
+else()
+  set(CMAKE_CXX_COMPILER "$ENV{CXX}" CACHE PATH "Path to the C++ compiler")
+endif()
+
+if (NOT DEFINED ENV{CC})
+  set(CMAKE_C_COMPILER "${rocm_bin}/hipcc" CACHE PATH "Path to the C compiler")
+else()
+  set(CMAKE_C_COMPILER "$ENV{CC}" CACHE PATH "Path to the C compiler")
+endif()


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Update `install.sh` script for RCCL build using CMake toolchain. Also, some minor changes to fix default `make` behavior.

**Why were the changes made?**  
- Add `toolchain-linux.cmake` to pre-define ROCM_PATH, CXX, and C compiler paths
- Use `toolchain-linux.cmake` in `CMakeLists.txt` for cmake builds and in `install.sh`
- Fix `--prefix` option in `install.sh`
- Fix the use of `VERBOSE` for `make` in `install.sh`
- Update path for `time-trace` in `install.sh`
- Bash-isms in `install.sh`
- Update `README.md`

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
