### PR TITLE
Initializing all ranks to the same value to avoid failure of  UT AllR…

### DIFF
--- a/test/AllReduceTests.cpp
+++ b/test/AllReduceTests.cpp
@@ -13,7 +13,7 @@ namespace RcclUnitTesting
 
     // Configuration
     std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllReduce};
-    std::vector<ncclDataType_t> const dataTypes       = {ncclFloat32};
+    std::vector<ncclDataType_t> const dataTypes       = {ncclFp8E4M3, ncclFp8E5M2};
     std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
     std::vector<int>            const roots           = {0};
     std::vector<int>            const numElements     = {393216, 384};

--- a/test/AllReduceTests.cpp
+++ b/test/AllReduceTests.cpp
@@ -13,7 +13,7 @@ namespace RcclUnitTesting
 
     // Configuration
     std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllReduce};
-    std::vector<ncclDataType_t> const dataTypes       = {ncclFp8E4M3, ncclFp8E5M2};
+    std::vector<ncclDataType_t> const dataTypes       = {ncclFloat32, ncclFp8E4M3, ncclFp8E5M2};
     std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
     std::vector<int>            const roots           = {0};
     std::vector<int>            const numElements     = {393216, 384};

--- a/test/common/PtrUnion.cpp
+++ b/test/common/PtrUnion.cpp
@@ -148,7 +148,9 @@ namespace RcclUnitTesting
 
     for (int i = 0; i < numElements; i++)
     {
-      int    valueI = (globalRank + i) % 256;
+      // Due to floating-point math not being commutative, the ordering in which ranks are added will matter.
+      // For lower-precision data types, we initialize all ranks to the same value to avoid this
+      int    valueI = (dataType == ncclFp8E4M3 || dataType == ncclFp8E5M2)? (i % 16) :(globalRank + i) % 256;
       double valueF = 1.0L/((double)valueI+1.0L);
       temp.Set(dataType, i, valueI, valueF);
     }


### PR DESCRIPTION
…educe for FP8 type

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Initializing all ranks to the same value to avoid failure of UT AllReduce for FP8 type

**Why were the changes made?**  
The UT was failed before for FP8 types.

**How was the outcome achieved?**  
Due to floating-point math not being commutative, the ordering in which ranks are added will matter, we need to initialize all the ranks to the same value to avoid it.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
