### PR TITLE
Remove 0 size UBR UT

### DIFF
--- a/test/SendRecvTests.cpp
+++ b/test/SendRecvTests.cpp
@@ -90,7 +90,7 @@ namespace RcclUnitTesting
 
     // Configuration
     std::vector<ncclDataType_t> const& dataTypes       = {ncclInt32, ncclFloat16, ncclFloat64};
-    std::vector<int>            const  numElements     = {1048576, 53327, 1024, 0};
+    std::vector<int>            const  numElements     = {1048576, 53327, 1024};
     bool                        const  inPlace         = false;
     bool                        const  useManagedMem   = false;
     bool                        const  userRegistered  = true;


### PR DESCRIPTION
ncclCommRegister, required for UBR, will call IB dmabuf regMr directly which forbids 0 size message

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** Internal

**What were the changes?**  
_One sentence describing the work done._

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
