### PR TITLE
net_ib: fix out of bounds read in ncclIbGdrSupport on non-RDMA kernel

### DIFF
--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -586,7 +586,8 @@ ncclResult_t ncclIbGdrSupport() {
     // or created under a different path like `/sys/kernel/` or `/sys/` (depending on your ib_peer_mem module)
     const char* memory_peers_paths[] = {"/sys/kernel/mm/memory_peers/amdkfd/version",
                                   "/sys/kernel/memory_peers/amdkfd/version",
-                                  "/sys/memory_peers/amdkfd/version"};
+                                  "/sys/memory_peers/amdkfd/version",
+                                  NULL};
     int i = 0;
 
     while (memory_peers_paths[i]) {


### PR DESCRIPTION
Fixes #1469

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** https://github.com/ROCm/rccl/issues/1469

**What were the changes?**  
Fixed out of bounds read and subsequent crash if none of the entries in memory_peers_path exist.

**Why were the changes made?**  
Crashing is bad.

**How was the outcome achieved?**  
Only crashes/demonstrates UB on a system that is missing all entries in this list.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [x] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
