### PR TITLE
Remove unused highestTransportType

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -898,7 +898,7 @@ static ncclResult_t collNetInitRailRankMap(ncclComm_t comm) {
 
   comm->collNetDenseToUserRank = ncclMemoryStackAlloc<int>(&comm->memPermanent, comm->nRanks);
   comm->collNetUserToDenseRank = ncclMemoryStackAlloc<int>(&comm->memPermanent, comm->nRanks);
-  // initialize collNetUserToDenseRank[rank]  
+  // initialize collNetUserToDenseRank[rank]
   comm->collNetUserToDenseRank[rank] = -1;
   for (int h = 0; h < comm->collNetHeadsNum; h++) {
     nonHeadMask ^= 1ull << comm->rankToLocalRank[comm->collNetHeads[h]];
@@ -1244,7 +1244,6 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   int *topParentLocalRanks = NULL;
   int tpProxyRank;
 
-  int highestTransportType = TRANSPORT_P2P;
   bool needsProxy = false;
   bool mscclNeedsProxy = needsProxy;
 
@@ -1701,7 +1700,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     if (comm->nRanks == 1) continue;
     NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &channel->ring.prev, 1, &channel->ring.next, 0), ret, fail);
   }
-  NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &ringGraph, 0, &highestTransportType, &needsProxy), ret, fail);
+  NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &ringGraph, 0, NULL, &needsProxy), ret, fail);
   mscclNeedsProxy |= needsProxy;
   if (ringGraph.nIntraChannels && rcclParamP2pNetDisable() == 0) {
     comm->useIntraNet = 1;
@@ -1722,7 +1721,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, NCCL_MAX_TREE_ARITY, channel->tree.down, 1, &channel->tree.up, 0), ret, fail);
     NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &channel->tree.up, NCCL_MAX_TREE_ARITY, channel->tree.down, 0), ret, fail);
   }
-  NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &treeGraph, 0, &highestTransportType, &needsProxy), ret, fail);
+  NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &treeGraph, 0, NULL, &needsProxy), ret, fail);
   mscclNeedsProxy |= needsProxy;
   INFO(NCCL_INIT, "Connected all trees");
 


### PR DESCRIPTION
## Details
___Value of `highestTransportType` was set and passed to `ncclTransportP2pSetup` where the value is output only for the latter function. `highestTransportType` is not used later by the caller___

**Work item:** _"Internal"_

**What were the changes?**  
_Remove the unused variable to improve readability._

**Why were the changes made?**  
_Easier maintenance. highestType is already set inside `ncclTransportP2pSetup`. Setting it outside distorts semantics_

**How was the outcome achieved?**  
_Passing NULL instead of an unused variable. If the value is to be used in the future, a non-NULL can be passed instead._

**Additional Documentation:**  
_None_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
