### PR TITLE
Addressing possible out-of-bounds mem access during channel duplication

### DIFF
--- a/src/graph/connect.cc
+++ b/src/graph/connect.cc
@@ -86,7 +86,7 @@ ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph** graphs
       topoRanks->nvlsHeads[topoRanks->nvlsHeadNum++] = nvlsIntra[0];
     }
   }
-  
+
   return ncclSuccess;
 }
 
@@ -637,8 +637,13 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   for (int c=0; c<nChannels; c++) {
     struct ncclChannel* channel0 = comm->channels+c;
     struct ncclChannel* channel1 = channel0+nChannels;
-    channel0->ring.prev = channel1->ring.prev = ringPrev[c*nranks+comm->rank];
-    channel0->ring.next = channel1->ring.next = ringNext[c*nranks+comm->rank];
+    channel0->ring.prev = ringPrev[c*nranks+comm->rank];
+    channel0->ring.next = ringNext[c*nranks+comm->rank];
+
+    if (c + nChannels < MAXCHANNELS) {
+      channel1->ring.prev = channel0->ring.prev;
+      channel1->ring.next = channel0->ring.next;
+    }
   }
 
   // Duplication should be complete now


### PR DESCRIPTION
## Details
Fixing potential out-of-bounds memory access issue during channel duplication

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Only duplicate if channel is within bounds

**Why were the changes made?**  
Avoid out-of-bound memory accesses if the number of channels is large (e.g. if NCCL_RINGS contains > 32 channels)

**How was the outcome achieved?**  
Only duplicate if channel is within bounds

**Additional Documentation:**  


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
