### PR TITLE
Use non-temporal store for access less than 16 bytes

### DIFF
--- a/src/device/op128.h
+++ b/src/device/op128.h
@@ -200,7 +200,7 @@ template<> __device__ __forceinline__ void st_global<0>(uintptr_t addr, BytePack
   template<> \
   __device__ __forceinline__ void st_##space<bytes>(addr_cxx_ty addr, BytePack<bytes> value) { \
     data_cxx_ty tmp = value.native; \
-    *((data_cxx_ty *)addr) = tmp; \
+    __builtin_nontemporal_store(tmp, (data_cxx_ty *)addr); \
   }
 
 // #if __CUDA_ARCH__ >= 700


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Use non-temporal store for access less than 16 bytes

**Why were the changes made?**  
Make sure all RCCL memory access are non-temporal

**How was the outcome achieved?**  
Use non-temporal store for access less than 16 bytes

**Additional Documentation:**  

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
