### PR TITLE
[BUILD] Update gfxTargets for ASAN build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,9 @@ option(TRACE                                   "Enable additional tracing"      
 # Default GPU architectures to build
 #==================================================================================================
 set(DEFAULT_GPUS
-      gfx803
-      gfx900:xnack-
-      gfx906:xnack-
-      gfx908:xnack-
-      gfx90a:xnack-
-      gfx90a:xnack+
+      gfx906
+      gfx908
+      gfx90a
       gfx940
       gfx941
       gfx942
@@ -75,13 +72,27 @@ endif()
 
 # Determine which GPU architectures to build for
 set(AMDGPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "Target default GPUs if AMDGPU_TARGETS is not defined.")
+
+# Modify GPU architectures for Address Sanitizer builds by appending "xnack+"
+if (BUILD_ADDRESS_SANITIZER)
+  SET(amdgpu_targets "")
+  foreach(amdgpu_target IN LISTS AMDGPU_TARGETS)
+    if(NOT amdgpu_target STREQUAL "")
+      list(APPEND amdgpu_targets "${amdgpu_target}:xnack+")
+    endif()
+  endforeach()
+  SET(AMDGPU_TARGETS "${amdgpu_targets}" CACHE STRING "Modified GPU list for Address-Sanitizer enabled build." FORCE)
+endif()
+
+# Check if clang compiler can offload to AMDGPU_TARGETS
 if (COMMAND rocm_check_target_ids)
-  message(STATUS "Checking for ROCm support for GPU targets:")
+  message(STATUS "Checking for ROCm support for GPU targets: " "${AMDGPU_TARGETS}")
   rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${AMDGPU_TARGETS})
 else()
   message(WARNING "Unable to check for supported GPU targets. Falling back to default GPUs.")
   set(SUPPORTED_GPUS ${DEFAULT_GPUS})
 endif()
+
 set(GPU_TARGETS "${SUPPORTED_GPUS}" CACHE STRING "GPU targets to compile for.")
 message(STATUS "Compiling for ${GPU_TARGETS}")
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ RCCL build & installation helper script
        --verbose               Show compile commands
 ```
 
+By default, RCCL builds for all GPU targets defined in `DEFAULT_GPUS` in `CMakeLists.txt`. To target specific GPU(s), and potentially reduce build time, use `--amdgpu_targets` as a `;` separated string listing GPU(s) to target.
+
 ## Manual build
 
 ### To build the library using CMake:


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
- Modify RCCL build for Address Sanitizer (ASAN)-enabled builds to only target GPU architectures with `xnack+`.
- Remove older GPU architectures like `gfx803`, `gfx900` from the DEFAULT_GPUS list as they are no longer supported by AMD.

**Why were the changes made?**  
Device-side address sanitizer instrumentation requires `xnack+`. Because of this, the gfxTargets included in the ASAN builds should include only `xnack+` targets.\
Additionally, this saves build time by removing any non-`xnack+` targets.

**How was the outcome achieved?**  
If ASAN is enabled, modify the GPU target list in `CMakeLists.txt` by appending `xnack+` to the default list of GPU targets (or, if defined, local GPU target).

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
