### PR TITLE
[CI] Temporarily disable RCCL UT Standalone.RegressionTiming in CI

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -17,6 +17,9 @@ def runCompileCommand(platform, project, jobName)
 
 def runTestCommand (platform, project, gfilter, envars)
 {
+    // Temporarily disable Standalone.RegressionTiming for RCCL CI
+    gfilter = "*:-Standalone.Regression*"
+
     String sudo = auxiliary.sudo(platform.jenkinsLabel)
 
     def command = """#!/usr/bin/env bash


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:**
Internal

**What were the changes?**  
Modify `--gtest_filter` for RCCL UnitTests in **CI** to temporarily skip `Standalone.RegressionTiming`.

**Why were the changes made?**  
Recent CI failures (reported as `memory access faults` with RCCL UT) are preventing the active use of RCCL CI checks.\
This change will be reverted as soon as build elements are rectified.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
