### PR TITLE
Include mscclpp as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "ext-src/mscclpp"]
+	path = ext-src/mscclpp
+	url = https://github.com/microsoft/mscclpp.git
+	ignore = dirty

--- a/README.md
+++ b/README.md
@@ -66,12 +66,17 @@ By default, RCCL builds for all GPU targets defined in `DEFAULT_GPUS` in `CMakeL
 ### To build the library using CMake:
 
 ```shell
-$ git clone https://github.com/ROCm/rccl.git
+$ git clone https://github.com/ROCm/rccl.git --recurse-submodules
 $ cd rccl
 $ mkdir build
 $ cd build
 $ cmake ..
 $ make -j 16      # Or some other suitable number of parallel jobs
+```
+If you have already cloned, you can checkout the `mscclpp` submodule manually.
+```shell
+$ cd ext-src/mscclpp
+$ git submodule update --init --recursive
 ```
 You may substitute an installation path of your own choosing by passing `CMAKE_INSTALL_PREFIX`. For example:
 ```shell

--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -45,6 +45,7 @@ endfunction()
 
 
 if(ENABLE_MSCCLPP)
+    set(MSCCLPP_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mscclpp CACHE PATH "")
     set(MSCCLPP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/ext/mscclpp CACHE PATH "")
     execute_process(
         COMMAND mkdir -p ${MSCCLPP_ROOT}
@@ -63,8 +64,8 @@ if(ENABLE_MSCCLPP)
         mscclpp_cmake_arg(HIP_COMPILER)
     
         download_project(PROJ                mscclpp_nccl
-                         GIT_REPOSITORY      https://github.com/microsoft/mscclpp.git
-                         GIT_TAG             1e82dd444fc1ed8b7add354eebaab8a94e67d5fc
+                         # GIT_REPOSITORY      https://github.com/microsoft/mscclpp.git
+                         # GIT_TAG             1e82dd444fc1ed8b7add354eebaab8a94e67d5fc
                          INSTALL_DIR         ${MSCCLPP_ROOT}
                          CMAKE_ARGS          -DGPU_TARGETS=gfx942 -DBYPASS_GPU_CHECK=ON -DUSE_ROCM=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DBUILD_APPS_NCCL=ON -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> "${CMAKE_PREFIX_PATH_ARG}" "${CMAKE_SHARED_LINKER_FLAGS_INIT_ARG}" "${CMAKE_EXE_LINKER_FLAGS_INIT_ARG}" -DCMAKE_VERBOSE_MAKEFILE=1 "${CMAKE_INSTALL_RPATH_USE_LINK_PATH_ARG}" "${HIP_COMPILER_ARG}"
                          LOG_DOWNLOAD        FALSE
@@ -72,6 +73,7 @@ if(ENABLE_MSCCLPP)
                          LOG_BUILD           FALSE
                          LOG_INSTALL         FALSE
                          UPDATE_DISCONNECTED TRUE
+                         SOURCE_DIR          ${MSCCLPP_SOURCE}
         )
 
         find_package(mscclpp_nccl REQUIRED)

--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -45,7 +45,7 @@ endfunction()
 
 
 if(ENABLE_MSCCLPP)
-    set(MSCCLPP_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mscclpp CACHE PATH "")
+    # Try to find the mscclpp install
     set(MSCCLPP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/ext/mscclpp CACHE PATH "")
     execute_process(
         COMMAND mkdir -p ${MSCCLPP_ROOT}
@@ -54,8 +54,17 @@ if(ENABLE_MSCCLPP)
     find_package(mscclpp_nccl)
 
     if(NOT mscclpp_nccl_FOUND)
-        message(STATUS "MSCCL++ not found. Downloading and building MSCCL++ only for gfx942.")
-        # Download, build and install mscclpp
+        # Ensure the source code is checked out
+        set(MSCCLPP_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mscclpp CACHE PATH "")
+        if(NOT EXISTS ${MSCCLPP_SOURCE}/CMakeLists.txt)
+            message(STATUS "Checking out microsoft/mscclpp")
+            execute_process(
+                COMMAND git submodule update --init --recursive
+                WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+            )
+        endif()
+        
+        message(STATUS "Building mscclpp only for gfx942.")
         
         mscclpp_cmake_arg(CMAKE_PREFIX_PATH)
         mscclpp_cmake_arg(CMAKE_SHARED_LINKER_FLAGS_INIT)


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**What were the changes?**  
Include the mscclpp source code as a git submodule rather than using `download_project` in the `cmake` step.

**Why were the changes made?**  
Some environments don't have internet access at compile time, so `download_project` won't work. Instead, we should checkout all code together when we do have access.

**How was the outcome achieved?**  
We are still technically using `download_project` to maintain the same semantics, but we skip the actual checkout step and just use the build step.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
