### PR TITLE
enable UT to test with channels greater than 64

### DIFF
--- a/test/AllReduceTests.cpp
+++ b/test/AllReduceTests.cpp
@@ -102,6 +102,30 @@ namespace RcclUnitTesting
     testBed.Finalize();
   }
 
+  TEST(AllReduce, Channels)
+  {
+    TestBed testBed;
+    if(testBed.ev.isGfx94) {
+      // Configuration
+      std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllReduce};
+      std::vector<ncclDataType_t> const dataTypes       = {ncclBfloat16, ncclHalf};
+      std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
+      std::vector<int>            const roots           = {0};
+      std::vector<int>            const numElements     = {64 * 1024 * 1024, 1024};
+      std::vector<bool>           const inPlaceList     = {false};
+      std::vector<bool>           const managedMemList  = {false};
+      std::vector<bool>           const useHipGraphList = {false, true};
+      std::vector<char *>         const channelList     = {"56", "84", "112"}; 
+      for (auto channel : channelList) {
+        setenv("NCCL_MIN_NCHANNELS", channel, 1);
+        testBed.RunSimpleSweep(funcTypes, dataTypes, redOps, roots, numElements,
+                              inPlaceList, managedMemList, useHipGraphList);
+        testBed.Finalize();
+        unsetenv("NCCL_MIN_NCHANNELS");
+      }
+    }
+  }
+
   TEST(AllReduce, ManagedMemGraph)
   {
     TestBed testBed;

--- a/test/AllToAllTests.cpp
+++ b/test/AllToAllTests.cpp
@@ -85,4 +85,28 @@ namespace RcclUnitTesting
                            inPlaceList, managedMemList, useHipGraphList);
     testBed.Finalize();
   }
+
+    TEST(AllToAll, Channels)
+  {
+    TestBed testBed;
+    if(testBed.ev.isGfx94) {
+      // Configuration
+      std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllToAll};
+      std::vector<ncclDataType_t> const dataTypes       = {ncclBfloat16, ncclHalf};
+      std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
+      std::vector<int>            const roots           = {0};
+      std::vector<int>            const numElements     = {64 * 1024 * 1024, 1024};
+      std::vector<bool>           const inPlaceList     = {false};
+      std::vector<bool>           const managedMemList  = {false};
+      std::vector<bool>           const useHipGraphList = {false, true};
+      std::vector<char *>         const channelList     = {"56", "84", "112"}; 
+      for (auto channel : channelList) {
+        setenv("NCCL_MIN_NCHANNELS", channel, 1);
+        testBed.RunSimpleSweep(funcTypes, dataTypes, redOps, roots, numElements,
+                              inPlaceList, managedMemList, useHipGraphList);
+        testBed.Finalize();
+        unsetenv("NCCL_MIN_NCHANNELS");
+      }
+    }
+  }
 }

--- a/test/common/EnvVars.hpp
+++ b/test/common/EnvVars.hpp
@@ -29,6 +29,7 @@ namespace RcclUnitTesting
     bool showTiming;     // Show timing per case at end            [UT_SHOW_TIMING]
     bool useInteractive; // Run in interactive mode                [UT_INTERACTIVE]
     int  timeoutUs;      // Set timeout for child in microseconds  [UT_TIMEOUT_US]
+    bool isGfx94;        // Detects if architecture is gfx94
 
     // Constructor that parses and collects environment variables
     EnvVars();


### PR DESCRIPTION
## Details
Enabling UT to test with channels greater than 64
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Enabled UT to test with channels 56, 84 and 112 for allreduce if the architecture is gfx94 (MI300)

**Why were the changes made?**  
There was no UT to test configuration greater than 64 channels on MI300X previously.

**How was the outcome achieved?**  
1) Enable this feature if the architecture is MI300 (gfx94).
2) Set number of channels as 56, 84 and 112 for allreduce test.

**Additional Documentation:**  
1) Only 3 values of number of channels and 1 type of collective algorithm was chosen for testing to not increase the total time consumption of test by a lot.
2) Had to create a separate child process to get the architecture information as we cannot use HIP call prior to launching unless it is inside another child process.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
