### PR TITLE
Enabling Unit Tests for CPX mode

### DIFF
--- a/test/common/EnvVars.cpp
+++ b/test/common/EnvVars.cpp
@@ -139,7 +139,6 @@ namespace RcclUnitTesting
     showNames      = GetEnvVar("UT_SHOW_NAMES"  , 1);
     minGpus        = GetEnvVar("UT_MIN_GPUS"    , 2);
     maxGpus        = GetEnvVar("UT_MAX_GPUS"    , numDetectedGpus);
-    onlyPow2Gpus   = GetEnvVar("UT_POW2_GPUS"   , false);
     processMask    = GetEnvVar("UT_PROCESS_MASK", UT_SINGLE_PROCESS | UT_MULTI_PROCESS);
     verbose        = GetEnvVar("UT_VERBOSE"     , 0);
     printValues    = GetEnvVar("UT_PRINT_VALUES", 0);
@@ -152,13 +151,12 @@ namespace RcclUnitTesting
     // Total number of reduction ops
     int numOps = ncclNumOps;
 
+    bool cpxMode = false;
     if(isGfx94) {
-      bool cpxMode = false;
       getDeviceMode(&cpxMode);
-      if(cpxMode) {
-        onlyPow2Gpus = true;
-      }
     }
+    onlyPow2Gpus   = GetEnvVar("UT_POW2_GPUS"   , cpxMode);
+    
     std::vector<std::string> redOpStrings = GetEnvVarsList("UT_REDOPS");
     for (auto s : redOpStrings)
     {

--- a/test/common/EnvVars.cpp
+++ b/test/common/EnvVars.cpp
@@ -155,8 +155,8 @@ namespace RcclUnitTesting
     if(isGfx94) {
       getDeviceMode(&cpxMode);
     }
-    onlyPow2Gpus   = GetEnvVar("UT_POW2_GPUS"   , cpxMode);
-    
+    onlyPow2Gpus   = GetEnvVar("UT_POW2_GPUS"   , cpxMode); //default value set based on whether system in CPX mode or not. UT_POW2_GPUS set by user overrides it.
+
     std::vector<std::string> redOpStrings = GetEnvVarsList("UT_REDOPS");
     for (auto s : redOpStrings)
     {

--- a/test/common/EnvVars.cpp
+++ b/test/common/EnvVars.cpp
@@ -155,7 +155,8 @@ namespace RcclUnitTesting
     if(isGfx94) {
       getDeviceMode(&cpxMode);
     }
-    onlyPow2Gpus   = GetEnvVar("UT_POW2_GPUS"   , cpxMode); //default value set based on whether system in CPX mode or not. UT_POW2_GPUS set by user overrides it.
+    // Test only pow2 number of GPUs for cpx mode to reduce the runtime for UT
+    onlyPow2Gpus   = GetEnvVar("UT_POW2_GPUS"   , cpxMode); // Default value set based on whether system is in CPX mode. UT_POW2_GPUS set by user overrides it.
 
     std::vector<std::string> redOpStrings = GetEnvVarsList("UT_REDOPS");
     for (auto s : redOpStrings)


### PR DESCRIPTION
## Details

**Work item:** "Internal"

**What were the changes?** 
Enabling Unit Tests to run for CPX mode. 

**Why were the changes made?** 
Currently UT tests all possible numbers of GPUs up to 16. If same scheme is used to test CPX mode, UT will take forever to complete. 

**How was the outcome achieved?**  
1) Detect if system is in CPX mode.
2) If yes, only test pow2 number of GPUs.

**Additional Documentation:**  
None.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
