### PR TITLE
Set minimum ROCm version for MSCCLPP to 6.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,11 +297,13 @@ endif()
 
 ## Disable building MSCCL++ if the build environment is invalid
 ## Currently MSCCL++ is supported only on gfx942
-if (ENABLE_MSCCLPP)
-  if(NOT ("gfx942" IN_LIST GPU_TARGETS OR "gfx942:xnack-" IN_LIST GPU_TARGETS OR "gfx942:xnack+" IN_LIST GPU_TARGETS))
-    set(ENABLE_MSCCLPP OFF)
-    message(WARNING "Can only build MSCCL++ for gfx942; disabling MSCCL++ build")
-  endif()
+if (ENABLE_MSCCLPP AND NOT ("gfx942" IN_LIST GPU_TARGETS OR "gfx942:xnack-" IN_LIST GPU_TARGETS OR "gfx942:xnack+" IN_LIST GPU_TARGETS))
+  set(ENABLE_MSCCLPP OFF)
+  message(WARNING "Can only build MSCCL++ for gfx942; disabling MSCCL++ build")
+endif()
+if (ENABLE_MSCCLPP AND ROCM_VERSION VERSION_LESS "60200")
+  set(ENABLE_MSCCLPP OFF)
+  message(WARNING "MSCCL++ integration only supported on ROCm 6.2 or greater; disabling MSCCL++ build")
 endif()
 
 # Determine version from makefiles/version.mk and fill in templates
@@ -828,7 +830,6 @@ endif()
 
 if(ENABLE_MSCCLPP)
   include(cmake/MSCCLPP.cmake)
-  message(STATUS "Building MSCCL++ with NCCL API support")
 endif()
 
 ## Track linking time


### PR DESCRIPTION
## Details

**What were the changes?**  
Added ROCm version check around setting `ENABLE_MSCCLPP` flag.

**Why were the changes made?**  
Prevent building with MSCCL++ integration feature when using incompatible ROCm version.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
MSCCL++ doesn't build on ROCm 6.1 or earlier.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
