### PR TITLE
Make proxy dump print out more meaningful information.

### DIFF
--- a/src/include/proxy.h
+++ b/src/include/proxy.h
@@ -58,6 +58,9 @@ struct ncclProxyOp {
   uint8_t* sendbuff;
   uint8_t* recvbuff;
 
+  int nextRank;
+  int prevRank;
+
   union ncclProxyOpSpecifics specifics;
 
   struct ncclProxyOp *enqNext;
@@ -129,6 +132,10 @@ struct ncclProxyArgs {
   struct ncclProxyArgs** proxyAppendPtr;
 
   union ncclProxyOpSpecifics specifics;
+
+  int prevRank;
+  int nextRank;
+  int send;
 };
 #define NCCL_MAX_NETDEVS 128
 

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -243,27 +243,30 @@ ncclResult_t getOpIndex(struct ncclProxyArgs* op, struct ncclProxyProgressState*
 }
 
 ncclResult_t printProxyOp(struct ncclProxyArgs* op, int poolIndex, int opIndex) {
-  printf("[%d-%d|%ld| %s", poolIndex, opIndex, op->opCount, op->pattern == ncclPatternSend ? "Send" : op->pattern == ncclPatternRecv ? "Recv" : "Coll");
+  int peer = op->send ? op->nextRank : op->prevRank;
+  int isColl = (op->pattern != ncclPatternSend && op->pattern != ncclPatternRecv);
+  printf("[%d-%d|%ld| %s", poolIndex, opIndex, op->opCount, isColl ? "Coll->" : "");
+  printf("%s", op->send ? "Send" : "Recv");
   for (int s=0; s<op->nsubs; s++) {
     struct ncclProxySubArgs* sub = op->subs+s;
     if (op->state == ncclProxyOpProgress) {
       char status = ' ';
-      if (op->pattern == ncclPatternRecv) {
+      if (! op->send) {
         if (sub->posted < sub->nsteps && sub->posted < sub->done + NCCL_STEPS) status = 'I'; // Init
         else if (sub->received < sub->posted) status = 'R'; // Receiving
         else if (sub->received < sub->transmitted) status = 'R'; // Receiving
         else if (sub->transmitted < sub->received) status = 'F'; // Flushing
         else if (sub->done < sub->transmitted) status = 'G'; // Waiting on GPU
         else status = 'D'; // Done
-      } else if (op->pattern == ncclPatternSend) {
+      } else {
         if (sub->posted < sub->nsteps && sub->posted < sub->done + NCCL_STEPS) status = 'I'; // Init
         else if (sub->transmitted < sub->posted) status = 'G'; // Waiting on GPU
         else if (sub->done < sub->transmitted) status = 'S'; // Sending
         else status = 'D'; // Done
       }
-      printf(" %d%c/%d", sub->peer, status, sub->channelId);
+      printf(" %d%c/%d", peer, status, sub->channelId);
     } else {
-      printf(" %d/%d", sub->peer, sub->channelId);
+      printf(" %d/%d", peer, sub->channelId);
     }
   }
   printf("]");
@@ -397,6 +400,9 @@ static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyAr
   args->state = ncclProxyOpReady;
   args->progress = op->connection->tcomm->proxyProgress;
   args->proxyAppendPtr = op->connection->proxyAppendPtr;
+  args->send = op->connection->send;
+  args->prevRank = op->prevRank;
+  args->nextRank = op->nextRank;
   return ncclSuccess;
 }
 
@@ -548,9 +554,13 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
   case ncclPatternPipelineTo: {
       struct ncclRing* ring = &channel->ring;
       if (NeedProxy(proxyRecv, op->pattern, op->root, ring, comm->nRanks)) {
+        op->prevRank = ring->prev;
+        op->nextRank = ring->next;
         NCCLCHECK(SaveProxy(comm, channel, proxyRecv, ring->prev, op, op->connIndex, justInquire));
       }
       if (NeedProxy(proxySend, op->pattern, op->root, ring, comm->nRanks)) {
+        op->prevRank = ring->prev;
+        op->nextRank = ring->next;
         NCCLCHECK(SaveProxy(comm, channel, proxySend, ring->next, op, op->connIndex, justInquire));
       }
     } break;


### PR DESCRIPTION
## Details
Proxy dump is a debugging tool to print out the current state and outstanding operations of the proxy. Proxy dump was not working properly prior to this patch. This PR made some modification to proxy dump code. This does not affect the communication logic in anyway.

Example:
```
[0-27|1780| Coll->Send 0G/2]  (send to rank 0 / state: waiting on GPU / on channel: 2)
| `-> [0-71|1782| Coll->Send 0/2]
| `-> [0-150|1784| Coll->Send 0/2]
| `-> [0-45|1786| Coll->Send 0/2]
| `-> [0-61|1788| Coll->Send 0/2]
| `-> [0-68|1790| Coll->Send 0/2]
| `-> [0-62|1792| Coll->Send 0/2]
```

Note that NCCL 2.23.4 made improvements in this area. We should revisit this when we eventually sync to that NCCL version.

This proves to be useful for debugging large scale job for us, and our partner are asking us to put this in as soon as possible.

**Work item:** : HPEXA-63 / LWPCOMMLIBS-559

**What were the changes?**  
Change how proxy dump prints out information (added more info).

**Why were the changes made?**  
This proxy dump is useful in debugging large scale multi-node hang.

**How was the outcome achieved?**  
printf

**Additional Documentation:**  
Note that NCCL 2.23.4 made improvements in this area. We should revisit this when we eventually sync to that NCCL version.

Proxy dump is not used in normal circumstance. This only affects debug instance when we set NCCL_DUMP_PROXY_SIGNAL.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [x] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
