### PR TITLE
Improved versioning info, added hostname and librccl path in NCCL_DEBUG=VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,7 @@ set(SRC_FILES
   src/include/git_version.h
   src/include/graph.h
   src/include/group.h
+  src/include/hip_rocm_version_info.h
   src/include/ibvcore.h
   src/include/ibvsymbols.h
   src/include/ibvwrap.h
@@ -391,6 +392,7 @@ set(SRC_FILES
   src/include/rccl_vars.h
   src/include/register.h
   src/include/rccl_float8.h
+  src/include/rccl_libpath_info.h
   src/include/rocm_smi_wrap.h
   src/include/rocmwrap.h
   src/include/roctx.h
@@ -449,6 +451,7 @@ set(SRC_FILES
   src/misc/nvmlwrap_stub.cc
   src/misc/param.cc
   src/misc/profiler.cc
+  src/misc/rccl_libpath_info.cc
   src/misc/rocm_smi_wrap.cc
   src/misc/rocmwrap.cc
   src/misc/roctx.cc

--- a/src/include/hip_rocm_version_info.h
+++ b/src/include/hip_rocm_version_info.h
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef RCCL_HIP_ROCM_VERSION_INFO_H_
+#define RCCL_HIP_ROCM_VERSION_INFO_H_
+
+#define STR2(v) #v
+#define STR(v) STR2(v)
+
+//HIP version info retrieval
+#if ROCM_VERSION >= 50000
+   #define HIP_BUILD_INFO STR(HIP_VERSION_MAJOR) "." STR(HIP_VERSION_MINOR) "." STR(HIP_VERSION_PATCH) "-" HIP_VERSION_GITHASH
+//Githash info not available in older Rocm versions < 5.0
+#elif ROCM_VERSION >= 40000
+   #define HIP_BUILD_INFO STR(HIP_VERSION_MAJOR) "." STR(HIP_VERSION_MINOR) "." STR(HIP_VERSION_PATCH)
+#else
+   #define HIP_BUILD_INFO "Unknown"
+#endif
+
+//RoCm version info retrieval  
+#if ROCM_VERSION >= 60000
+   //rocm_version.h moved to rocm/include/rocm-core from ROCm 6.0
+   #include <rocm-core/rocm_version.h>
+#else
+   // rocm-core/rocm_version.h not present in some ROCm versions < 6.0. 
+   // So, including it from rocm/include/rocm_version.h
+   #include <rocm_version.h>
+   //ROCM_BUILD_INFO not defined in ROCm Versions < 5.50
+   #if !defined(ROCM_BUILD_INFO) && ROCM_VERSION >= 50000
+      #define ROCM_BUILD_INFO STR(ROCM_VERSION_MAJOR) "." STR(ROCM_VERSION_MINOR) "." STR(ROCM_VERSION_PATCH)
+   //ROCm version info not available for ROCm versions < 5.0
+   #else
+      #define ROCM_BUILD_INFO "Unknown"
+   #endif
+#endif
+
+#endif

--- a/src/include/rccl_libpath_info.h
+++ b/src/include/rccl_libpath_info.h
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef RCCL_LIBPATH_INFO_H_
+#define RCCL_LIBPATH_INFO_H_
+
+void getRcclLibPath(char *libPath, int pathLen);
+
+#endif

--- a/src/init.cc
+++ b/src/init.cc
@@ -42,6 +42,8 @@
 // [RCCL]
 #include "git_version.h"
 #include "rccl_vars.h"
+#include "hip_rocm_version_info.h"
+#include "rccl_libpath_info.h"
 //#include "clique/CliqueManager.h"
 //#include <hsa/hsa_ext_amd.h>
 // [/RCCL]
@@ -49,8 +51,13 @@
 #include "msccl/msccl_lifecycle.h"
 #include "msccl/msccl_status.h"
 
-#define STR2(v) #v
-#define STR(v) STR2(v)
+#ifndef STR2
+  #define STR2(v) #v
+#endif
+
+#ifndef STR
+  #define STR(v) STR2(v)
+#endif
 
 #if CUDART_VERSION >= 9020 || defined(__HIP_PLATFORM_AMD__) || defined(__HCC__) || defined(__HIPCC__)
 #define NCCL_GROUP_CUDA_STREAM 0 // CGMD: CUDA 9.2,10.X Don't need to use an internal CUDA stream
@@ -683,17 +690,26 @@ fail:
 
 // Pre-process the string so that running "strings" on the lib can quickly reveal the version.
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HCC__) || defined(__HIPCC__)
-#define VERSION_STRING "RCCL version " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX "+hip" STR(HIP_VERSION_MAJOR) "." STR(HIP_VERSION_MINOR)
+#define VERSION_STRING "RCCL version : " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX
+#define VERSION_STRING_EXTENDED "HIP version  : " HIP_BUILD_INFO "\nROCm version : " ROCM_BUILD_INFO
 #else
-#define VERSION_STRING "NCCL version " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX "+cuda" STR(CUDA_MAJOR) "." STR(CUDA_MINOR)
+#define VERSION_STRING "NCCL version " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX
+#define VERSION_STRING_EXTENDED "CUDA version " STR(CUDA_MAJOR) "." STR(CUDA_MINOR)
 #endif
 static void showVersion() {
   static int shown = 0;
   if (shown == 0 && ncclDebugLevel >= NCCL_LOG_VERSION) {
-    printf("%s %s\n", VERSION_STRING, rcclGitHash);
+    char hostInfo[512], libPathInfo[2048];
+    if (gethostname(hostInfo, 512) != 0)
+      strncpy(hostInfo, "Unknown", 512); //Returns Unknown in hostInfo if function call unsuccessful
+    getRcclLibPath(libPathInfo, 2048);
+    printf("%s-%s\n%s\n", VERSION_STRING, rcclGitHash, VERSION_STRING_EXTENDED);
+    printf("%-12s : %s\n%-12s : %s\n", "Hostname", hostInfo, "Librccl path", libPathInfo);
     fflush(stdout);
-    if (ncclDebugFile != stdout)
-      INFO(NCCL_ALL,"%s %s", VERSION_STRING, rcclGitHash); // Also log NCCL version in one of the files
+    if (ncclDebugFile != stdout) {
+      INFO(NCCL_ALL, "%s-%s\n%s\n", VERSION_STRING, rcclGitHash, VERSION_STRING_EXTENDED); // Also log NCCL version in one of the files
+      INFO(NCCL_ALL, "%-12s : %s\n%-12s : %s\n", "Hostname", hostInfo, "Librccl path", libPathInfo);
+    }
     shown = 1;
   }
 }

--- a/src/misc/rccl_libpath_info.cc
+++ b/src/misc/rccl_libpath_info.cc
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include "rccl_libpath_info.h"
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <link.h>
+#include <string.h>
+
+void getRcclLibPath(char *libPath, int pathLen) {
+    const char *rcclLib = "librccl.so";
+    //Open lib handle
+    void *dlHandle = dlopen(rcclLib, RTLD_LAZY);
+    //Return Unknown if opening handle was not successful
+    if (!dlHandle) {
+        strncpy(libPath, "Unknown", pathLen);
+        return;
+    }
+    //Retrive lib info
+    struct link_map *dlLinkMap;
+    if (dlinfo(dlHandle, RTLD_DI_LINKMAP, &dlLinkMap) != 0) {
+        strncpy(libPath, "Unknown", pathLen);
+        return;
+    }
+    //Retrieval successful. Copy to libPath
+    strncpy(libPath, dlLinkMap->l_name, pathLen - 1);
+    libPath[pathLen - 1] = '\0';
+    //Close handle
+    dlclose(dlHandle);
+}

--- a/src/misc/rccl_libpath_info.cc
+++ b/src/misc/rccl_libpath_info.cc
@@ -21,29 +21,17 @@ THE SOFTWARE.
 */
 
 #include "rccl_libpath_info.h"
-#include <stdlib.h>
 #include <dlfcn.h>
-#include <link.h>
 #include <string.h>
 
 void getRcclLibPath(char *libPath, int pathLen) {
-    const char *rcclLib = "librccl.so";
-    //Open lib handle
-    void *dlHandle = dlopen(rcclLib, RTLD_LAZY);
-    //Return Unknown if opening handle was not successful
-    if (!dlHandle) {
-        strncpy(libPath, "Unknown", pathLen);
-        return;
+    Dl_info pathInfo;
+    if (dladdr((void*)getRcclLibPath, &pathInfo)) {
+        strncpy(libPath, pathInfo.dli_fname, pathLen - 1);
+        libPath[pathLen - 1] = '\0'; //To prevent overflow
     }
-    //Retrive lib info
-    struct link_map *dlLinkMap;
-    if (dlinfo(dlHandle, RTLD_DI_LINKMAP, &dlLinkMap) != 0) {
+    else {
+        //Sets libPath to Unknown if the above function call is not successful
         strncpy(libPath, "Unknown", pathLen);
-        return;
     }
-    //Retrieval successful. Copy to libPath
-    strncpy(libPath, dlLinkMap->l_name, pathLen - 1);
-    libPath[pathLen - 1] = '\0';
-    //Close handle
-    dlclose(dlHandle);
 }


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** Internal

**What were the changes?**  
To improve HIP and ROCm versioning info (includes build number, patch and githash). Added support to display hostname and path to librccl.so.

**Why were the changes made?**  
Displaying complete version info helps in understanding the rocm/hip build type (mainline, staging etc). Enabling support for displaying hostname can retrieve (dell, banff, etc if specified in hostname). Path to librccl.so is important to understand user's librccl path loaded by the dynamic linker at runtime.

**How was the outcome achieved?**  
**Changes to init.cc**: Added a new macro, VERSION_STRING_EXTENDED to display hip and rocm version. Added support to display hostname using **gethostname** function.
**New files**: 
1. **hip_rocm_version_info.h**: Checks rocm version and sets the macro HIP_BUILD_INFO, ROCM_BUILD_INFO. 
2. **rccl_libpath_info.h** and **rccl_libpath_info.cc**: Added to new function to display librccl.so path used by dynamic linker at runtime. Used dynamic linker api to achieve this.

**Additional Documentation:**  

Sample output:

![image](https://github.com/ROCm/rccl/assets/13920827/debedc25-cea2-46d5-bb76-70235931f548)


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
