### PR TITLE
Added RCCL env params to control setting the SO_REUSEADDR and SO_LINGER socket options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for RCCL is available at [https://rccl.readthedocs.io](https://rccl.readthedocs.io)
 
+## Unreleased
+
+### Added
+
+* `RCCL_SOCKET_REUSEADDR` and `RCCL_SOCKET_LINGER` environment parameters
+
 ## RCCL 2.21.5 for ROCm 6.3.1
 
 ### Added

--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -736,9 +736,9 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, union ncclSocketAddress* ad
       int opt = 1;
       SYSCHECKGOTO(setsockopt(sock->fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)), ret, fail);
     }
-    auto lingerParam = rcclParamSocketLinger();
+    int lingerParam = (int)rcclParamSocketLinger();
     if (lingerParam > -1) {
-      linger linger_opt = { 1, (int)lingerParam };
+      linger linger_opt = { 1, lingerParam };
       SYSCHECKGOTO(setsockopt(sock->fd, SOL_SOCKET, SO_LINGER, &linger_opt, sizeof(linger_opt)), ret, fail);
     }
   } else {

--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -15,6 +15,9 @@
 #include <sys/syscall.h>
 #include "param.h"
 
+RCCL_PARAM(SocketReuseAddr, "SOCKET_REUSEADDR", 0);
+RCCL_PARAM(SocketLinger, "SOCKET_LINGER", -1);
+
 static ncclResult_t socketProgressOpt(int op, struct ncclSocket* sock, void* ptr, int size, int* offset, int block, int* closed) {
   int bytes = 0;
   *closed = 0;
@@ -726,6 +729,17 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, union ncclSocketAddress* ad
       WARN("ncclSocketInit: Socket creation failed : %s", strerror(errno));
       ret = ncclSystemError;
       goto fail;
+    }
+
+    // [RCCL] Runtime socket options
+    if (rcclParamSocketReuseAddr()) {
+      int opt = 1;
+      SYSCHECKGOTO(setsockopt(sock->fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)), ret, fail);
+    }
+    auto lingerParam = rcclParamSocketLinger();
+    if (lingerParam > -1) {
+      linger linger_opt = { 1, (int)lingerParam };
+      SYSCHECKGOTO(setsockopt(sock->fd, SOL_SOCKET, SO_LINGER, &linger_opt, sizeof(linger_opt)), ret, fail);
     }
   } else {
     memset(&sock->addr, 0, sizeof(union ncclSocketAddress));


### PR DESCRIPTION
## Details

**Work item:** SWDEV-491354

**What were the changes?**  
Added `RCCL_SOCKET_REUSEADDR` and `RCCL_SOCKET_LINGER` env params to control setting the `SO_REUSEADDR` and `SO_LINGER` socket options.

**Why were the changes made?**  
This can allow control over the number of file descriptors created during bootstrapping.

**How was the outcome achieved?**  
Conducted tests of FD count while repeatedly running AllReduce under the given test conditions, and saw a reduction with `RCCL_SOCKET_LINGER=0` and `=2`, and a change in behaviour over time using `RCCL_SOCKET_REUSEADDR=1`.

**Additional Documentation:**  
This is still under investigation.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
