### PR TITLE
Increase default number of channels for MI300A in multi-node scenario.

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -1449,16 +1449,16 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     int managed = 0;
     CUDACHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeDirectManagedMemAccessFromHost, 0));
     if (managed && nNodes > 1) {
+      // This forces the minimum channels to 24
       allGather3Data[rank].nc = 6;
     } else {
-
-    // MI300
-    if (nranks == 2)
-      // NCCL_MIN_NCHANNELS=32
-      allGather3Data[rank].nc = 16;
-    else if (nranks == 4)
-      // NCCL_MIN_NCHANNELS=24
-      allGather3Data[rank].nc = 4;
+      // MI300X
+      if (nranks == 2)
+        // NCCL_MIN_NCHANNELS=32
+        allGather3Data[rank].nc = 16;
+      else if (nranks == 4)
+        // NCCL_MIN_NCHANNELS=24
+        allGather3Data[rank].nc = 4;
     }
   }
 

--- a/src/init.cc
+++ b/src/init.cc
@@ -1444,7 +1444,6 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   if (ringGraph.nChannels > MAXCHANNELS/2)
     allGather3Data[rank].nc = 1;
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx94")) {
-
     // Multi-node MI300A
     int managed = 0;
     CUDACHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeDirectManagedMemAccessFromHost, 0));

--- a/src/init.cc
+++ b/src/init.cc
@@ -1448,8 +1448,8 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     // Multi-node MI300A
     int managed = 0;
     CUDACHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeDirectManagedMemAccessFromHost, 0));
-    if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx94") && managed && comm->nNodes > 1) {
-      allGather3Data[rank].nc = 3; // Default is 8, with 3 as a multiplier = 24 channels.
+    if (managed && nNodes > 1) {
+      allGather3Data[rank].nc = 6;
     } else {
 
     // MI300


### PR DESCRIPTION
This commit changed the default of channels of MI300A from 8 upto 24. This helps bring up multi-node performance to the expected level.

## Details
MI300A is not in the list of pre-defined rome model. This caused RCCL to fallback and set the default number of channels to 8, which is not sufficient to saturate the bandwidth. Increasing this default number to 24 brings the performance up to expected number.

**Work item:** Internal

**What were the changes?**  
Change the default number of channels for MI300A in multi-node scenario.

**Why were the changes made?**  
Performance is not at expected level.

