### PR TITLE
Fix min_nchannels bug for gfx94* nranks=4

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -1396,10 +1396,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       allGather3Data[rank].nc = 16;
     else if (nranks == 4)
       // NCCL_MIN_NCHANNELS=24
-      allGather3Data[rank].nc = 6;
-    else if (nranks == 8)
-      // NCCL_MIN_NCHANNELS=56
-      allGather3Data[rank].nc = 2;
+      allGather3Data[rank].nc = 4;
   }
 
   allGather3Data[rank].pivotA2AEnabled = comm->topo->pivotA2AEnabled && rcclParamPivotAlltoallEnable();


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Fix bug to enable `NCCL_MIN_NCHANNELS=24` for 4 ranks on gfx94* GPUs

**Why were the changes made?**  
The current definition of `allGather3Data[rank].nc = 6` results (from https://github.com/ROCm/rccl/pull/1195) in 36 channels for 4 ranks on gfx942 GPUs.\
Changing this to `allGather3Data[rank].nc = 4` results in the intended 24 channels for 4 ranks on gfx942 GPUs.\
Also, removing the condition for 8 ranks, as it is no longer valid after https://github.com/ROCm/rccl/pull/1196

**How was the outcome achieved?**  
Use `NCCL_DEBUG=INFO` to confirm

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
