### PR TITLE
Dynamically select unroll factor to build for when targeting local arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,7 +600,7 @@ set(GEN_DIR "${HIPIFY_DIR}/gensrc")
 
 # Execute the python script to generate required files
 execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/device/generate.py ${GEN_DIR} ${IFC_ENABLED} ${COLLTRACE} ${ENABLE_MSCCL_KERNEL} ${ONLY_FUNCS}
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/device/generate.py ${GEN_DIR} ${IFC_ENABLED} ${COLLTRACE} ${ENABLE_MSCCL_KERNEL} ${BUILD_LOCAL_GPU_TARGET_ONLY} ${ONLY_FUNCS}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     RESULT_VARIABLE gen_py_result
     ERROR_VARIABLE gen_py_error

--- a/src/device/common.cu
+++ b/src/device/common.cu
@@ -18,17 +18,11 @@ struct RunWorkNop {
 };
 
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic(struct ncclDevComm* comm, struct channelMasks channelMask, struct ncclWork* workHead) {
-  ncclKernelMain<-1, RunWorkNop, false, 2>(comm, channelMask, workHead);
-}
-__launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_4(struct ncclDevComm* comm, struct channelMasks channelMask, struct ncclWork* workHead) {
-  ncclKernelMain<-1, RunWorkNop, false, 4>(comm, channelMask, workHead);
+  ncclKernelMain<-1, RunWorkNop, false>(comm, channelMask, workHead);
 }
 #ifdef ENABLE_COLLTRACE
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Generic(struct ncclDevComm* comm, struct channelMasks channelMask, struct ncclWork* workHead) {
-  ncclKernelMain<-1, RunWorkNop, true, 2>(comm, channelMask, workHead);
-}
-__launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Generic_4(struct ncclDevComm* comm, struct channelMasks channelMask, struct ncclWork* workHead) {
-  ncclKernelMain<-1, RunWorkNop, true, 4>(comm, channelMask, workHead);
+  ncclKernelMain<-1, RunWorkNop, true>(comm, channelMask, workHead);
 }
 #endif
 

--- a/src/device/common.h
+++ b/src/device/common.h
@@ -227,7 +227,7 @@ static __forceinline__ __device__ void ncclRedopPtrDeref(struct ncclWorkElem* we
   }
 }
 
-template<int SpecializedFnId, typename SpecializedRunWork, bool COLLTRACE, int COLL_UNROLL>
+template<int SpecializedFnId, typename SpecializedRunWork, bool COLLTRACE>
 __forceinline__ __device__ void ncclKernelMain(struct ncclDevComm* comm, struct channelMasks channelMask, struct ncclWork* workHead) {
   const int tid = threadIdx.x;
   int x = tid;
@@ -346,15 +346,9 @@ __forceinline__ __device__ void ncclKernelMain(struct ncclDevComm* comm, struct 
       SpecializedRunWork().run(&ncclShmem.work);
     } else {
 #ifdef USE_INDIRECT_FUNCTION_CALL
-      if (COLL_UNROLL == 4)
-        ncclDevFuncTable_4[ncclShmem.work.header.funcIndex]();
-      else
-        ncclDevFuncTable[ncclShmem.work.header.funcIndex]();
+      ncclDevFuncTable[ncclShmem.work.header.funcIndex]();
 #else
-      if (COLL_UNROLL == 4)
-        NCCL_CALL_FUNCTIONS_4(ncclShmem.work.header.funcIndex);
-      else
-        NCCL_CALL_FUNCTIONS(ncclShmem.work.header.funcIndex);
+      NCCL_CALL_FUNCTIONS(ncclShmem.work.header.funcIndex);
 #endif
     }
 
@@ -385,27 +379,19 @@ __forceinline__ __device__ void ncclKernelMain(struct ncclDevComm* comm, struct 
 }
 
 __global__ void ncclDevKernel_Generic(struct ncclDevComm* comm, struct channelMasks channelMask, struct ncclWork* workHead);
-__global__ void ncclDevKernel_Generic_4(struct ncclDevComm* comm, struct channelMasks channelMask, struct ncclWork* workHead);
 #ifdef ENABLE_COLLTRACE
 __global__ void ncclDevKernelDebug_Generic(struct ncclDevComm* comm, struct channelMasks channelMask, struct ncclWork* workHead);
-__global__ void ncclDevKernelDebug_Generic_4(struct ncclDevComm* comm, struct channelMasks channelMask, struct ncclWork* workHead);
 #endif
 
 #ifdef USE_INDIRECT_FUNCTION_CALL
-#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto) \
+#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, unroll) \
   __device__ void ncclDevFunc_##suffix() { \
-    RunWork<coll, ty, redop<ty>, algo, proto, 2>().run(&ncclShmem.work); \
-  } \
-  __device__ void ncclDevFunc_##suffix##_4() { \
-    RunWork<coll, ty, redop<ty>, algo, proto, 4>().run(&ncclShmem.work); \
+    RunWork<coll, ty, redop<ty>, algo, proto, unroll>().run(&ncclShmem.work); \
   }
 #else
-#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto) \
+#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, unroll) \
   __device__ __attribute__((noinline)) void ncclDevFunc_##suffix() { \
-    RunWork<coll, ty, redop<ty>, algo, proto, 2>().run(&ncclShmem.work); \
-  } \
-  __device__ __attribute__((noinline)) void ncclDevFunc_##suffix##_4() { \
-    RunWork<coll, ty, redop<ty>, algo, proto, 4>().run(&ncclShmem.work); \
+    RunWork<coll, ty, redop<ty>, algo, proto, unroll>().run(&ncclShmem.work); \
   }
 #endif
 

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -31,16 +31,15 @@ struct ncclKernelMatch {
 };
 
 #ifdef ENABLE_COLLTRACE
-static ncclKernelMatch const ncclKerns[4] = {
+#define ncclGetKernelIndex(p_comm) ((p_comm)->collTraceThread ? 1 : 0)
+static ncclKernelMatch const ncclKerns[2] = {
   {(void *)ncclDevKernel_Generic, true},
-  {(void *)ncclDevKernel_Generic_4, true},
   {(void *)ncclDevKernelDebug_Generic, true},
-  {(void *)ncclDevKernelDebug_Generic_4, true},
 };
 #else
-static ncclKernelMatch const ncclKerns[2] = {
-  {(void*)ncclDevKernel_Generic, true},
-  {(void*)ncclDevKernel_Generic_4, true},
+#define ncclGetKernelIndex(p_comm) (0)
+static ncclKernelMatch const ncclKerns[1] = {
+  {(void*)ncclDevKernel_Generic, true}
 };
 #endif
 
@@ -61,19 +60,14 @@ static ncclResult_t getPatternInfo(struct ncclInfo* collInfo);
 static ncclResult_t getLoopInfo(struct ncclInfo* collInfo);
 static ncclResult_t getCollNetSupport(struct ncclInfo* info, int* collNetSupport);
 
-int ncclGetKernelIndex(struct ncclComm* comm) {
-#if ENABLE_COLLTRACE
-  int start_idx = comm->collTraceThread ? 2 : 0;
-#else
-  int start_idx = 0;
-#endif
+int getUnrollFactor(struct ncclComm* comm) {
   hipDeviceProp_t devProp;
   CUDACHECK(hipGetDeviceProperties(&devProp, comm->cudaDev));
   if(IsArchMatch(devProp.gcnArchName, "gfx908") || (IsArchMatch(devProp.gcnArchName, "gfx94")
     && devProp.multiProcessorCount > 80))
-    return start_idx;
+    return NCCL_UNROLL_2;
   else
-    return start_idx + 1;
+    return NCCL_UNROLL_4;
 }
 
 // Returns maximum kernel stack size of all CUDA kernels
@@ -194,7 +188,7 @@ static ncclResult_t appendWorkElemP2p(
     struct ncclComm* comm, struct ncclKernelPlan* plan, int channelId,
     struct ncclWorkElemP2p const *elem, bool fuseOk
   ) {
-  int funcIndex = ncclDevFuncId_P2p();
+  int funcIndex = ncclDevFuncId_P2p(getUnrollFactor(comm));
   if (funcIndex < 0) {
     WARN("%s: unsupported collective. Please ensure the collective has been enabled in build.", __func__);
     return ncclInvalidUsage;
@@ -220,7 +214,7 @@ static ncclResult_t appendWorkElemP2p(
   }
   q = ncclMemoryStackAlloc<struct ncclWorkList>(&comm->memScoped);
   q->work.header.type = ncclWorkTypeP2p;
-  q->work.header.funcIndex = ncclDevFuncId_P2p();
+  q->work.header.funcIndex = ncclDevFuncId_P2p(getUnrollFactor(comm));
   chan->p2pTailElem[ncclWorkP2pTypeRecv-1] = 0;
   chan->p2pTailElem[ncclWorkP2pTypeSend-1] = 1;
   q->work.p2pElems[chan->p2pTailElem[elem->p2pType-1]] = *elem; // C++ struct assignment
@@ -845,6 +839,7 @@ static ncclResult_t scheduleCollTasksToPlan(
           }
         }
 
+        aggInfo->unroll = getUnrollFactor(comm);
         nvlsSupport = comm->nvlsSupport && ncclNvlsSupported(aggInfo->opFull.op, aggInfo->datatype);
         NCCLCHECK(getCollNetSupport(aggInfo, &collNetSupport));
         NCCLCHECK(ncclInfoSetDerived(aggInfo, comm->nRanks));
@@ -1763,7 +1758,7 @@ static ncclResult_t getPatternInfo(struct ncclInfo* collInfo) {
 RCCL_PARAM(IntraNetThreshold, "INTRANET_THRESHOLD", 8388608);
 
 static ncclResult_t computeCollWorkFunc(struct ncclInfo* collInfo) {
-  collInfo->workFuncIndex = ncclDevFuncId(collInfo->coll, collInfo->opFull.op, collInfo->datatype, collInfo->algorithm, collInfo->protocol);
+  collInfo->workFuncIndex = ncclDevFuncId(collInfo->coll, collInfo->opFull.op, collInfo->datatype, collInfo->algorithm, collInfo->protocol, collInfo->unroll);
   if (collInfo->workFuncIndex < 0) {
     WARN("%s: unsupported collective. Please ensure the collective has been enabled in build.", __func__);
     return ncclInvalidUsage;

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -55,7 +55,7 @@ static ncclResult_t initCollProxyOp(struct ncclInfo* collInfo, int channelId, ui
 static ncclResult_t getTunerInfo(struct ncclInfo* collInfo, int collNetSupport, int nvlsSupport, int numPipeOps);
 static ncclResult_t topoGetAlgoInfo(struct ncclInfo* collInfo, int collNetSupport, int nvlsSupport, int numPipeOps);
 static ncclResult_t getChannnelThreadInfo(struct ncclInfo* collInfo);
-static ncclResult_t computeCollWorkFunc(struct ncclInfo* collInfo);
+static ncclResult_t computeCollWorkFunc(struct ncclInfo* collInfo, int unroll);
 static ncclResult_t getPatternInfo(struct ncclInfo* collInfo);
 static ncclResult_t getLoopInfo(struct ncclInfo* collInfo);
 static ncclResult_t getCollNetSupport(struct ncclInfo* info, int* collNetSupport);
@@ -188,7 +188,7 @@ static ncclResult_t appendWorkElemP2p(
     struct ncclComm* comm, struct ncclKernelPlan* plan, int channelId,
     struct ncclWorkElemP2p const *elem, bool fuseOk
   ) {
-  int funcIndex = ncclDevFuncId_P2p(getUnrollFactor(comm));
+  int funcIndex = ncclDevFuncId_P2p(plan->unroll);
   if (funcIndex < 0) {
     WARN("%s: unsupported collective. Please ensure the collective has been enabled in build.", __func__);
     return ncclInvalidUsage;
@@ -214,7 +214,7 @@ static ncclResult_t appendWorkElemP2p(
   }
   q = ncclMemoryStackAlloc<struct ncclWorkList>(&comm->memScoped);
   q->work.header.type = ncclWorkTypeP2p;
-  q->work.header.funcIndex = ncclDevFuncId_P2p(getUnrollFactor(comm));
+  q->work.header.funcIndex = funcIndex;
   chan->p2pTailElem[ncclWorkP2pTypeRecv-1] = 0;
   chan->p2pTailElem[ncclWorkP2pTypeSend-1] = 1;
   q->work.p2pElems[chan->p2pTailElem[elem->p2pType-1]] = *elem; // C++ struct assignment
@@ -839,14 +839,13 @@ static ncclResult_t scheduleCollTasksToPlan(
           }
         }
 
-        aggInfo->unroll = getUnrollFactor(comm);
         nvlsSupport = comm->nvlsSupport && ncclNvlsSupported(aggInfo->opFull.op, aggInfo->datatype);
         NCCLCHECK(getCollNetSupport(aggInfo, &collNetSupport));
         NCCLCHECK(ncclInfoSetDerived(aggInfo, comm->nRanks));
         NCCLCHECK(getTunerInfo(aggInfo, collNetSupport, nvlsSupport, 1));
         NCCLCHECK(topoGetAlgoInfo(aggInfo, collNetSupport, nvlsSupport, 1));
         NCCLCHECK(getChannnelThreadInfo(aggInfo));
-        NCCLCHECK(computeCollWorkFunc(aggInfo));
+        NCCLCHECK(computeCollWorkFunc(aggInfo, plan->unroll));
         NCCLCHECK(getPatternInfo(aggInfo));
 
         // Try to assign algo and proto to all possible collectives
@@ -1325,6 +1324,7 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       plan->comm = comm;
       plan->reclaimer.fn = reclaimPlan;
       plan->persistent = persistent;
+      plan->unroll = getUnrollFactor(comm);
 
       // Non-persistent kernels fill up at most half of our fifo per kernel.
       int nWorkBudget = plan->persistent ? INT_MAX : comm->workFifoDepth/2;
@@ -1757,8 +1757,8 @@ static ncclResult_t getPatternInfo(struct ncclInfo* collInfo) {
 
 RCCL_PARAM(IntraNetThreshold, "INTRANET_THRESHOLD", 8388608);
 
-static ncclResult_t computeCollWorkFunc(struct ncclInfo* collInfo) {
-  collInfo->workFuncIndex = ncclDevFuncId(collInfo->coll, collInfo->opFull.op, collInfo->datatype, collInfo->algorithm, collInfo->protocol, collInfo->unroll);
+static ncclResult_t computeCollWorkFunc(struct ncclInfo* collInfo, int unroll) {
+  collInfo->workFuncIndex = ncclDevFuncId(collInfo->coll, collInfo->opFull.op, collInfo->datatype, collInfo->algorithm, collInfo->protocol, unroll);
   if (collInfo->workFuncIndex < 0) {
     WARN("%s: unsupported collective. Please ensure the collective has been enabled in build.", __func__);
     return ncclInvalidUsage;

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -224,6 +224,9 @@ struct ncclKernelPlan {
     struct ncclIntruQueue<struct ncclProxyOp, &ncclProxyOp::enqNext> proxyOpQueue;
   } channels[MAXCHANNELS];
   size_t maxBytesPerChannel;
+
+  // Unroll factor for plan [RCCL]
+  int unroll;
 };
 
 #define NCCL_MAGIC 0x0280028002800280 // Nickel atomic number is 28.

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -610,6 +610,6 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, 
   return ncclDevFuncRowToId[row];
 }
 
-inline int ncclDevFuncId_P2p(int unroll) { return ncclDevFuncRowToId[FUNC_INDEX_TOTAL - NCCL_NUM_ONERANK - unroll - 1]; }
+inline int ncclDevFuncId_P2p(int unroll) { return ncclDevFuncRowToId[FUNC_INDEX_TOTAL - NCCL_NUM_ONERANK - (unroll > 0 ? 0 : 1) - 1]; }
 
 #endif

--- a/src/include/info.h
+++ b/src/include/info.h
@@ -74,6 +74,7 @@ struct ncclInfo {
   int protocol;
   bool userTuned;
   struct ncclInfo *next;
+  int unroll;
 };
 
 inline ncclResult_t ncclInfoSetDerived(struct ncclInfo* info, int nRanks) {

--- a/src/include/info.h
+++ b/src/include/info.h
@@ -74,7 +74,6 @@ struct ncclInfo {
   int protocol;
   bool userTuned;
   struct ncclInfo *next;
-  int unroll;
 };
 
 inline ncclResult_t ncclInfoSetDerived(struct ncclInfo* info, int nRanks) {

--- a/src/include/nccl_common.h
+++ b/src/include/nccl_common.h
@@ -13,7 +13,7 @@ typedef enum {NCCL_INIT=1, NCCL_COLL=2, NCCL_P2P=4, NCCL_SHM=8, NCCL_NET=16, NCC
 typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char *file, int line, const char *fmt, ...);
 
 #define NCCL_NUM_ONERANK 12
-#define FUNC_INDEX_TOTAL 656 + NCCL_NUM_ONERANK
+#define FUNC_INDEX_TOTAL 1312 + NCCL_NUM_ONERANK
 
 #define NCCL_NUM_FUNCTIONS 5 // Send/Recv not included for now
 typedef enum {
@@ -44,6 +44,10 @@ typedef enum {
 #define NCCL_PROTO_LL128 1
 #define NCCL_PROTO_SIMPLE 2
 
-#define NCCL_NUM_FLOATS 6 // half/float/double/rccl_bfloat16
+#define NCCL_NUM_UNROLLS 2 // 2/4
+#define NCCL_UNROLL_2 0
+#define NCCL_UNROLL_4 1
+
+#define NCCL_NUM_FLOATS 6  // half/float/double/rccl_bfloat16
 
 #endif

--- a/src/init.cc
+++ b/src/init.cc
@@ -243,7 +243,7 @@ void *ncclCommThreadMain(void *arg) {
             (double)(td->timeStamp)/vega_gpu_rtc_freq, comm->rank, td->bid,
             fIdx, td->data_0, td->opCount, td->data_1);
         } else {
-          if (fIdx == ncclDevFuncId_P2p() || type == ncclCollTraceP2pElemType)
+          if (type == ncclCollTraceP2pElemType)
             sprintf(line, "## [%012.6f] [%02d:%02d] %06x-%06x", (double)(td->timeStamp)/vega_gpu_rtc_freq, comm->rank, td->bid, td->p2pOpCount[0], td->p2pOpCount[1]);
           else
             sprintf(line, "## [%012.6f] [%02d:%02d] %06lx", (double)(td->timeStamp)/vega_gpu_rtc_freq, comm->rank, td->bid, td->opCount);


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal

**What were the changes?**  
Stop templating generic kernel for different variants of COLL_UNROLL and put all the generated device functions in the same table instead. 

**Why were the changes made?**  
We want to have control over what unroll factor to build for in the generator file.

**How was the outcome achieved?**  
- Have only 1 generic kernel
- New logic including unroll factor when calculating funcId.
- Calculate unroll factor to build for during funcgen by parsing pre-built ROCm binary output.

**Additional Documentation:**  
_What else should the reviewer know?_
<img width="1568" alt="RCCL-build-time-comparison" src="https://github.com/user-attachments/assets/88e3bcaa-69c6-40ff-b999-6652ba77d72e">

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
