### PR TITLE
added atomic acquire for gfx12 on prims_simple

### DIFF
--- a/src/device/prims_simple.h
+++ b/src/device/prims_simple.h
@@ -101,7 +101,11 @@ private:
     #endif
     // volatile is faster than acquire but not as correct. Make sure reduceCopy
     // loads data using volatile so it doesn't see stale data in L1.
+#if defined(__gfx1200__) || defined(__gfx1201__)
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+#else
     return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+#endif
   }
 
   template <int DirectRecv, int DirectSend, int Recv, int Send, int Src, int Dst>


### PR DESCRIPTION
## Details
changed from atomic relaxed to acquire for gfx12 on prims_simple to work properly with that memory model

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
