### PR TITLE
fix initOnceFunc setting incorrect result code

### DIFF
--- a/src/misc/rocmwrap.cc
+++ b/src/misc/rocmwrap.cc
@@ -162,6 +162,7 @@ static void initOnceFunc() {
   pfn_hsa_init();
 
   initResult = ncclSuccess;
+  return;
 
 error:
   initResult = ncclSystemError;


### PR DESCRIPTION


## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
fix initOnceFunc setting incorrect result code

**Why were the changes made?**  
Checks for DMA-BUF support were unexpectedly failing when checking return from rocmLibraryInit()

**How was the outcome achieved?**  
Function always fell through to error case.  Added return after setting ncclSuccess.

**Additional Documentation:**  
Unsure if you CHANGELOG line desired for this.  Let me know if one should be added.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
