### PR TITLE
[BUILD] Enable MSCCL++ for gfx942 variants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,8 +287,9 @@ if (HAVE_KERNARG_PRELOAD)
 endif()
 
 ## Disable building MSCCL++ if the build environment is invalid
+## Currently MSCCL++ is supported only on gfx942
 if (ENABLE_MSCCLPP)
-  if(NOT "gfx942" IN_LIST GPU_TARGETS)
+  if(NOT ("gfx942" IN_LIST GPU_TARGETS OR "gfx942:xnack-" IN_LIST GPU_TARGETS OR "gfx942:xnack+" IN_LIST GPU_TARGETS))
     set(ENABLE_MSCCLPP OFF)
     message(WARNING "Can only build MSCCL++ for gfx942; disabling MSCCL++ build")
   endif()


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Enable building MSCCL++ for `gfx942` variants like `gfx942:xnack-` and `gfx942:xnack+`.

**Why were the changes made?**  
MSCCL++ is not built if the target GPU architecture(s) for `gfx942` has `xnack` modifiers.

**How was the outcome achieved?**  
Check for `gfx942:xnack-` and `gfx942:xnack+`, in addition to `gfx942` in `GPU_TARGETS`

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
