### PR TITLE
force GPU_Target to change and running ASAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ else()
   set(SUPPORTED_GPUS ${DEFAULT_GPUS})
 endif()
 
-set(GPU_TARGETS "${SUPPORTED_GPUS}" CACHE STRING "GPU targets to compile for.")
+set(GPU_TARGETS "${SUPPORTED_GPUS}" CACHE STRING "GPU targets to compile for." FORCE)
 message(STATUS "Compiling for ${GPU_TARGETS}")
 
 ## NOTE: Reload rocm-cmake in order to update GPU_TARGETS


### PR DESCRIPTION
## Details
Change so that we force the gpu_targets to have xnack+ when address sanitizer is build

**Why were the changes made?**  
Currently of somebody sets both AMDGPU_TARGETS and GPU_TARGETS Cmake does not force xnack as it is supposed to

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
