### PR TITLE
Add macro for channel mask offset

### DIFF
--- a/src/include/transport.h
+++ b/src/include/transport.h
@@ -48,7 +48,7 @@ struct ncclPeerInfo {
   // MNNVL support
   nvmlGpuFabricInfoV_t fabricInfo;
 };
-
+#define CHANNEL_MASK_OFFSET(nranks, connIndex) (nranks * (connIndex == NCCL_CONN_IDX_P2P_NET ? NCCL_CONN_IDX_P2P_NET : 0))
 #define CONNECT_SIZE 128
 struct ncclConnect {
   char data[CONNECT_SIZE];


### PR DESCRIPTION
## Details
The indexing logic for send/recv channel masks is repeated and any change would have to be propagated in many places

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Put repeated indexing code in macro

**Why were the changes made?**  
Improve maintenance 

**How was the outcome achieved?**  
N/A

**Additional Documentation:**  
N/A

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
