### PR TITLE
Fix number of loops in p2p-latency-test

### DIFF
--- a/tools/p2p-latency-test/ll_latency_test.cpp
+++ b/tools/p2p-latency-test/ll_latency_test.cpp
@@ -78,14 +78,14 @@ __device__ uint64_t readLL(union LLFifoLine* src, uint32_t flag, uint32_t* abort
 __global__ void PingKernel(LLFifoLine* local_flag, LLFifoLine* remote_flag, uint64_t* time_delta, uint32_t* abortFlag) {
   int tid = threadIdx.x;
   #pragma unroll
-  for (uint32_t i = 1; i < NUM_LOOPS_WARMUP; i++) {
+  for (uint32_t i = 1; i <= NUM_LOOPS_WARMUP; i++) {
     storeLL(remote_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, i);
     while (readLL(local_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, abortFlag) != i);
   }
   uint64_t start_time, end_time;
   if (tid == 0) start_time = wall_clock64();
   #pragma unroll
-  for (uint32_t i = NUM_LOOPS_WARMUP; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
+  for (uint32_t i = NUM_LOOPS_WARMUP + 1; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
     storeLL(remote_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, i);
     while (readLL(local_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, abortFlag) != i);
   }
@@ -97,14 +97,14 @@ __global__ void PingKernel(LLFifoLine* local_flag, LLFifoLine* remote_flag, uint
 __global__ void PongKernel(LLFifoLine* local_flag, LLFifoLine* remote_flag, uint64_t* time_delta, uint32_t* abortFlag) {
   int tid = threadIdx.x;
   #pragma unroll
-  for (uint32_t i = 1; i < NUM_LOOPS_WARMUP; i++) {
+  for (uint32_t i = 1; i <= NUM_LOOPS_WARMUP; i++) {
     while (readLL(local_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, abortFlag) != i);
     storeLL(remote_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, i);
   }
   uint64_t start_time, end_time;
   if (tid == 0) start_time = wall_clock64();
   #pragma unroll
-  for (uint32_t i = NUM_LOOPS_WARMUP; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
+  for (uint32_t i = NUM_LOOPS_WARMUP + 1; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
     while (readLL(local_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, abortFlag) != i);
     storeLL(remote_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, i);
   }

--- a/tools/p2p-latency-test/ll_latency_test.cu
+++ b/tools/p2p-latency-test/ll_latency_test.cu
@@ -69,14 +69,14 @@ __device__ uint64_t readLL(union LLFifoLine* src, uint32_t flag, uint32_t* abort
 __global__ void PingKernel(LLFifoLine* local_flag, LLFifoLine* remote_flag, uint64_t* time_delta, uint32_t* abortFlag) {
   int tid = threadIdx.x;
   #pragma unroll
-  for (uint32_t i = 1; i < NUM_LOOPS_WARMUP; i++) {
+  for (uint32_t i = 1; i <= NUM_LOOPS_WARMUP; i++) {
     storeLL(remote_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, i);
     while (readLL(local_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, abortFlag) != i);
   }
   uint64_t start_time, end_time;
   if (tid == 0) start_time = clock64();
   #pragma unroll
-  for (uint32_t i = NUM_LOOPS_WARMUP; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
+  for (uint32_t i = NUM_LOOPS_WARMUP + 1; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
     storeLL(remote_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, i);
     while (readLL(local_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, abortFlag) != i);
   }
@@ -88,14 +88,14 @@ __global__ void PingKernel(LLFifoLine* local_flag, LLFifoLine* remote_flag, uint
 __global__ void PongKernel(LLFifoLine* local_flag, LLFifoLine* remote_flag, uint64_t* time_delta, uint32_t* abortFlag) {
   int tid = threadIdx.x;
   #pragma unroll
-  for (uint32_t i = 1; i < NUM_LOOPS_WARMUP; i++) {
+  for (uint32_t i = 1; i <= NUM_LOOPS_WARMUP; i++) {
     while (readLL(local_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, abortFlag) != i);
     storeLL(remote_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, i);
   }
   uint64_t start_time, end_time;
   if (tid == 0) start_time = clock64();
   #pragma unroll
-  for (uint32_t i = NUM_LOOPS_WARMUP; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
+  for (uint32_t i = NUM_LOOPS_WARMUP + 1; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
     while (readLL(local_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, abortFlag) != i);
     storeLL(remote_flag+tid+(i%LL_MAX_LINES)*LL_MAX_THREADS, i, i);
   }

--- a/tools/p2p-latency-test/p2p_latency_test.cpp
+++ b/tools/p2p-latency-test/p2p_latency_test.cpp
@@ -23,13 +23,13 @@
 
 __global__ void PingKernel(uint64_t* local_flag, uint64_t* remote_flag, uint64_t* time_delta) {
   #pragma unroll
-  for (uint32_t i = 1; i < NUM_LOOPS_WARMUP; i++) {
+  for (uint32_t i = 1; i <= NUM_LOOPS_WARMUP; i++) {
     __atomic_store_n(remote_flag, i, __ATOMIC_RELAXED);
     while (__atomic_load_n(local_flag, __ATOMIC_RELAXED) != i);
   }
   uint64_t start_time = wall_clock64();
   #pragma unroll
-  for (uint32_t i = NUM_LOOPS_WARMUP; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
+  for (uint32_t i = NUM_LOOPS_WARMUP + 1; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
     __atomic_store_n(remote_flag, i, __ATOMIC_RELAXED);
     while (__atomic_load_n(local_flag, __ATOMIC_RELAXED) != i);
   }
@@ -39,13 +39,13 @@ __global__ void PingKernel(uint64_t* local_flag, uint64_t* remote_flag, uint64_t
 
 __global__ void PongKernel(uint64_t* local_flag, uint64_t* remote_flag, uint64_t* time_delta) {
   #pragma unroll
-  for (uint32_t i = 1; i < NUM_LOOPS_WARMUP; i++) {
+  for (uint32_t i = 1; i <= NUM_LOOPS_WARMUP; i++) {
     while (__atomic_load_n(local_flag, __ATOMIC_RELAXED) != i);
     __atomic_store_n(remote_flag, i, __ATOMIC_RELAXED);
   }
   uint64_t start_time = wall_clock64();
   #pragma unroll
-  for (uint32_t i = NUM_LOOPS_WARMUP; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
+  for (uint32_t i = NUM_LOOPS_WARMUP + 1; i <= NUM_LOOPS_WARMUP + NUM_LOOPS_RUN; i++) {
     while (__atomic_load_n(local_flag, __ATOMIC_RELAXED) != i);
     __atomic_store_n(remote_flag, i, __ATOMIC_RELAXED);
   }


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Fix number of loops calculation in tests in tools/p2p-latency-test folder.

**Why were the changes made?**  
Previous number of loops calculation was wrong that warmup loops has a -1 offset and test loops has a +1 offset.
This leads to around 1/1e4 inflation of final latency.

**How was the outcome achieved?**  
Revise the loop condition in PingKernel and PongKernel.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
