### PR TITLE
[TRANSPORT] Add RCCL_FORCE_ENABLE_GDRDMA for debugging

### DIFF
--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -557,12 +557,24 @@ ncclResult_t ncclIbDevices(int* ndev) {
   return ncclSuccess;
 }
 
+// Introduce RCCL_FORCE_ENABLE_GDRDMA to force load GPU-NIC RDMA module
+// Use ONLY for debugging!
+RCCL_PARAM(ForceEnableGdrdma, "FORCE_ENABLE_GDRDMA", -1);
+
 // Detect whether GDR can work on a given NIC with the current CUDA device
 // Returns :
 // ncclSuccess : GDR works
 // ncclSystemError : no module or module loaded but not supported by GPU
 ncclResult_t ncclIbGdrSupport() {
   static int moduleLoaded = -1;
+
+  if (rcclParamForceEnableGdrdma() == 1) {
+    // RCCL_FORCE_ENABLE_GDRDMA=1 enables GPU-NIC RDMA only from RCCL-side
+    // Requires support from NIC driver modules
+    // Use ONLY for debugging!
+    moduleLoaded = 1;
+    INFO(NCCL_INIT, "RCCL_FORCE_ENABLE_GDRDMA = 1, so explicitly setting moduleLoaded = 1");
+  }
 
   if (moduleLoaded == -1) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Add a RCCL environment variable `RCCL_FORCE_ENABLE_GDRDMA` to force load the GPU-NIC RDMA module in RCCL. **To be only used for debugging.**

**Why were the changes made?**  
When testing/debugging multi-node RCCL runs on new OS/linux kernels, this environment variable can help force enable GPU-NIC RDMA.

**How was the outcome achieved?**  
Setting `RCCL_FORCE_ENABLE_GDRDMA=1` will force-set `moduleLoaded=1`, which will enable GPU-NIC RDMA from RCCL-side. Still requires support from NIC driver modules.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
