### PR TITLE
Enable MSCCLPP use in CPX mode

### DIFF
--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -63,7 +63,10 @@ if(ENABLE_MSCCLPP)
                 WORKING_DIRECTORY ${MSCCLPP_SOURCE}
             )
         endif()
-        
+        execute_process(
+           COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/cpx.patch
+           WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+        ) 
         message(STATUS "Building mscclpp only for gfx942.")
         
         mscclpp_cmake_arg(CMAKE_PREFIX_PATH)

--- a/ext-src/cpx.patch
+++ b/ext-src/cpx.patch
@@ -1,0 +1,12 @@
+diff --git a/src/numa.cc b/src/numa.cc
+index d72c99e..16c903d 100644
+--- a/src/numa.cc
++++ b/src/numa.cc
+@@ -26,6 +26,7 @@ namespace mscclpp {
+ 
+ MSCCLPP_API_CPP int getDeviceNumaNode(int cudaDev) {
+   std::string busId = getBusId(cudaDev);
++  busId[busId.length() - 1] = '0';
+   std::string file_str = "/sys/bus/pci/devices/" + busId + "/numa_node";
+   std::ifstream file(file_str);
+   int numaNode;


### PR DESCRIPTION
This PR enables the use of MSCCLPP in CPX mode for 8 GPUs.

## Details
RCCL by default cannot invoke MSCCLPP in CPX mode. This would lead to a failure from MSCCLPP. This PR fixes the MSCCLPP failure and enables RCCL to invoke MSCCLPP allreduce on MI300X in CPX mode.

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
