### PR TITLE
Adding RCCL_MODEL_REVERSAL_DISABLE env var to disable model reversal

### DIFF
--- a/src/graph/rome_models.cc
+++ b/src/graph/rome_models.cc
@@ -1137,7 +1137,7 @@ ncclResult_t parseGraph(const char* str, struct ncclTopoSystem* system, struct n
   int ngpus = system->nodes[GPU].count;
   int nnets = system->nodes[NET].count;
 
-  if (rcclParamModelReversalDisable) reverse = 0;
+  if (rcclParamModelReversalDisable()) reverse = 0;
 
   do {
     if (str[offset] == 'N') {

--- a/src/graph/rome_models.cc
+++ b/src/graph/rome_models.cc
@@ -1117,6 +1117,9 @@ static struct rcclRomeModel romeTopoModels[] = {
   rome_model_87, /* 43 */
 };
 
+// This environment variable allows disabling of the reversal the graph parsing
+RCCL_PARAM(ModelReversalDisable, "MODEL_REVERSAL_DISABLE", 0);
+
 /* Parse user defined rings. Format is like :
  * "0 1|1 0|0 1 2 3|3 2 1 0|N0 0 2 3 1 N1|1 3 2 0|0 1 2 3 4 5 6 7|N2 7 6 5 4 3 2 1 0 N1"
  * Network interfaces can be optionally specified by N prefix.
@@ -1133,6 +1136,9 @@ ncclResult_t parseGraph(const char* str, struct ncclTopoSystem* system, struct n
   int net_offset = 0, net_count = 0;
   int ngpus = system->nodes[GPU].count;
   int nnets = system->nodes[NET].count;
+
+  if (rcclParamModelReversalDisable) reverse = 0;
+
   do {
     if (str[offset] == 'N') {
       if (status == 0) {


### PR DESCRIPTION
## Details
Adding a RCCL_MODEL_REVERSAL_DISABLE environment variable that disables the normal reversal of even/odd nodes for rings.
This is to enable experimenting the whether or not model reversal provides benefits.

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
None

**What were the changes?**  
Adding env var that forces reversal to false when parsing.

**Why were the changes made?**  
To enable flipping on/off "rail-optimized" rings.

**How was the outcome achieved?**  
See above.

**Additional Documentation:**  
none

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
