### PR TITLE
Added Known Issues section for ROCm 6.3.0 with note about MSCCL AllGather.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 * Fixed model matching with PXN enable
 
-### Known Issues
+### Known issues
 
 * MSCCL is temporarily disabled for AllGather collectives.
   - This can impact in-place messages (< 2 MB) with ~2x latency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
   - This can impact in-place messages (< 2 MB) with ~2x latency.
   - Older RCCL versions are not impacted.
   - This issue will be addressed in a future ROCm release.
+* Unit tests do not exit gracefully when running on a single GPU.
+  - This issue will be addressed in a future ROCm release.
 
 ## RCCL 2.20.5 for ROCm 6.2.1
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 * Fixed model matching with PXN enable
 
+### Known Issues
+
+* MSCCL is temporarily disabled for AllGather collectives.
+  - This can impact in-place messages (< 2 MB) with ~2x latency.
+  - Older RCCL versions are not impacted.
+  - This issue will be addressed in a future ROCm release.
+
 ## RCCL 2.20.5 for ROCm 6.2.1
 ### Fixed
 - GDR support flag now set with DMABUF


### PR DESCRIPTION
## RCCL 2.21.5 for ROCm 6.3.0

...

### Known Issues

* MSCCL is temporarily disabled for AllGather collectives.
  - This can impact in-place messages (< 2 MB) with ~2x latency.
  - Older RCCL versions are not impacted.
  - This issue will be addressed in a future ROCm release.
