### PR TITLE
Fix regression in multi-thread mode even while MSCCL is disabled

### DIFF
--- a/src/graph/connect.cc
+++ b/src/graph/connect.cc
@@ -690,7 +690,9 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   if (mscclEnabled() && (comm->topo->mscclEnabled || mscclForceEnabled())) {
     int mscclNumChannelsRequired = maxNchannels;
     mscclSchedulerInit(comm, &mscclNumChannelsRequired);
-    minNchannels = std::max(minNchannels, mscclNumChannelsRequired);
+    if (comm->mscclCompatible) {
+      minNchannels = std::max(minNchannels, mscclNumChannelsRequired);
+    }
   }
 
   // Honor NCCL_MIN_NRINGS/NCCL_MAX_NRINGS.


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** Internal

**What were the changes?**  
When MSCCL is enabled, only adjust `minNchannels` if `mscclCompatible` is true.

**Why were the changes made?**  
Even if MSCCL is enabled, we do a further check for compatibility and set the `mscclCompatible` flag. MSCCL will only be used in this case, so we shouldn't do any further adjustments if it's not.

**Additional Documentation:**  
This was causing a significant performance regression.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
