### PR TITLE
Remove unused but set variable from all_reduce.h

### DIFF
--- a/src/device/all_reduce.h
+++ b/src/device/all_reduce.h
@@ -59,14 +59,6 @@ namespace {
     }
 #endif
 
-    int minChunkSize;
-    if (Proto::Id == NCCL_PROTO_LL)
-      minChunkSize = nthreads*(Proto::calcBytePerGrain()/sizeof(T));
-    if (Proto::Id == NCCL_PROTO_LL128) {
-      // We should not need the final /2 but it makes performance much, much smoother. Might be a bug somewhere.
-      minChunkSize = nthreads*(Proto::calcBytePerGrain()/sizeof(T))/2;
-    }
-
     Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0> prims
       (tid, nthreads, &ring->prev, &ring->next, args->sendbuff, args->recvbuff, args->redOpArg, 0, args->connIndex, args->connIndex);
 


### PR DESCRIPTION
Allows `-Wunused-but-set-variable` to pass

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
