### PR TITLE
Check nvlink_node instead of xgmi_node in xml.cc

### DIFF
--- a/src/graph/xml.cc
+++ b/src/graph/xml.cc
@@ -766,7 +766,11 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
   NCCLCHECK(xmlGetAttrInt(gpuNode, "arch", &arch.value));
 
   struct ncclXmlNode* nvlNode = NULL;
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  NCCLCHECK(xmlGetSub(gpuNode, "xgmi", &nvlNode));
+#else
   NCCLCHECK(xmlGetSub(gpuNode, "nvlink", &nvlNode));
+#endif
   if (nvlNode == NULL) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     const char* busId;


### PR DESCRIPTION
## Details
It seems like here wants to check xgmi_node instead. If checks node for "nvlink", it will verify the link_info everytime.
If checks node for "xgmi", when get yes answer, it won't need check vsmi topo interface for twice.

**What were the changes?**  
It may reduce link_info check turns.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
