### PR TITLE
Remove unhandled switch case fall-through in MSCCL

### DIFF
--- a/src/misc/msccl/msccl_lifecycle.cc
+++ b/src/misc/msccl/msccl_lifecycle.cc
@@ -595,6 +595,7 @@ ncclResult_t mscclEnqueueCheck(
         }
       threadLocalStatus.groupStatus = mscclGroupUnsupportedOp;
       NCCLCHECK(mscclFallBackSavedParams());
+      break;
     case mscclGroupUnsupportedOp:
       NCCLCHECK(mscclFallBackSavedParams());
       break;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** #1254

**What were the changes?**  
Added missing `break` in switch case.

**Why were the changes made?**  
Switch case was falling through unhandled.

**Additional Documentation:**  
Need to determine if this fall-through was intentional.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
