### PR TITLE
Remove unused but set variable from prims_ll128.h

### DIFF
--- a/src/device/prims_ll128.h
+++ b/src/device/prims_ll128.h
@@ -382,7 +382,6 @@ private:
 
     T const *srcPtr = srcs[0];
     T       *dstPtr = dsts[0];
-    int wireOffset = WireWordPerSlice*warp + 2*wid;
     const int nwarps = nthreads/WARP_SIZE;
     nelem = nelem < 0 ? 0 : nelem;
 
@@ -438,7 +437,6 @@ private:
         }
       }
 
-      wireOffset += WireWordPerSlice*nwarps;
       srcPtr += DataEltPerSlice*nwarps;
       dstPtr += DataEltPerSlice*nwarps;
       if (MULTISRCS){


### PR DESCRIPTION
Allows `-Wunused-but-set-variable` to pass

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
