### PR TITLE
Remove IBVerbs dependency for mscclpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,11 +278,7 @@ endif()
 
 ## Disable building MSCCL++ if the build environment is invalid
 if (ENABLE_MSCCLPP)
-  find_package(IBVerbs)
-  if (NOT IBVerbs_FOUND)
-    set(ENABLE_MSCCLPP OFF)
-    message(WARNING "IBVerbs not found; disabling MSCCL++ build")
-  elseif(NOT "gfx942" IN_LIST GPU_TARGETS)
+  if(NOT "gfx942" IN_LIST GPU_TARGETS)
     set(ENABLE_MSCCLPP OFF)
     message(WARNING "Can only build MSCCL++ for gfx942; disabling MSCCL++ build")
   endif()

--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -64,7 +64,7 @@ if(ENABLE_MSCCLPP)
     
         download_project(PROJ                mscclpp_nccl
                          GIT_REPOSITORY      https://github.com/microsoft/mscclpp.git
-                         GIT_TAG             8c6fb429e92e07acb82c0fdcdab44854fc63aa68
+                         GIT_TAG             1e82dd444fc1ed8b7add354eebaab8a94e67d5fc
                          INSTALL_DIR         ${MSCCLPP_ROOT}
                          CMAKE_ARGS          -DGPU_TARGETS=gfx942 -DBYPASS_GPU_CHECK=ON -DUSE_ROCM=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DBUILD_APPS_NCCL=ON -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> "${CMAKE_PREFIX_PATH_ARG}" "${CMAKE_SHARED_LINKER_FLAGS_INIT_ARG}" "${CMAKE_EXE_LINKER_FLAGS_INIT_ARG}" -DCMAKE_VERBOSE_MAKEFILE=1 "${CMAKE_INSTALL_RPATH_USE_LINK_PATH_ARG}" "${HIP_COMPILER_ARG}"
                          LOG_DOWNLOAD        FALSE


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
- Changed mscclpp commit to where IBVerbs dependency was removed.
- Removed the dependency check from cmake step

**Why were the changes made?**  
MSCCL++ doesn't require IBVerbs anymore.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
