### PR TITLE
Remove unused but set variable from prims_ll.h

### DIFF
--- a/src/device/prims_ll.h
+++ b/src/device/prims_ll.h
@@ -529,7 +529,6 @@ private:
         dsts[i] += tid*EltPerLine;
       }
     }
-    int offset = tid;
     int eltPerTrip = nthreads*EltPerLine;
     while (nelem > 0) {
       int eltInLine = EltPerLine < nelem ? EltPerLine : nelem;
@@ -569,7 +568,6 @@ private:
         }
       }
       nelem -= eltPerTrip;
-      offset += nthreads;
     }
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT)


### PR DESCRIPTION
Allows `-Wunused-but-set-variable` to pass

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
