### PR TITLE
Allow multiple parameters during selective function generation

### DIFF
--- a/cmake/Generator.cmake
+++ b/cmake/Generator.cmake
@@ -64,6 +64,7 @@ set(FLOATS_LIST "half" "float" "double" "hip_bfloat16" "rccl_float8" "rccl_bfloa
 # make ONLY_FUNCS="AllReduce RING SIMPLE * *|ReduceScatter RING LL * float"
 #                         --- or ---
 # make ONLY_FUNCS="AllReduce RING SIMPLE|ReduceScatter RING LL * float"
+# make ONLY_FUNCS="AllReduce RING/TREE LL/SIMPLE Sum/MinMax int8_t/uint8_t/half/float/double/hip_bfloat16/rccl_float8/rccl_bfloat8|AllGather RING LL/SIMPLE Sum int8_t|AllToAllPivot RING SIMPLE Sum int8_t|Broadcast RING LL/SIMPLE Sum int8_t|Reduce RING LL/SIMPLE Sum/MinMax int8_t/uint8_t/half/float/double/hip_bfloat16/rccl_float8/rccl_bfloat8|ReduceScatter RING LL/SIMPLE Sum/MinMax int8_t/uint8_t/half/float/double/hip_bfloat16/rccl_float8/rccl_bfloat8|SendRecv RING SIMPLE Sum int8_t"
 
 set(AllGather_Params     "RING" "*"      "Sum" "int8_t")
 set(AllReduce_Params     "*"    "*"      "*"   "*")

--- a/cmake/Generator.cmake
+++ b/cmake/Generator.cmake
@@ -417,7 +417,6 @@ function(gen_functions CONFIG_INPUT)
   list(SORT INPUT_LIST)
 
   foreach(INPUT ${INPUT_LIST})
-    message(${INPUT})
     # Parse the the config string and make it a list
     string(REPLACE " " ";" FUNCTION_PARAMS ${INPUT})
 


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Allow multiple parameters during selective function generation

**Why were the changes made?**  
To allow multiple parameters during selective function generation

**How was the outcome achieved?**  
Update to cmake generator

**Additional Documentation:**  
Usage example:
CXX=/opt/rocm/bin/hipcc cmake -DCMAKE_PREFIX_PATH=/opt/rocm/ -DBUILD_LOCAL_GPU_TARGET_ONLY=ON -DONLY_FUNCS="AllReduce RING/TREE LL/SIMPLE Sum/MinMax int8_t/uint8_t/half/float/double/hip_bfloat16/rccl_float8/rccl_bfloat8|AllGather RING LL/SIMPLE Sum int8_t|AllToAllPivot RING SIMPLE Sum int8_t|Broadcast RING LL/SIMPLE Sum int8_t|Reduce RING LL/SIMPLE Sum/MinMax int8_t/uint8_t/half/float/double/hip_bfloat16/rccl_float8/rccl_bfloat8|ReduceScatter RING LL/SIMPLE Sum/MinMax int8_t/uint8_t/half/float/double/hip_bfloat16/rccl_float8/rccl_bfloat8|SendRecv RING SIMPLE Sum int8_t" -DENABLE_MSCCL_KERNEL=OFF ..

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
