### PR TITLE
Restore number of parallel linking jobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -706,8 +706,15 @@ execute_process(
 if (${memory_max_string} MATCHES "^[0-9]+")
   math(EXPR memory_in_gb "${memory_max_string} / (1024 * 1024 * 1024)")
 else()
-  cmake_host_system_information(RESULT memory_max_string QUERY AVAILABLE_PHYSICAL_MEMORY )
-  math(EXPR memory_in_gb "${memory_max_string} / 1024")
+  execute_process(
+    COMMAND bash "-c" "cat /sys/fs/cgroup/memory/memory.limit_in_bytes"
+    OUTPUT_VARIABLE memory_max_string)
+  if (${memory_max_string} MATCHES "^[0-9]+")
+    math(EXPR memory_in_gb "${memory_max_string} / (1024 * 1024 * 1024)")
+  else()
+    cmake_host_system_information(RESULT memory_max_string QUERY AVAILABLE_PHYSICAL_MEMORY )
+    math(EXPR memory_in_gb "${memory_max_string} / 1024")
+  endif()
 endif()
 ## Reserve 16GB for each linker job. Limit max number of linker jobs to 16
 math(EXPR num_linker_jobs "(${memory_in_gb} + 15) / 16")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,7 +699,7 @@ target_link_libraries(rccl PRIVATE   dl)
 target_link_libraries(rccl PRIVATE   ${ROCM_SMI_LIBRARIES})
 
 ## Set RCCL link options
-target_link_options(rccl PRIVATE -parallel-jobs=6)       # Use multiple threads to link
+target_link_options(rccl PRIVATE -parallel-jobs=16)       # Use multiple threads to link
 if(BUILD_ADDRESS_SANITIZER)
   target_link_options(rccl PRIVATE -fuse-ld=lld)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,7 +711,7 @@ else()
 endif()
 ## Reserve 16GB for each linker job. Limit max number of linker jobs to 16
 math(EXPR num_linker_jobs "(${memory_in_gb} + 15) / 16")
-if (${num_linker_jobs} VERSION_GREATER_EQUAL "16")
+if (${num_linker_jobs} GREATER_EQUAL "16")
   set(num_linker_jobs "16")
 endif()
 message(STATUS "Use ${num_linker_jobs} jobs for linking")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,7 +699,23 @@ target_link_libraries(rccl PRIVATE   dl)
 target_link_libraries(rccl PRIVATE   ${ROCM_SMI_LIBRARIES})
 
 ## Set RCCL link options
-target_link_options(rccl PRIVATE -parallel-jobs=16)       # Use multiple threads to link
+## Find out available memory
+execute_process(
+  COMMAND bash "-c" "cat /sys/fs/cgroup/memory.max"
+  OUTPUT_VARIABLE memory_max_string)
+if (${memory_max_string} MATCHES "^[0-9]+")
+  math(EXPR memory_in_gb "${memory_max_string} / (1024 * 1024 * 1024)")
+else()
+  cmake_host_system_information(RESULT memory_max_string QUERY AVAILABLE_PHYSICAL_MEMORY )
+  math(EXPR memory_in_gb "${memory_max_string} / 1024")
+endif()
+## Reserve 16GB for each linker job. Limit max number of linker jobs to 16
+math(EXPR num_linker_jobs "(${memory_in_gb} + 15) / 16")
+if (${num_linker_jobs} VERSION_GREATER_EQUAL "16")
+  set(num_linker_jobs "16")
+endif()
+message(STATUS "Use ${num_linker_jobs} jobs for linking")
+target_link_options(rccl PRIVATE -parallel-jobs=${num_linker_jobs})       # Use multiple threads to link
 if(BUILD_ADDRESS_SANITIZER)
   target_link_options(rccl PRIVATE -fuse-ld=lld)
 endif()


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal

**What were the changes?**  
Dynamically adjust number of parallel linking jobs based on available memory

**Why were the changes made?**  
Reduce RCCL compilation time and avoid OOM

**How was the outcome achieved?**  
Dynamically adjust number of parallel linking jobs based on available memory

**Additional Documentation:**  
Limit to 16 jobs max to avoid too large memory usage

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
