### PR TITLE
Adds API for non-caching-store and load

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,7 @@ set(SRC_FILES
   src/device/broadcast.h
   src/device/common.h
   src/device/common_kernel.h
+  src/device/non_caching_load.h
   src/device/non_caching_store.h
   src/device/non_caching_store_vec4.h
   src/device/op128.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,8 @@ set(SRC_FILES
   src/device/broadcast.h
   src/device/common.h
   src/device/common_kernel.h
+  src/device/non_caching_store.h
+  src/device/non_caching_store_vec4.h
   src/device/op128.h
   src/device/primitives.h
   src/device/prims_ll128.h

--- a/src/device/non_caching_load.h
+++ b/src/device/non_caching_load.h
@@ -1,0 +1,77 @@
+#ifndef NON_CACHING_LOAD_H_
+#define NON_CACHING_LOAD_H_
+
+template<typename T>
+inline
+__attribute__((always_inline))
+__host__ __device__ T __non_caching_load(const T* p)
+{
+    #if !defined(__GFX11__) && !defined(GFX12)
+        #define LD "global_load_ubyte"
+        #define LD2 "global_load_ushort"
+        #define LD3 "global_load_dword"
+        #define LD4 "global_load_dwordx2"
+        #define LD5 "global_load_dwordx4"
+        #if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+            #define BITS "sc0 sc1 nt"
+        #elif defined(__GFX9__) || defined(__gfx1010__) || defined(__gfx1011__) || defined(__gfx1012__) || defined(__gfx1013__)
+            #define BITS "glc slc"
+        #else
+            #define BITS "glc slc dlc"
+        #endif
+        #define WAIT ((0 << 14) | (0x3f << 8) | (0x7) << 4)
+    #else
+        #define LD "global_load_u8"
+        #define LD2 "global_load_u16"
+        #define LD3 "global_load_b32"
+        #define LD4 "global_load_b64"
+        #define LD5 "global_load_b128"
+        #define BITS "glc slc dlc"
+        #define WAIT ((0 << 10) | (0x3f << 4) | 0x7)
+    #endif
+    #define LOAD LD " %0 %1 off " BITS
+    #define LOAD2 LD2 " %0 %1 off " BITS
+    #define LOAD3 LD3 " %0 %1 off " BITS
+    #define LOAD4 LD4 " %0 %1 off " BITS
+    #define LOAD5 LD5 " %0 %1 off " BITS
+    
+    T r{};
+
+    switch (sizeof(T)) {
+    case 1:
+        asm volatile(LOAD : "={v0}"(r) : "v"(p));
+        break;
+    case 2:
+        asm volatile(LOAD2 : "={v0}"(r) : "v"(p));
+        break;
+    case 4:
+        asm volatile(LOAD3 : "={v0}"(r) : "v"(p));
+        break;
+    case 8:
+        asm volatile(LOAD4 : "={v[0:1]}"(r) : "v"(p));
+        break;
+    case 16:
+        asm volatile(LOAD5 : "=v"(r) : "v"(p));
+        break;
+    default: __builtin_trap();
+    }
+    __builtin_amdgcn_s_waitcnt(WAIT);
+
+    return r;
+
+    #undef LOAD5
+    #undef LOAD4
+    #undef LOAD3
+    #undef LOAD2
+    #undef LOAD
+    #undef WAIT
+    #undef BITS
+    #undef LD5
+    #undef LD4
+    #undef LD3
+    #undef LD2
+    #undef LD
+}
+ 
+#endif
+

--- a/src/device/non_caching_store.h
+++ b/src/device/non_caching_store.h
@@ -45,7 +45,6 @@ __host__ __device__ T __non_caching_store(const T val, const T* p)
         break;
     default: __builtin_trap();
     }
-    asm volatile("s_endpgm");
 
     #undef STORE4
     #undef STORE3

--- a/src/device/non_caching_store.h
+++ b/src/device/non_caching_store.h
@@ -59,3 +59,4 @@ __host__ __device__ T __non_caching_store(const T val, const T* p)
 }
 
 #endif
+

--- a/src/device/non_caching_store.h
+++ b/src/device/non_caching_store.h
@@ -1,0 +1,61 @@
+#ifndef NON_CACHING_STORE_H_
+#define NON_CACHING_STORE_H_
+
+template<typename T>
+inline
+__attribute__((always_inline))
+__host__ __device__ T __non_caching_store(const T val, const T* p)
+{
+    #if !defined(__GFX11__) && !defined(GFX12)
+        #define ST "global_store_byte"
+        #define ST2 "global_store_short"
+        #define ST3 "global_store_dword"
+        #define ST4 "global_store_dwordx2"
+        #if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+            #define BITS "sc0 sc1 nt"
+        #elif defined(__GFX9__) || defined(__gfx1010__) || defined(__gfx1011__) || defined(__gfx1012__) || defined(__gfx1013__)
+            #define BITS "glc slc"
+        #else
+            #define BITS "glc slc dlc"
+        #endif
+    #else
+        #define ST "global_store_b8"
+        #define ST2 "global_store_b16"
+        #define ST3 "global_store_b32"
+        #define ST4 "global_store_b64"
+        #define BITS "glc slc dlc"
+    #endif
+    #define STORE ST " %0 %1 %2 " BITS
+    #define STORE2 ST2 " %0 %1 %2 " BITS
+    #define STORE3 ST3 " %0 %1 %2 " BITS
+    #define STORE4 ST4 " %0 %1 %2 " BITS
+
+    switch (sizeof(T)) {
+    case 1:
+        asm volatile(STORE :: "v"(0), "v"(uint32_t(val)) , "s"(p));
+        break;
+    case 2:
+        asm volatile(STORE2 :: "v"(0), "v"(val) , "s"(p));
+        break;
+    case 4:
+        asm volatile(STORE3 :: "v"(0), "v"(val) , "s"(p));
+        break;
+    case 8:
+        asm volatile(STORE4 :: "v"(0), "v"(val) , "s"(p));
+        break;
+    default: __builtin_trap();
+    }
+    asm volatile("s_endpgm");
+
+    #undef STORE4
+    #undef STORE3
+    #undef STORE2
+    #undef STORE
+    #undef BITS
+    #undef ST4
+    #undef ST3
+    #undef ST2
+    #undef ST
+}
+
+#endif

--- a/src/device/non_caching_store_vec4.h
+++ b/src/device/non_caching_store_vec4.h
@@ -31,3 +31,4 @@ __host__ __device__ T __non_caching_store_vec4(const T val, const T* p)
 }
 
 #endif
+

--- a/src/device/non_caching_store_vec4.h
+++ b/src/device/non_caching_store_vec4.h
@@ -23,7 +23,6 @@ __host__ __device__ T __non_caching_store_vec4(const T val, const T* p)
     #define STORE ST " %0 %1 %2 " BITS
 
     asm volatile(STORE :: "v"(0), "v"(val) , "s"(p));
-    asm volatile("s_endpgm");
    
     #undef STORE
     #undef BITS

--- a/src/device/non_caching_store_vec4.h
+++ b/src/device/non_caching_store_vec4.h
@@ -1,0 +1,33 @@
+#ifndef NON_CACHING_STORE_VEC4_H_
+#define NON_CACHING_STORE_VEC4_H_
+
+template<typename T>
+inline
+__attribute__((always_inline))
+__host__ __device__ T __non_caching_store_vec4(const T val, const T* p)
+{
+    #if !defined(__GFX11__) && !defined(GFX12)
+        #define ST "global_store_dwordx4"
+        #if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+            #define BITS "sc0 sc1 nt"
+        #elif defined(__GFX9__) || defined(__gfx1010__) || defined(__gfx1011__) || defined(__gfx1012__) || defined(__gfx1013__)
+            #define BITS "glc slc"
+        #else
+            #define BITS "glc slc dlc"
+        #endif
+    #else
+        #define ST "global_store_b128"
+        #define BITS "glc slc dlc"
+    #endif
+
+    #define STORE ST " %0 %1 %2 " BITS
+
+    asm volatile(STORE :: "v"(0), "v"(val) , "s"(p));
+    asm volatile("s_endpgm");
+   
+    #undef STORE
+    #undef BITS
+    #undef ST
+}
+
+#endif

--- a/tools/memoryRAR/Makefile
+++ b/tools/memoryRAR/Makefile
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+# Set to where RCCL is installed
+RCCL_INSTALL=../../build/release
+
+HIP_PATH?= $(wildcard /opt/rocm)
+ifeq (,$(HIP_PATH))
+HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+EXE=memoryRAR
+CXXFLAGS = -std=c++11 -O3 -I../../src/include  -I../../src/device -I$(RCCL_INSTALL)/include -L$(RCCL_INSTALL) -lrccl
+
+all: $(EXE)
+
+$(EXE): $(EXE).cpp $(shell find -regex ".*\.\hpp")
+	$(HIPCC) $(CXXFLAGS) $< -o $@
+
+clean:
+	rm -f *.o $(EXE) *.bc *.hip* *.out* *.s *.hsaco
+

--- a/tools/memoryRAR/memoryRAR.cpp
+++ b/tools/memoryRAR/memoryRAR.cpp
@@ -1,0 +1,105 @@
+/*
+Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <sys/socket.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <cstdio>
+#include <string>
+#include <chrono>
+#include <hip/hip_runtime.h>
+#include <rccl/rccl.h>
+#include <cstdlib>
+#include <fstream>
+#include <iostream> //cerr
+#include <cstring>
+#include "memoryRAR.hpp"
+#include "non_caching_load.h"
+#include "non_caching_store.h"
+#include "non_caching_store_vec4.h"
+
+constexpr int N = 1024;
+typedef uint32_t uint32x4 __attribute__((ext_vector_type(4)));
+
+template<typename T>
+__global__ void readKernel(T* data, T* out){
+    T temp;
+    temp = __non_caching_load<T>(out);
+
+    T temp1;
+    temp1 = __non_caching_load<T>(out);
+
+    if constexpr (std::is_same<T, uint32x4>::value){
+        if(temp[0] == temp1[0])
+            printf("PASSED\n");
+    }
+    else{
+        if(temp == temp1)
+            printf("PASSED\n");
+    }
+}
+
+template<typename T>
+void caching_load_store() {
+    T* d_data;
+    T* out;
+    size_t size = N * sizeof(d_data);
+
+    hipMalloc(&d_data, size);
+    hipMalloc(&out, size);
+
+    int* h_data = new int[N];
+    for(int i = 0; i < N; ++i){
+        h_data[i] = 105;
+    }
+
+    HIP_CALL(hipMemcpy(d_data, h_data, size, hipMemcpyHostToDevice));
+
+    dim3 threadsPerBlock(256);
+    dim3 blocksPerGrid((N + threadsPerBlock.x - 1) / threadsPerBlock.x);
+
+    std::cout << "Running Read After Read(RAR) Test" << std::endl;
+    hipLaunchKernelGGL(readKernel, blocksPerGrid, threadsPerBlock, 0, 0, d_data, out);
+    HIP_CALL(hipDeviceSynchronize());
+
+    HIP_CALL(hipMemcpy(h_data, d_data, size, hipMemcpyDeviceToHost));
+
+    HIP_CALL(hipFree(d_data));
+    delete[] h_data;
+
+    std::cout << "Testing done" << std::endl;
+
+    return;
+}
+
+int main(int argc, char **argv){
+    caching_load_store<uint64_t>();
+    caching_load_store<uint32_t>();
+    caching_load_store<uint16_t>();
+    caching_load_store<uint8_t>();
+    using V2 = unsigned __attribute__((ext_vector_type(4)));
+    caching_load_store<V2>();
+
+    return 0;
+}
+

--- a/tools/memoryRAR/memoryRAR.hpp
+++ b/tools/memoryRAR/memoryRAR.hpp
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef HELLORCCL_HPP
+#define HELLORCCL_HPP
+#include <iostream>
+
+#define HIP_CALL(cmd)                                                 \
+  do {                                                                \
+    hipError_t error = (cmd);                                         \
+    if (error != hipSuccess)                                          \
+    {                                                                   \
+      std::cerr << "Encountered HIP error (" << hipGetErrorString(error) << ") at line " \
+                << __LINE__ << " in file " << __FILE__ << "\n";         \
+      exit(-1);                                                         \
+    }                                                                   \
+  } while (0)
+
+#define NCCL_CALL(cmd) \
+  do { \
+    ncclResult_t error = (cmd);                 \
+    if (error != ncclSuccess)                   \
+    {                                           \
+      std::cerr << "Encountered NCCL error (" << ncclGetErrorString(error) << ") at line " \
+                << __LINE__ << " in file " << __FILE__ << "\n";         \
+      exit(-1);                                                         \
+    }                                                                   \
+  } while (0)
+
+#endif
+

--- a/tools/memoryRAW/Makefile
+++ b/tools/memoryRAW/Makefile
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+# Set to where RCCL is installed
+RCCL_INSTALL=../../build/release
+
+HIP_PATH?= $(wildcard /opt/rocm)
+ifeq (,$(HIP_PATH))
+HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+EXE=memoryRAW
+CXXFLAGS = -std=c++11 -O3 -I../../src/include  -I../../src/device -I$(RCCL_INSTALL)/include -L$(RCCL_INSTALL) -lrccl
+
+all: $(EXE)
+
+$(EXE): $(EXE).cpp $(shell find -regex ".*\.\hpp")
+	$(HIPCC) $(CXXFLAGS) $< -o $@
+
+clean:
+	rm -f *.o $(EXE) *.bc *.hip* *.out* *.s *.hsaco
+

--- a/tools/memoryRAW/memoryRAW.cpp
+++ b/tools/memoryRAW/memoryRAW.cpp
@@ -1,0 +1,102 @@
+/*
+Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <sys/socket.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <cstdio>
+#include <string>
+#include <chrono>
+#include <hip/hip_runtime.h>
+#include <rccl/rccl.h>
+#include <cstdlib>
+#include <fstream>
+#include <iostream> //cerr
+#include <cstring>
+#include "memoryRAW.hpp"
+#include "non_caching_load.h"
+#include "non_caching_store.h"
+#include "non_caching_store_vec4.h"
+
+constexpr int N = 1024;
+typedef uint32_t uint32x4 __attribute__((ext_vector_type(4)));
+
+template<typename T>
+__global__ void writeKernel(T* data, T* out){
+    if constexpr (std::is_same<T, uint32x4>::value)
+        __non_caching_store_vec4<T>(data[0], out);
+    else
+        __non_caching_store<T>(data[0], out);
+}
+
+template<typename T>
+__global__ void readKernel(T* data, T* out){
+    T temp;
+    temp = __non_caching_load<T>(out);
+}
+
+template<typename T>
+void caching_load_store() {
+    T* d_data;
+    T* out;
+    size_t size = N * sizeof(d_data);
+
+    hipMalloc(&d_data, size);
+    hipMalloc(&out, size);
+
+    int* h_data = new int[N];
+    for(int i = 0; i < N; ++i){
+        h_data[i] = 105;
+    }
+
+    HIP_CALL(hipMemcpy(d_data, h_data, size, hipMemcpyHostToDevice));
+
+    dim3 threadsPerBlock(256);
+    dim3 blocksPerGrid((N + threadsPerBlock.x - 1) / threadsPerBlock.x);
+
+    std::cout << "Running Read After Write(RAW) Test" << std::endl;
+    hipLaunchKernelGGL(writeKernel, blocksPerGrid, threadsPerBlock, 0, 0, d_data, out);
+    HIP_CALL(hipDeviceSynchronize());
+    hipLaunchKernelGGL(readKernel, blocksPerGrid, threadsPerBlock, 0, 0, d_data, out);
+
+    HIP_CALL(hipMemcpy(h_data, d_data, size, hipMemcpyDeviceToHost));
+
+    HIP_CALL(hipFree(d_data));
+    delete[] h_data;
+
+    std::cout << "Testing done" << std::endl;
+
+    return;
+}
+
+int main(int argc, char **argv){
+    caching_load_store<uint64_t>();
+    caching_load_store<uint32_t>();
+    caching_load_store<uint16_t>();
+    caching_load_store<uint8_t>();
+    using V2 = unsigned __attribute__((ext_vector_type(4)));
+    caching_load_store<V2>();
+
+    return 0;
+}
+

--- a/tools/memoryRAW/memoryRAW.hpp
+++ b/tools/memoryRAW/memoryRAW.hpp
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef HELLORCCL_HPP
+#define HELLORCCL_HPP
+#include <iostream>
+
+#define HIP_CALL(cmd)                                                 \
+  do {                                                                \
+    hipError_t error = (cmd);                                         \
+    if (error != hipSuccess)                                          \
+    {                                                                   \
+      std::cerr << "Encountered HIP error (" << hipGetErrorString(error) << ") at line " \
+                << __LINE__ << " in file " << __FILE__ << "\n";         \
+      exit(-1);                                                         \
+    }                                                                   \
+  } while (0)
+
+#define NCCL_CALL(cmd) \
+  do { \
+    ncclResult_t error = (cmd);                 \
+    if (error != ncclSuccess)                   \
+    {                                           \
+      std::cerr << "Encountered NCCL error (" << ncclGetErrorString(error) << ") at line " \
+                << __LINE__ << " in file " << __FILE__ << "\n";         \
+      exit(-1);                                                         \
+    }                                                                   \
+  } while (0)
+
+#endif
+

--- a/tools/memoryWAR/Makefile
+++ b/tools/memoryWAR/Makefile
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+# Set to where RCCL is installed
+RCCL_INSTALL=../../build/release
+
+HIP_PATH?= $(wildcard /opt/rocm)
+ifeq (,$(HIP_PATH))
+HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+EXE=memoryWAR
+CXXFLAGS = -std=c++11 -O3 -I../../src/include  -I../../src/device -I$(RCCL_INSTALL)/include -L$(RCCL_INSTALL) -lrccl
+
+all: $(EXE)
+
+$(EXE): $(EXE).cpp $(shell find -regex ".*\.\hpp")
+	$(HIPCC) $(CXXFLAGS) $< -o $@
+
+clean:
+	rm -f *.o $(EXE) *.bc *.hip* *.out* *.s *.hsaco
+

--- a/tools/memoryWAR/memoryWAR.cpp
+++ b/tools/memoryWAR/memoryWAR.cpp
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <sys/socket.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <cstdio>
+#include <string>
+#include <chrono>
+#include <hip/hip_runtime.h>
+#include <rccl/rccl.h>
+#include <cstdlib>
+#include <fstream>
+#include <iostream> //cerr
+#include <cstring>
+#include "memoryWAR.hpp"
+#include "non_caching_load.h"
+#include "non_caching_store.h"
+#include "non_caching_store_vec4.h"
+
+constexpr int N = 1024;
+typedef uint32_t uint32x4 __attribute__((ext_vector_type(4)));
+
+template<typename T>
+__global__ void writeKernel(T* data, T* out){
+    if constexpr (std::is_same<T, uint32x4>::value)
+        __non_caching_store_vec4<T>(data[0], out);
+    else
+        __non_caching_store<T>(data[0], out);
+}
+
+template<typename T>
+__global__ void readKernel(T* data, T* out){
+    T temp;
+    temp = __non_caching_load<T>(out);
+}
+
+template<typename T>
+void caching_load_store() {
+    T* d_data;
+    T* out;
+    size_t size = N * sizeof(d_data);
+
+    hipMalloc(&d_data, size);
+    hipMalloc(&out, size);
+
+    int* h_data = new int[N];
+    for(int i = 0; i < N; ++i){
+        h_data[i] = 105;
+    }
+
+    HIP_CALL(hipMemcpy(d_data, h_data, size, hipMemcpyHostToDevice));
+
+    dim3 threadsPerBlock(256);
+    dim3 blocksPerGrid((N + threadsPerBlock.x - 1) / threadsPerBlock.x);
+
+    std::cout << "Running Write After Read(WAR) Test" << std::endl;
+    hipLaunchKernelGGL(readKernel, blocksPerGrid, threadsPerBlock, 0, 0, d_data, out);
+    HIP_CALL(hipDeviceSynchronize());
+    hipLaunchKernelGGL(writeKernel, blocksPerGrid, threadsPerBlock, 0, 0, d_data, out);
+    HIP_CALL(hipDeviceSynchronize());
+    hipLaunchKernelGGL(readKernel, blocksPerGrid, threadsPerBlock, 0, 0, d_data, out);
+
+    HIP_CALL(hipMemcpy(h_data, d_data, size, hipMemcpyDeviceToHost));
+
+    HIP_CALL(hipFree(d_data));
+    delete[] h_data;
+
+    std::cout << "Testing done" << std::endl;
+
+    return;
+}
+
+int main(int argc, char **argv){
+    caching_load_store<uint64_t>();
+    caching_load_store<uint32_t>();
+    caching_load_store<uint16_t>();
+    caching_load_store<uint8_t>();
+    using V2 = unsigned __attribute__((ext_vector_type(4)));
+    caching_load_store<V2>();
+
+    return 0;
+}
+

--- a/tools/memoryWAR/memoryWAR.hpp
+++ b/tools/memoryWAR/memoryWAR.hpp
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef HELLORCCL_HPP
+#define HELLORCCL_HPP
+#include <iostream>
+
+#define HIP_CALL(cmd)                                                 \
+  do {                                                                \
+    hipError_t error = (cmd);                                         \
+    if (error != hipSuccess)                                          \
+    {                                                                   \
+      std::cerr << "Encountered HIP error (" << hipGetErrorString(error) << ") at line " \
+                << __LINE__ << " in file " << __FILE__ << "\n";         \
+      exit(-1);                                                         \
+    }                                                                   \
+  } while (0)
+
+#define NCCL_CALL(cmd) \
+  do { \
+    ncclResult_t error = (cmd);                 \
+    if (error != ncclSuccess)                   \
+    {                                           \
+      std::cerr << "Encountered NCCL error (" << ncclGetErrorString(error) << ") at line " \
+                << __LINE__ << " in file " << __FILE__ << "\n";         \
+      exit(-1);                                                         \
+    }                                                                   \
+  } while (0)
+
+#endif
+

--- a/tools/memoryWAW/Makefile
+++ b/tools/memoryWAW/Makefile
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+# Set to where RCCL is installed
+RCCL_INSTALL=../../build/release
+
+HIP_PATH?= $(wildcard /opt/rocm)
+ifeq (,$(HIP_PATH))
+HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+EXE=memoryWAW
+CXXFLAGS = -std=c++11 -O3 -I../../src/include  -I../../src/device -I$(RCCL_INSTALL)/include -L$(RCCL_INSTALL) -lrccl
+
+all: $(EXE)
+
+$(EXE): $(EXE).cpp $(shell find -regex ".*\.\hpp")
+	$(HIPCC) $(CXXFLAGS) $< -o $@
+
+clean:
+	rm -f *.o $(EXE) *.bc *.hip* *.out* *.s *.hsaco
+

--- a/tools/memoryWAW/memoryWAW.cpp
+++ b/tools/memoryWAW/memoryWAW.cpp
@@ -1,0 +1,109 @@
+/*
+Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <sys/socket.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <cstdio>
+#include <string>
+#include <chrono>
+#include <hip/hip_runtime.h>
+#include <rccl/rccl.h>
+#include <cstdlib>
+#include <fstream>
+#include <iostream> //cerr
+#include <cstring>
+#include "memoryWAW.hpp"
+#include "non_caching_load.h"
+#include "non_caching_store.h"
+#include "non_caching_store_vec4.h"
+
+constexpr int N = 1024;
+typedef uint32_t uint32x4 __attribute__((ext_vector_type(4)));
+
+template<typename T>
+__global__ void writeKernel(T* data, T* out){
+    // first write
+    if constexpr (std::is_same<T, uint32x4>::value)
+        __non_caching_store_vec4<T>(data[0], out);
+    else
+        __non_caching_store<T>(data[0], out);
+
+    // second write
+    if constexpr (std::is_same<T, uint32x4>::value)
+        __non_caching_store_vec4<T>(data[0], out);
+    else
+        __non_caching_store<T>(data[0], out);
+}
+
+template<typename T>
+__global__ void readKernel(T* data, T* out){
+    T temp;
+    temp = __non_caching_load<T>(out);
+}
+
+template<typename T>
+void caching_load_store() {
+    T* d_data;
+    T* out;
+    size_t size = N * sizeof(d_data);
+
+    hipMalloc(&d_data, size);
+    hipMalloc(&out, size);
+
+    int* h_data = new int[N];
+    for(int i = 0; i < N; ++i){
+        h_data[i] = 105;
+    }
+
+    HIP_CALL(hipMemcpy(d_data, h_data, size, hipMemcpyHostToDevice));
+
+    dim3 threadsPerBlock(256);
+    dim3 blocksPerGrid((N + threadsPerBlock.x - 1) / threadsPerBlock.x);
+
+    std::cout << "Running Write After Write(WAW) Test" << std::endl;
+    hipLaunchKernelGGL(writeKernel, blocksPerGrid, threadsPerBlock, 0, 0, d_data, out);
+    HIP_CALL(hipDeviceSynchronize());
+    hipLaunchKernelGGL(readKernel, blocksPerGrid, threadsPerBlock, 0, 0, d_data, out);
+
+    HIP_CALL(hipMemcpy(h_data, d_data, size, hipMemcpyDeviceToHost));
+
+    HIP_CALL(hipFree(d_data));
+    delete[] h_data;
+
+    std::cout << "Testing done" << std::endl;
+
+    return;
+}
+
+int main(int argc, char **argv){
+    caching_load_store<uint64_t>();
+    caching_load_store<uint32_t>();
+    caching_load_store<uint16_t>();
+    caching_load_store<uint8_t>();
+    using V2 = unsigned __attribute__((ext_vector_type(4)));
+    caching_load_store<V2>();
+
+    return 0;
+}
+

--- a/tools/memoryWAW/memoryWAW.hpp
+++ b/tools/memoryWAW/memoryWAW.hpp
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef HELLORCCL_HPP
+#define HELLORCCL_HPP
+#include <iostream>
+
+#define HIP_CALL(cmd)                                                 \
+  do {                                                                \
+    hipError_t error = (cmd);                                         \
+    if (error != hipSuccess)                                          \
+    {                                                                   \
+      std::cerr << "Encountered HIP error (" << hipGetErrorString(error) << ") at line " \
+                << __LINE__ << " in file " << __FILE__ << "\n";         \
+      exit(-1);                                                         \
+    }                                                                   \
+  } while (0)
+
+#define NCCL_CALL(cmd) \
+  do { \
+    ncclResult_t error = (cmd);                 \
+    if (error != ncclSuccess)                   \
+    {                                           \
+      std::cerr << "Encountered NCCL error (" << ncclGetErrorString(error) << ") at line " \
+                << __LINE__ << " in file " << __FILE__ << "\n";         \
+      exit(-1);                                                         \
+    }                                                                   \
+  } while (0)
+
+#endif
+

--- a/tools/non-caching-load/Makefile
+++ b/tools/non-caching-load/Makefile
@@ -9,8 +9,8 @@ HIP_PATH=../../..
 endif
 HIPCC=$(HIP_PATH)/bin/hipcc
 
-EXE=non-caching-store
-CXXFLAGS = -std=c++11 -O3 -I../../src/include  -I../../src/device -I$(RCCL_INSTALL)/include -L$(RCCL_INSTALL) -lrccl
+EXE=non-caching-load
+CXXFLAGS = -std=c++11 -O3 -I../../src/include  -I../../src/device -I$(RCCL_INSTALL) -L$(RCCL_INSTALL) -lrccl
 
 all: $(EXE)
 

--- a/tools/non-caching-load/non-caching-load.cpp
+++ b/tools/non-caching-load/non-caching-load.cpp
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <sys/socket.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <cstdio>
+#include <string>
+#include <chrono>
+#include <hip/hip_runtime.h>
+#include <rccl/rccl.h>
+#include <cstdlib>
+#include <fstream>
+#include <iostream> //cerr
+#include <cstring>
+#include "non-caching-load.hpp"
+#include "non_caching_load.h"
+
+typedef uint32_t uint32x4 __attribute__((ext_vector_type(4)));
+
+template<typename T>
+__global__ void nonCachingLoad(T* p, T* out){
+  if constexpr (std::is_same<T, uint32x4>::value)
+    p[0] = {22, 22, 22, 22};
+  else
+    p[0] = 22;
+	out[0] = __non_caching_load<T>(p);
+}
+
+template<typename T>
+__global__ void builtinTemporalLoad(T* p, T* out){
+  if constexpr (std::is_same<T, uint32x4>::value)
+    p[0] = {22, 22, 22, 22};
+  else
+    p[0] = 22;
+	out[0] = __builtin_nontemporal_load(p);
+}
+
+template<typename T>
+void caching_load() {
+  T* data;
+  T* out1;
+  T* out2;
+  size_t size = sizeof(data);
+
+  hipMalloc(&data, size);
+  hipMalloc(&out1, size);
+  hipMalloc(&out2, size);
+
+  hipLaunchKernelGGL(nonCachingLoad<T>, dim3(1), dim3(1), 0, 0, data, out1);
+  hipLaunchKernelGGL(builtinTemporalLoad<T>, dim3(1), dim3(1), 0, 0, data, out2);
+
+  hipDeviceSynchronize();
+
+  T* host_data = (T*)malloc(size);
+  T* h_o1 = (T*)malloc(size);
+  T* h_o2 = (T*)malloc(size);
+
+  hipMemcpy(host_data, data, size, hipMemcpyDeviceToHost);
+  hipMemcpy(h_o1, out1, size, hipMemcpyDeviceToHost);
+  hipMemcpy(h_o2, out2, size, hipMemcpyDeviceToHost);
+
+  if constexpr (std::is_same<T, uint32x4>::value)
+  {
+    if ( ((*h_o1)[0] == (*h_o2)[0]) && ((*h_o1)[1] == (*h_o2)[1]) && ((*h_o1)[2] == (*h_o2)[2])
+     && ((*h_o1)[3] == (*h_o2)[3]))
+      std::cout << "PASS" << std::endl;
+    else
+      std::cout << "FAIL" << std::endl; 
+  }
+  else {
+    if(*h_o1 == *h_o2)
+    {
+      std::cout << "PASS" << std::endl; 
+    }
+    else{
+      std::cout << "FAIL" << std::endl;
+    }
+  }
+
+  hipFree(data);
+  return;
+}
+
+int main(int argc, char **argv)
+{
+  caching_load<uint64_t>();
+  caching_load<uint32_t>();
+  caching_load<uint16_t>();
+  caching_load<uint8_t>();
+  using V2 = unsigned __attribute__((ext_vector_type(4)));
+  caching_load<V2>();
+
+  return 0;
+}
+

--- a/tools/non-caching-load/non-caching-load.hpp
+++ b/tools/non-caching-load/non-caching-load.hpp
@@ -1,13 +1,16 @@
 /*
 Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
+
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE

--- a/tools/non-caching-store/Makefile
+++ b/tools/non-caching-store/Makefile
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+
+# Set to where RCCL is installed
+RCCL_INSTALL=../../build/release
+
+HIP_PATH?= $(wildcard /opt/rocm)
+ifeq (,$(HIP_PATH))
+HIP_PATH=../../..
+endif
+HIPCC=$(HIP_PATH)/bin/hipcc
+
+EXE=non-caching-store
+CXXFLAGS = -std=c++11 -O3 -I../../src/include  -I../../src/device -I$(RCCL_INSTALL)/include -L$(RCCL_INSTALL) -lrccl
+
+all: $(EXE)
+
+$(EXE): $(EXE).cpp $(shell find -regex ".*\.\hpp")
+	$(HIPCC) $(CXXFLAGS) $< -o $@
+
+clean:
+	rm -f *.o $(EXE)

--- a/tools/non-caching-store/non-caching-store.cpp
+++ b/tools/non-caching-store/non-caching-store.cpp
@@ -78,3 +78,4 @@ int main(int argc, char **argv)
 
     return 0;
 }
+

--- a/tools/non-caching-store/non-caching-store.cpp
+++ b/tools/non-caching-store/non-caching-store.cpp
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <sys/socket.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <cstdio>
+#include <string>
+#include <chrono>
+#include <hip/hip_runtime.h>
+#include <rccl/rccl.h>
+#include <cstdlib>
+#include <fstream>
+#include <iostream> //cerr
+#include <cstring>
+#include "non-caching-store.hpp"
+#include "non_caching_store.h"
+#include "non_caching_store_vec4.h"
+
+typedef uint32_t uint32x4 __attribute__((ext_vector_type(4)));
+
+template<typename T>
+__global__ void nonCachingStore(T* out){
+    T val[4];
+    if constexpr (std::is_same<T, uint32x4>::value){
+        val[4] = {22, 22, 22, 22};
+        __non_caching_store_vec4<T>(val[0], out);
+    }
+    else{
+        val[0] = 22;
+        __non_caching_store<T>(val[0], out);
+    }
+    return;
+}
+
+template<typename T>
+void cachingStore() {
+    T* out1;
+    size_t size = sizeof(out1);
+    hipMalloc(&out1, size);
+
+    hipLaunchKernelGGL(nonCachingStore<T>, dim3(1), dim3(1), 0, 0, out1);
+    hipDeviceSynchronize();
+
+    T* h_o1 = (T*)malloc(size);
+    hipMemcpy(h_o1, out1, size, hipMemcpyDeviceToHost);
+
+    hipFree(out1);
+    hipFree(h_o1);
+    return;
+}
+
+int main(int argc, char **argv)
+{
+    cachingStore<uint64_t>();
+    cachingStore<uint32_t>();
+    cachingStore<uint16_t>();
+    cachingStore<uint8_t>();
+    using V2 = unsigned __attribute__((ext_vector_type(4)));
+    cachingStore<V2>();
+
+    return 0;
+}

--- a/tools/non-caching-store/non-caching-store.hpp
+++ b/tools/non-caching-store/non-caching-store.hpp
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef HELLORCCL_HPP
+#define HELLORCCL_HPP
+#include <iostream>
+
+#define HIP_CALL(cmd)                                                 \
+  do {                                                                \
+    hipError_t error = (cmd);                                         \
+    if (error != hipSuccess)                                          \
+    {                                                                   \
+      std::cerr << "Encountered HIP error (" << hipGetErrorString(error) << ") at line " \
+                << __LINE__ << " in file " << __FILE__ << "\n";         \
+      exit(-1);                                                         \
+    }                                                                   \
+  } while (0)
+
+#define NCCL_CALL(cmd) \
+  do { \
+    ncclResult_t error = (cmd);                 \
+    if (error != ncclSuccess)                   \
+    {                                           \
+      std::cerr << "Encountered NCCL error (" << ncclGetErrorString(error) << ") at line " \
+                << __LINE__ << " in file " << __FILE__ << "\n";         \
+      exit(-1);                                                         \
+    }                                                                   \
+  } while (0)
+
+#endif


### PR DESCRIPTION
RCCL provides "low latency" protocols for communication between agents, where the entire message consisting of data and flags is packed into a single L2 cache line. This is usually accomplished using atomic relaxed instructions in LLVM. But the 128-byte version of this protocol (LL-128) requires 128-bit load or store instructions that bypass the cache and are not broken up into multiple instructions. The nontemporal builtin is not always suitable for this use case.

The proposed approach is to provide a C++ function template that encapsulates an inline assembly call. This asm is intended to use the appropriate load/store parameters for each combination of data size and architecture.