### PR TITLE
disabled wbinvl1 for gfx9x on ll128

### DIFF
--- a/src/device/prims_ll128.h
+++ b/src/device/prims_ll128.h
@@ -13,7 +13,7 @@
 #define NCCL_LL128_FLAGTHREAD (NCCL_LL128_LINEELEMS-1)
 
 #ifndef RCCL_USE_WBINVL1_VOL
-#if defined(__GFX8__) || defined(__GFX9__)
+#if defined(__GFX8__) || defined(__gfx906__) || defined(__gfx908__) || defined(__gfx90a__)
 #define RCCL_USE_WBINVL1_VOL 1
 #else
 #define RCCL_USE_WBINVL1_VOL 0


### PR DESCRIPTION
## Details
Built in is no longer valid on gfx9 so it creates compilations issues. ll128 will need rework to be reenabled at gfx9x



## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
