### PR TITLE
Fixing install.sh to properly accept spaces in ONLY_FUNCS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -388,7 +388,7 @@ else
 fi
 
 # Add common CMake options
-cmake_common_options="${cmake_common_options} -DROCM_PATH=${ROCM_PATH} -DONLY_FUNCS=${ONLY_FUNCS} ${enable_ninja}"
+cmake_common_options="${cmake_common_options} -DROCM_PATH=${ROCM_PATH} ${enable_ninja}"
 
 # Build RCCL-UnitTests, if enabled
 if [[ "${build_tests}" == true ]] || ([[ "${run_tests}" == true ]] && [[ ! -x ./test/rccl-UnitTests ]]); then
@@ -398,7 +398,7 @@ fi
 # Initiate RCCL CMake
 # Passing NPKIT_FLAGS separately (not as part of ${cmake_common_options}) as
 # ${npkit_options} need to be passed "as-is" i.e. with `-D` to CMakeLists.txt
-${cmake_executable} ${cmake_common_options} -DNPKIT_FLAGS="${npkit_options}" ../../.
+${cmake_executable} ${cmake_common_options} -DNPKIT_FLAGS="${npkit_options}" -DONLY_FUNCS="${ONLY_FUNCS}" ../../.
 check_exit_code "$?"
 
 # Enable verbose output from Makefile


### PR DESCRIPTION
## Details
ONLY_FUNCS was not working with install.sh because of the spaces in the variables
It would only build pass the first token into the generator

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Change how ONLY_FUNCS is passed in 

**Why were the changes made?**  
To be able to call things such as: 
ONLY_FUNCS="AllReduce RING SIMPLE Sum float" ./install.sh -l
and only have it generate the correct collectives

**How was the outcome achieved?**  
Moved the ONLY_FUNCS definition out of the common args

**Additional Documentation:**  
None

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
