### PR TITLE
Improve the handling of CMake deduplication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -824,7 +824,7 @@ else()
   message(STATUS "Building shared RCCL library")
 endif()
 if (HAVE_KERNARG_PRELOAD)
-  target_link_options(rccl PRIVATE -Xoffload-linker -mllvm=-amdgpu-kernarg-preload-count=16)
+  target_link_options(rccl PRIVATE "SHELL:-Xoffload-linker -mllvm=-amdgpu-kernarg-preload-count=16")
 endif()
 
 if(ENABLE_MSCCLPP)


### PR DESCRIPTION
Certain CMake functions deduplicates arguments by default. For example, if we have two `target_link_options` with both `-Xoffload-linker -opt-A` and then `-Xoffload-linker -opt-B`, the final link command would be `-Xoffload-linker -opt-A -opt-B`, which is not what we want.

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
