### PR TITLE
Cherry-pick to release-staging/rocm-rel-6.4: Change kernel reference to use new terminology (#1462)

### DIFF
--- a/docs/how-to/troubleshooting-rccl.rst
+++ b/docs/how-to/troubleshooting-rccl.rst
@@ -90,7 +90,7 @@ details about the platform and system. Some issues to consider include:
 
    *  Build or run the develop branch version of RCCL and see if the problem persists.
    *  Try an earlier RCCL version (minor or major).
-   *  If you recently changed the ROCm runtime configuration, KFD/driver, or compiler,
+   *  If you recently changed the ROCm runtime configuration, AMD Kernel-mode GPU Driver (KMD), or compiler,
       rerun the test with the previous configuration.
 
 .. _collecting-rccl-info:


### PR DESCRIPTION
(cherry picked from commit 2934bf6fc6496d4ff3adf2a708c036b63303715d)

## Details

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal

**What were the changes?**  
Change the kernel driver reference in the new troubleshooting doc to KMD

**Why were the changes made?**  
ROCm docs-wide directive

**How was the outcome achieved?**  
Edited troubleshooting doc to change the reference

**Additional Documentation:**  
One-line docs-only change. No functional impact.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
