### PR TITLE
Temporary patch for unit tests in cpx mode

### DIFF
--- a/test/common/EnvVars.cpp
+++ b/test/common/EnvVars.cpp
@@ -94,6 +94,7 @@ namespace RcclUnitTesting
     // NOTE: Cannot use HIP call prior to launching unless it is inside another child process
     numDetectedGpus = 0;
     getDeviceCount(&numDetectedGpus);
+    numDetectedGpus = min(numDetectedGpus, 16);
     isGfx94 = false;
     getArchInfo(&isGfx94, "gfx94");
     isGfx12 = false;


### PR DESCRIPTION
## Details
Currently CPX mode will crash in AllReduce.Channels at ranks=24, while we are still investigating, we will cap the number of ranks at 16. This should not affect nodes in SPX mode.

**Work item:**
Internal

**What were the changes?**  
Just change default MAX_GPU to 16 instead of all that can be detected



## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
