### PR TITLE
Hide or fix all build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(DEFAULT_GPUS
 include(CheckIncludeFiles)
 include(CheckSymbolExists)
 include(cmake/Dependencies.cmake) # GTest, rocm-cmake, rocm_local_targets
+include(cmake/CheckSymbolExistsNoWarn.cmake)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/cmake/CheckSymbolExistsNoWarn.cmake
+++ b/cmake/CheckSymbolExistsNoWarn.cmake
@@ -1,0 +1,40 @@
+# MIT License
+#
+# Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# These overrides are due to CMake CHECK_SYMBOL_EXISTS modifying CMAKE_CXX_FLAGS to do a test compile,
+# while ROCMChecks gives a warning if this variable is modified manually without a target.
+
+# We now choose to disable ROCMChecks for this one case.
+
+set(DISABLE_ROCM_CHECK OFF)
+
+function(rocm_check_toolchain_var var access value list_file)
+  if(NOT DISABLE_ROCM_CHECK)
+    _rocm_check_toolchain_var("${var}" "${access}" "${value}" "${list_file}")
+  endif()
+endfunction()
+
+macro(CHECK_SYMBOL_EXISTS)
+  set(DISABLE_ROCM_CHECK ON)
+  _check_symbol_exists(${ARGN})
+  set(DISABLE_ROCM_CHECK OFF)
+endmacro()

--- a/src/graph/rome_models.cc
+++ b/src/graph/rome_models.cc
@@ -1743,10 +1743,10 @@ int checkAlltoallWidth(struct rcclRomeModel *romeTopo) {
 }
 
 ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, const char *ringBase) {
-  #define NUMA_CPUS 2
-  #define NUMA_GPUS 4
-  #define NUMA_PERMUTE_COUNT 24
-  #define TOTAL_PERMUTE_COUNT (NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT)
+  constexpr int NUMA_CPUS = 2;
+  constexpr int NUMA_GPUS = 4;
+  constexpr int NUMA_PERMUTE_COUNT = 24;
+  constexpr int TOTAL_PERMUTE_COUNT = (NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT);
 
   static char ringRemap[256];
   int i;
@@ -2106,10 +2106,10 @@ ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* 
 }
 
 ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* graph) {
-  #define NUMA_CPUS 4
-  #define NUMA_GPUS 4
-  #define NUMA_PERMUTE_COUNT 24
-  #define TOTAL_PERMUTE_COUNT (NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT)
+  constexpr int NUMA_CPUS = 4;
+  constexpr int NUMA_GPUS = 4;
+  constexpr int NUMA_PERMUTE_COUNT = 24;
+  constexpr int TOTAL_PERMUTE_COUNT = (NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT);
 
   static char ringRemap[256];
   int i;
@@ -2244,8 +2244,8 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
 }
 
 ncclResult_t parse4H4P(struct ncclTopoSystem* system, struct ncclTopoGraph* graph) {
-  #define NUM_HIVES 4
-  #define HIVE_GPUS 4
+  constexpr int NUM_HIVES = 4;
+  constexpr int HIVE_GPUS = 4;
 
   static char ringRemap[256];
 

--- a/src/graph/rome_models.cc
+++ b/src/graph/rome_models.cc
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include <math.h>
 #include <sys/time.h>
 #include <algorithm>
+#include <vector>
 #include <string.h>
 #include "rome_models.h"
 
@@ -1750,9 +1751,9 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   static char ringRemap[256];
   int i;
 
-  int ngpus = system->nodes[GPU].count;
-  int ncpus = system->nodes[CPU].count;
-  int nnets = system->nodes[NET].count;
+  const int ngpus = system->nodes[GPU].count;
+  const int ncpus = system->nodes[CPU].count;
+  const int nnets = system->nodes[NET].count;
 
   // number of GPUs and NICs on each numa node is used as first screening pattern
   struct rcclRomeModel romeTopo;
@@ -1771,11 +1772,12 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   int *all_gpu_permutations = (int *)malloc(TOTAL_PERMUTE_COUNT*NUMA_CPUS*NUMA_GPUS*sizeof(int));
   struct timeval tvs, tve;
   gettimeofday(&tvs, NULL);
+  std::vector<int> r(ngpus), g(ngpus);
   for (i = 0; i < sizeof(romeTopoModels)/sizeof(romeTopoModels[0]); i++) {
     if (romeTopo.nCpus != romeTopoModels[i].nCpus || romeTopo.nGpus != romeTopoModels[i].nGpus ||
       romeTopo.nNics != romeTopoModels[i].nNics || romeTopo.nLinks != romeTopoModels[i].nLinks) continue;
     if (strcmp(romeTopoModels[i].pattern, pattern)) continue;
-    int j, r[ngpus], g[ngpus];
+    int j;
     int numa_gpu_permutations[NUMA_CPUS][NUMA_PERMUTE_COUNT][NUMA_GPUS];
     if (isAlltoall != checkAlltoallWidth(romeTopoModels+i))
       continue;
@@ -1794,12 +1796,12 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
         if (romeTopo.gpuNuma[k] != j) continue;
         g[(2+cnt++)%ngpusPerNuma] = k;
       }
-      std::sort(g, g+ngpusPerNuma);
+      std::sort(g.begin(), g.begin()+ngpusPerNuma);
       do {
         for (int n = 0; n < ngpusPerNuma; n++)
           numa_gpu_permutations[j][npermute][n] = g[n];
         npermute++;
-      } while (std::next_permutation(g, g+ngpusPerNuma));
+      } while (std::next_permutation(g.begin(), g.begin()+ngpusPerNuma));
       if (npermute != NUMA_PERMUTE_COUNT) break;
     }
     if (j < ncpus) continue;
@@ -2112,9 +2114,9 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   static char ringRemap[256];
   int i;
 
-  int ngpus = system->nodes[GPU].count;
-  int ncpus = system->nodes[CPU].count;
-  int nnets = system->nodes[NET].count;
+  const int ngpus = system->nodes[GPU].count;
+  const int ncpus = system->nodes[CPU].count;
+  const int nnets = system->nodes[NET].count;
 
   // only valid on Rome
   int arch, vendor, model;
@@ -2135,11 +2137,12 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   int *all_gpu_permutations = (int *)malloc(TOTAL_PERMUTE_COUNT*NUMA_CPUS*NUMA_GPUS*sizeof(int));
   struct timeval tvs, tve;
   gettimeofday(&tvs, NULL);
+  std::vector<int> r(ngpus), g(ngpus);
   for (i = 0; i < sizeof(romeTopoModels)/sizeof(romeTopoModels[0]); i++) {
     if (romeTopo.nCpus != romeTopoModels[i].nCpus || romeTopo.nGpus != romeTopoModels[i].nGpus ||
       romeTopo.nNics != romeTopoModels[i].nNics || romeTopo.nLinks != romeTopoModels[i].nLinks) continue;
     if (strcmp(romeTopoModels[i].pattern, pattern)) continue;
-    int j, r[ngpus], g[ngpus];
+    int j;
     int numa_gpu_permutations[NUMA_CPUS][NUMA_PERMUTE_COUNT][NUMA_GPUS];
     // permute GPUs for each CPU NUMA nodes
     for (j = 0; j < ncpus; j++) {
@@ -2156,12 +2159,12 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
         if (romeTopo.gpuNuma[k] != j) continue;
         g[(2+cnt++)%ngpusPerNuma] = k;
       }
-      std::sort(g, g+ngpusPerNuma);
+      std::sort(g.begin(), g.begin()+ngpusPerNuma);
       do {
         for (int n = 0; n < ngpusPerNuma; n++)
           numa_gpu_permutations[j][npermute][n] = g[n];
         npermute++;
-      } while (std::next_permutation(g, g+ngpusPerNuma));
+      } while (std::next_permutation(g.begin(), g.begin()+ngpusPerNuma));
       if (npermute != NUMA_PERMUTE_COUNT) break;
     }
     if (j < ncpus) continue;
@@ -2246,8 +2249,8 @@ ncclResult_t parse4H4P(struct ncclTopoSystem* system, struct ncclTopoGraph* grap
 
   static char ringRemap[256];
 
-  int ngpus = system->nodes[GPU].count;
-  int nnets = system->nodes[NET].count;
+  const int ngpus = system->nodes[GPU].count;
+  const int nnets = system->nodes[NET].count;
 
   // only valid on Rome
   int arch, vendor, model;
@@ -2263,7 +2266,7 @@ ncclResult_t parse4H4P(struct ncclTopoSystem* system, struct ncclTopoGraph* grap
   // only match for system with 16 GPUs
   if (ngpus != NUM_HIVES*HIVE_GPUS || nnets != NUM_HIVES*HIVE_GPUS) return ncclSuccess;
 
-  int g_hives[ngpus], n_hives[nnets];
+  std::vector<int> g_hives(ngpus), n_hives(nnets);
   int ng_hives[NUM_HIVES];
 
   // try to sort GPUs into hives
@@ -2334,6 +2337,6 @@ ncclResult_t parse4H4P(struct ncclTopoSystem* system, struct ncclTopoGraph* grap
     system->type |= RCCL_TOPO_4P2H_ROME;
   parseOptions(system, rome_model_68.options);
   // create 4P4H based on reference and remapped ids
-  NCCLCHECK(parseGraph(rome_model_68.ringBase, system, graph, g_hives, n_hives, false));
+  NCCLCHECK(parseGraph(rome_model_68.ringBase, system, graph, g_hives.data(), n_hives.data(), false));
   return ncclSuccess;
 }

--- a/test/AllReduceTests.cpp
+++ b/test/AllReduceTests.cpp
@@ -116,7 +116,7 @@ namespace RcclUnitTesting
         std::vector<bool>           const inPlaceList     = {false};
         std::vector<bool>           const managedMemList  = {false};
         std::vector<bool>           const useHipGraphList = {false, true};
-        std::vector<char *>         const channelList     = {"84", "112"};
+        std::vector<const char *>   const channelList     = {"84", "112"};
         bool                        const enableSweep     = false; 
         for (auto channel : channelList) {
           setenv("NCCL_MIN_NCHANNELS", channel, 1);

--- a/test/AllToAllTests.cpp
+++ b/test/AllToAllTests.cpp
@@ -100,7 +100,7 @@ namespace RcclUnitTesting
         std::vector<bool>           const inPlaceList     = {false};
         std::vector<bool>           const managedMemList  = {false};
         std::vector<bool>           const useHipGraphList = {false, true};
-        std::vector<char *>         const channelList     = {"112"}; 
+        std::vector<const char *>   const channelList     = {"112"}; 
         bool                        const enableSweep     = false;
         for (auto channel : channelList) {
           setenv("NCCL_MIN_NCHANNELS", channel, 1);


### PR DESCRIPTION
## Details
**What were the changes?**  
- Fix variable-length arrays warnings by switching to `std::vector`
- Fixed some const-correctness in unit tests
- Fixed macro redefinition warnings from `#define` inside functions by switching to `constexpr int`
- Disabled cmake warnings due to `check_symbol_exists` modifying `CMAKE_CXX_FLAGS`

**Why were the changes made?**  
Compile warnings are problematic.

**Additional Notes**
CI builds will still show CMake warnings because they use CMake 3.25, and the behaviour is different in 3.30.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
