### PR TITLE
Increased maximum number of XML nodes to support CPX mode.

### DIFF
--- a/src/graph/topo.h
+++ b/src/graph/topo.h
@@ -200,8 +200,8 @@ ncclResult_t ncclTopoPrintPaths(struct ncclTopoSystem* system);
 ncclResult_t ncclTopoLoadSystem(const char* xmlTopoFile, struct ncclTopoSystem* system);
 ncclResult_t ncclTopoGetIntermediateRank(struct ncclTopoSystem* system, int rank, int64_t netId, int* intermediateRank);
 
-#define NCCL_TOPO_XML_MAX_NODES 256
-#define NCCL_GRAPH_XML_MAX_NODES 4096
+#define NCCL_TOPO_XML_MAX_NODES 8192
+#define NCCL_GRAPH_XML_MAX_NODES 8192
 ncclResult_t ncclTopoGetSystemFromXml(struct ncclXml* xml, struct ncclTopoSystem** topoSystem, uint64_t localHostHash);
 ncclResult_t ncclTopoGetGraphFromXml(struct ncclXmlNode *xmlGraphs, struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int* nChannels);
 ncclResult_t ncclTopoGetXmlFromGraphs(int ngraphs, struct ncclTopoGraph** graphs, struct ncclTopoSystem* system, struct ncclXml *xml);


### PR DESCRIPTION
## Details
This PR increased the maximum number of XML nodes to support CPX mode, after the recent NCCL sync.

**Work item:** Internal

**What were the changes?**  
Increase the maximum possible XML nodes to support CPX mode.

**Why were the changes made?**  
Recent NCCL sync changed the way we handle XML which negated our early change to support CPX mode.

**How was the outcome achieved?**  
Increase the maximum number.

**Additional Documentation:**  
This particular number 8192, is obtained through experiments.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [x] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
