### PR TITLE
[BUILD] Require use of Python3 interpreter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,15 +591,24 @@ endforeach()
 
 # Generate device/host tables and all the collective functions that are going to be in librccl.so
 #==================================================================================================
-find_package(PythonInterp REQUIRED)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+if (NOT Python3_FOUND)
+  message(FATAL_ERROR "RCCL requires Python3 for generating host/device tables")
+endif()
+
 set(GEN_DIR "${HIPIFY_DIR}/gensrc")
 
 # Execute the python script to generate required files
 execute_process(
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/device/generate.py ${GEN_DIR} ${IFC_ENABLED} ${COLLTRACE} ${ENABLE_MSCCL_KERNEL} ${ONLY_FUNCS}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    RESULT_VARIABLE result
+    RESULT_VARIABLE gen_py_result
+    ERROR_VARIABLE gen_py_error
 )
+if (gen_py_result)
+  message(SEND_ERROR "Error: ${gen_py_error}")
+  message(FATAL_ERROR "${CMAKE_SOURCE_DIR}/src/device/generate.py failed")
+endif()
 
 # Find the generated files in the output directory
 file(GLOB GENERATED_FILES "${GEN_DIR}/*")


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Use the Python3 interpreter in the CMake build process to generate host/device tables.

**Why were the changes made?**  
`src/device/generate.py` fails with syntax errors if the default Python interpreter is Python2.

**How was the outcome achieved?**  
Replace `find_package(PythonInterp REQUIRED)` with `find_package(Python3 COMPONENTS Interpreter)` in CMakeLists.txt.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
