### PR TITLE
Moved `mscclpp_ncclGetUniqueId` call into `ncclCommInitRankFunc`

### DIFF
--- a/src/include/mscclpp/mscclpp_nccl.h
+++ b/src/include/mscclpp/mscclpp_nccl.h
@@ -49,4 +49,6 @@ namespace std {
 
 bool operator ==(const ncclUniqueId& a, const ncclUniqueId& b);
 
+bool mscclppCommCompatible(ncclComm_t comm);
+
 #endif

--- a/src/init.cc
+++ b/src/init.cc
@@ -1970,7 +1970,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 #endif
   if (rcclParamMscclppEnabled()) {
 #ifdef ENABLE_MSCCLPP
-    if (mscclEnabled() && comm->topo->mscclEnabled && mscclppCommCompatible(comm)) {
+    if (mscclEnabled() && (comm->topo->mscclEnabled || mscclForceEnabled()) && mscclppCommCompatible(comm)) {
       hipDeviceProp_t devProp;
       CUDACHECK(hipGetDeviceProperties(&devProp, cudaDev));
       comm->mscclppCompatible = IsArchMatch(devProp.gcnArchName, "gfx94");

--- a/src/init.cc
+++ b/src/init.cc
@@ -1970,7 +1970,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 #endif
   if (rcclParamMscclppEnabled()) {
 #ifdef ENABLE_MSCCLPP
-    if (mscclppCommCompatible(comm)) {
+    if (mscclEnabled() && comm->topo->mscclEnabled && mscclppCommCompatible(comm)) {
       hipDeviceProp_t devProp;
       CUDACHECK(hipGetDeviceProperties(&devProp, cudaDev));
       comm->mscclppCompatible = IsArchMatch(devProp.gcnArchName, "gfx94");

--- a/src/misc/msccl/msccl_lifecycle.cc
+++ b/src/misc/msccl/msccl_lifecycle.cc
@@ -84,6 +84,12 @@ static bool mscclCommCompatible(ncclComm_t comm) {
   return true;
 }
 
+#ifdef ENABLE_MSCCLPP
+bool mscclppCommCompatible(ncclComm_t comm) {
+  return mscclCommCompatible(comm);
+}
+#endif
+
 const char *mscclFuncNames[] = {
             "mscclFuncReduce",
             "mscclFuncBroadcast",


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**What were the changes?**  
Moved call to `mscclpp_ncclGetUniqueId` into `ncclCommInitRankFunc` to avoid setting up transport early in environments where MSCCL++ isn't valid. Allow it to use `mscclEnabled` flags as well as `mscclppCommCompatible` to add the MSCCL logic to disable on multi-node.

**Why were the changes made?**  
MSCCL++ was being enabled on multi-node runs where it isn't valid.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
