### PR TITLE
Checking kernel header files only when missing sysfs entry

### DIFF
--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -362,10 +362,9 @@ ncclResult_t ncclIbGdrSupport() {
       NCCLCHECK(ncclTopoGetStrFromSys("/proc/sys/kernel", "numa_balancing", strValue));
       if (strcmp(strValue, "1") == 0 && roMode == 0)
         moduleLoaded = 0;
-    } else {
+    } else if (moduleLoaded == 0) {
       char kernel_header_file[256];
       struct utsname utsname;
-      moduleLoaded = 0;
       char buf[256];
       FILE *fp = NULL;
       //check for kernel name exists


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Checking kernel header files only when missing sysfs entry

**Why were the changes made?**  
Do not overwrite moduleLoaded if detected from sysfs

**How was the outcome achieved?**  
Add conditions to check kernel headers

**Additional Documentation:**  

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
