### PR TITLE
Modify cmake instruction in build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ git submodule update --init --recursive --depth=1
 ```
 You may substitute an installation path of your own choosing by passing `CMAKE_INSTALL_PREFIX`. For example:
 ```shell
-$ cmake -DCMAKE_INSTALL_PREFIX=$PWD/rccl-install ..
+$ cmake -DCMAKE_INSTALL_PREFIX=$PWD/rccl-install -DCMAKE_BUILD_TYPE=Release ..
 ```
 Note: ensure rocm-cmake is installed, `apt install rocm-cmake`.
 

--- a/docs/install/building-installing.rst
+++ b/docs/install/building-installing.rst
@@ -45,11 +45,12 @@ to ``CMAKE_INSTALL_PREFIX``, for example:
 
 .. code-block:: shell
 
-    cmake -DCMAKE_INSTALL_PREFIX=$PWD/rccl-install ..
+    cmake -DCMAKE_INSTALL_PREFIX=$PWD/rccl-install -DCMAKE_BUILD_TYPE=Release ..
 
 .. note::
 
-    Ensure ROCm CMake is installed using the command ``apt install rocm-cmake``.
+    Ensure ROCm CMake is installed using the command ``apt install rocm-cmake``. By default,
+    CMake builds the component in debug mode unless ``DCMAKE_BUILD_TYPE`` is specified.
 
 
 Building the RCCL package and install package:


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal

**What were the changes?**  
Modifies the build command based on feedback  to add -DCMAKE_BUILD_TYPE=Release

**Why were the changes made?**  
The change was recommended by reviewers in https://github.com/ROCm/rccl/pull/1427 after the PR was merged and endorsed by the sw team.

**How was the outcome achieved?**  
Modified the relevant rst doc and the read me file (to keep them aligned)

**Additional Documentation:**  
No functional changes. PR 1427 must be merged first.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
