### PR TITLE
[SWDEV-497665] Cherry-pick: Blocked `cudaMemcpyAsync` race condition by synchronizing (#1447)

### DIFF
--- a/src/transport.cc
+++ b/src/transport.cc
@@ -263,6 +263,8 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
     }
   }
 
+  CUDACHECKGOTO(cudaStreamSynchronize(comm->sharedRes->hostStream.cudaStream), ret, fail);
+
   if (timeReported) {
     struct timeval now;
     gettimeofday(&now, NULL);


### PR DESCRIPTION
Cherry-pick of PR #1447 for ROCm 6.3.2