### PR TITLE
Fix MSCCLPP seg-fault when RCCL_MSCCL_ENABLE_SINGLE_PROCESS is enabled in MT mode

### DIFF
--- a/src/misc/msccl/msccl_lifecycle.cc
+++ b/src/misc/msccl/msccl_lifecycle.cc
@@ -84,7 +84,7 @@ static bool mscclCommCompatible(ncclComm_t comm) {
     // Single process usage enabled. No need to guard against multi-thread.
     return true;
   }
-  return mscclIsMultithreadedComm(comm);
+  return allProcessHostsUnique(comm);
 }
 
 #ifdef ENABLE_MSCCLPP 

--- a/src/misc/msccl/msccl_lifecycle.cc
+++ b/src/misc/msccl/msccl_lifecycle.cc
@@ -68,15 +68,15 @@ static bool mscclIsMultithreadedComm(ncclComm_t comm) {
   for (int i = 0; i < comm->nRanks; i++) {
     uint64_t hostHash = comm->peerInfo[i].hostHash;
     uint64_t pidHash = comm->peerInfo[i].pidHash;
-    if (hostHashToPidHashes.find(hostHash) != hostHashToPidHashes.end()){
-      auto &pidHashSet = hostHashToPidHashes[hostHash];
-      if (pidHashSet.find(pidHash) != pidHashSet.end()){
+    if (hostHashToPidHashes.find(hostHash) != hostHashToPidHashes.end()) {
+      auto& pidHashSet = hostHashToPidHashes[hostHash];
+      if (pidHashSet.find(pidHash) != pidHashSet.end()) {
         return false;
       }
     }
     hostHashToPidHashes[hostHash].insert(pidHash);
   }
-  return true;  
+  return true;
 }
 
 static bool mscclCommCompatible(ncclComm_t comm) {

--- a/src/misc/msccl/msccl_lifecycle.cc
+++ b/src/misc/msccl/msccl_lifecycle.cc
@@ -63,7 +63,7 @@ bool mscclAvailable(int rank) {
   return mscclEnabled() && mscclInitialized(rank);
 }
 
-static bool mscclIsMultithreadedComm(ncclComm_t comm) {
+static bool allProcessHostsUnique(ncclComm_t comm) {
   std::map<uint64_t, std::set<uint64_t>> hostHashToPidHashes;
   for (int i = 0; i < comm->nRanks; i++) {
     uint64_t hostHash = comm->peerInfo[i].hostHash;
@@ -89,7 +89,7 @@ static bool mscclCommCompatible(ncclComm_t comm) {
 
 #ifdef ENABLE_MSCCLPP 
 bool mscclppCommCompatible(ncclComm_t comm) {
-  return mscclIsMultithreadedComm(comm);
+  return allProcessHostsUnique(comm);
 }
 #endif
 

--- a/src/misc/msccl/msccl_lifecycle.cc
+++ b/src/misc/msccl/msccl_lifecycle.cc
@@ -63,7 +63,7 @@ bool mscclAvailable(int rank) {
   return mscclEnabled() && mscclInitialized(rank);
 }
 
-static bool mscclIsMultithreadedComm(ncclComm_t comm) {
+static bool allProcessHostsUnique(ncclComm_t comm) {
   std::map<uint64_t, std::set<uint64_t>> hostHashToPidHashes;
   for (int i = 0; i < comm->nRanks; i++) {
     uint64_t hostHash = comm->peerInfo[i].hostHash;
@@ -84,12 +84,12 @@ static bool mscclCommCompatible(ncclComm_t comm) {
     // Single process usage enabled. No need to guard against multi-thread.
     return true;
   }
-  return mscclIsMultithreadedComm(comm);
+  return allProcessHostsUnique(comm);
 }
 
 #ifdef ENABLE_MSCCLPP 
 bool mscclppCommCompatible(ncclComm_t comm) {
-  return mscclIsMultithreadedComm(comm);
+  return allProcessHostsUnique(comm);
 }
 #endif
 


### PR DESCRIPTION
## Details

**Work item:** internal

**What were the changes?**  
Disable MSCCLPP in Multithreaded mode even when the newly introduced single process mode is forced.

**Why were the changes made?**  
A segfault is triggered upon setting `RCCL_MSCCL_ENABLE_SINGLE_PROCESS`

**How was the outcome achieved?**  
Making sure that only the MSCCL path can bypass MT mode check

**Additional Documentation:**  

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
