### PR TITLE
GDR enablement logic fix for kernel 6.4.0+

### DIFF
--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -607,7 +607,9 @@ ncclResult_t ncclIbGdrSupport() {
       NCCLCHECK(ncclTopoGetStrFromSys("/proc/sys/kernel", "numa_balancing", strValue));
       if (strcmp(strValue, "1") == 0 && roMode == 0)
         moduleLoaded = 0;
-    } else if (moduleLoaded == 0) {
+    }
+
+    if (moduleLoaded == 0) {
       // Check for `ib_register_peer_memory_client` symbol in `/proc/kallsyms`
       // if your system uses native OS ib_peer module
       char buf[256];


### PR DESCRIPTION
## Details
Fix to enable GDR on HWE kernel 6.5.0

**Work item:** https://github.com/ROCm/rccl/issues/1377

**What were the changes?**  
The GDR enablement logic was not being exercised when bios version was Hyper-V UEFI Release vXX

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
