### PR TITLE
use maxChannel 64 for multi-node inside kernel

### DIFF
--- a/src/device/common.h
+++ b/src/device/common.h
@@ -231,7 +231,13 @@ __forceinline__ __device__ void ncclKernelMain(struct ncclDevComm* comm, struct 
   const int tid = threadIdx.x;
   int x = tid;
   int total = 0, y;
-  int num = MAXCHANNELS/64 > 0 ? MAXCHANNELS/64 : 1;
+  int num;
+
+  if (comm->maxChannels == 64) {
+        num = 1;
+  } else {
+	num = MAXCHANNELS/64 > 0 ? MAXCHANNELS/64 : 1;
+  }
 
   switch (tid/WARP_SIZE) {
   case 0:

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -422,7 +422,7 @@ struct ncclDevComm {
 
   // Channels, device side
   struct ncclDevChannel* channels/*[MAXCHANNELS]*/;
-
+  int maxChannels;
 #if defined(ENABLE_NPKIT)
   NpKitEventCollectContext* npKitEventCollectContexts;
   uint64_t* cpuTimestamp;

--- a/src/init.cc
+++ b/src/init.cc
@@ -1731,6 +1731,9 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   // Call devCommSetup before the last barrier, making sure we don't have a thread running in front and starting to
   // launch NCCL kernels before all cuda mem allocation is complete. That could cause a deadlock.
   NCCLCHECKGOTO(devCommSetup(comm), ret, fail);
+  if (comm->nNodes > 1) {
+	comm->devComm->maxChannels = 64;
+  }
 
   if (mscclEnabled() && (comm->topo->mscclEnabled || mscclForceEnabled())) {
     NCCLCHECK(mscclInit(comm));


### PR DESCRIPTION
For multi-node, the maxChannel value is set to 64. This value should be used inside the kernel also.

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
RCCL was using pre-defined MAXCHANNELS value inside the kernel. But the maxChannel is set to 64 for multi-node. So, inside the kernel also, it should use 64 as the maxChannel.

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
