### PR TITLE
Increase MAX_STACK_SIZE for UT

### DIFF
--- a/test/common/StandaloneUtils.hpp
+++ b/test/common/StandaloneUtils.hpp
@@ -25,7 +25,7 @@
 } while(0)
 
 // should be 112, temp fix to make CI pass
-#define MAX_STACK_SIZE 360
+#define MAX_STACK_SIZE 448
 
 #ifdef ENABLE_LL128
 #define MAX_STACK_SIZE_gfx90a 296


### PR DESCRIPTION
## Details
Increase MAX_STACK_SIZE value to 448 due to recent changes in the compiler.
New stack size seems to have no effect on small msg sizes.

___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
