### PR TITLE
[MSCCLPP] IBVerbs: Check if IBV_ACCESS_RELAXED_ORDERING exists

### DIFF
--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -71,6 +71,10 @@ if(ENABLE_MSCCLPP)
            COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/read-allred.patch
            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
+        execute_process(
+            COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mscclpp_ibv_access_relaxed_ordering.patch
+            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+        )
 
         message(STATUS "Building mscclpp only for gfx942.")
 
@@ -104,6 +108,10 @@ if(ENABLE_MSCCLPP)
 	execute_process(
            COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/read-allred.patch
            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+        )
+        execute_process(
+            COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mscclpp_ibv_access_relaxed_ordering.patch
+            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
     endif()
 

--- a/ext-src/check_ibv_access_relaxed_ordering.cc
+++ b/ext-src/check_ibv_access_relaxed_ordering.cc
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <infiniband/verbs.h>
+
+int main(void) {
+  enum ibv_access_flags has_ibv_access_relaxed_ordering = IBV_ACCESS_RELAXED_ORDERING;
+  printf("IBV_ACCESS_RELAXED_ORDERING: %d\n", has_ibv_access_relaxed_ordering);
+  return 0;
+}

--- a/ext-src/mscclpp_ibv_access_relaxed_ordering.patch
+++ b/ext-src/mscclpp_ibv_access_relaxed_ordering.patch
@@ -1,0 +1,51 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a95a8e5..62b4f22 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -96,6 +96,24 @@ include(${PROJECT_SOURCE_DIR}/cmake/AddFormatTargets.cmake)
+ 
+ # Find ibverbs and libnuma
+ find_package(IBVerbs)
++
++# Check if IBV_ACCESS_RELAXED_ORDERING exists in infiniband/verbs.h
++# Disable use of this symbol in mscclpp/src/ib.cc if it does not exist
++if(IBVERBS_FOUND)
++  try_compile(HAS_IBV_ACCESS_RELAXED_ORDERING
++    ${CMAKE_BINARY_DIR}
++    "${CMAKE_CURRENT_SOURCE_DIR}/../check_ibv_access_relaxed_ordering.cc"
++    CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${IBVERBS_INCLUDE_DIRS}"
++    OUTPUT_VARIABLE try_compile_output
++  )
++  message(STATUS "try_compile_output: ${try_compile_output}")
++  if(NOT HAS_IBV_ACCESS_RELAXED_ORDERING)
++    message(WARNING "IBV_ACCESS_RELAXED_ORDERING does not exist in ${IBVERBS_INCLUDE_DIRS}/infiniband/verbs.h. Disabling this symbol in mscclpp/src/ib.cc.")
++  else()
++    message(STATUS "IBV_ACCESS_RELAXED_ORDERING exists in ${IBVERBS_INCLUDE_DIRS}/infiniband/verbs.h.")
++  endif()
++endif()
++
+ find_package(NUMA REQUIRED)
+ find_package(Threads REQUIRED)
+ 
+diff --git a/src/ib.cc b/src/ib.cc
+index d9d72d1..bddd4a8 100644
+--- a/src/ib.cc
++++ b/src/ib.cc
+@@ -48,9 +48,17 @@ IbMr::IbMr(ibv_pd* pd, void* buff, std::size_t size) : buff(buff) {
+   }
+   uintptr_t addr = reinterpret_cast<uintptr_t>(buff) & -pageSize;
+   std::size_t pages = (size + (reinterpret_cast<uintptr_t>(buff) - addr) + pageSize - 1) / pageSize;
++
++#if defined(HAS_IBV_ACCESS_RELAXED_ORDERING)
+   this->mr = IBVerbs::ibv_reg_mr2(pd, reinterpret_cast<void*>(addr), pages * pageSize,
+                                   IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ |
+                                       IBV_ACCESS_RELAXED_ORDERING | IBV_ACCESS_REMOTE_ATOMIC);
++#else
++  this->mr = IBVerbs::ibv_reg_mr2(pd, reinterpret_cast<void*>(addr), pages * pageSize,
++                                  IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ |
++                                      IBV_ACCESS_REMOTE_ATOMIC);
++#endif
++
+   if (this->mr == nullptr) {
+     std::stringstream err;
+     err << "ibv_reg_mr failed (errno " << errno << ")";


### PR DESCRIPTION
## Details

**Work item:**
SWDEV-506051

**What were the changes?**  
When building MSCCLPP, check if `IBV_ACCESS_RELAXED_ORDERING` is defined in `infiniband/verbs.h`. If not, disable symbol use in `ext-src/mscclpp/src/ib.cc`

**Why were the changes made?**  
Some environments (like Debian 10) inherently support older versions of `libibverbs` (e.g. 22.1-1) that do not have `IBV_ACCESS_RELAXED_ORDERING` defined. This can cause a compile-time error when building RCCL with MSCCL++ support.

**How was the outcome achieved?**  
Patching MSCCLPP's CMakeLists.txt to check if `IBV_ACCESS_RELAXED_ORDERING` is defined in `infiniband/verbs.h`. If not, disable the use of this symbol in MSCCLPP's `src/ib.cc`

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
