### PR TITLE
Fix size matching in MSCCL

### DIFF
--- a/src/misc/msccl/msccl_lifecycle.cc
+++ b/src/misc/msccl/msccl_lifecycle.cc
@@ -304,7 +304,7 @@ static ncclResult_t mscclInternalSchedulerSelectAlgo(int rank, struct mscclSched
     auto &m = status.algoMetas[i];
     size_t nBytes = param->count * ncclTypeSize(param->dataType) * m.sizeMultiplier;
     bool msgSizeIsValid =
-      param->count > 0 && (param->count % m.nChunksPerLoop) == 0 &&
+      param->count > 0 && ((param->count * m.sizeMultiplier) % m.nChunksPerLoop) == 0 &&
       nBytes >= m.minBytes && (m.maxBytes == 0 || nBytes <= m.maxBytes);
     if (msgSizeIsValid &&
         m.nRanks == param->nRanks &&


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_Fixing size matching in MSCCL._

**Why were the changes made?**  
_Original logic was wrong for collectives with sizeMultiplier > 1 like all-gather, reduce-scatter and all-to-all._

**How was the outcome achieved?**  
_Fixing count calculation._

**Additional Documentation:**  
_N/A_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [x] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
