### PR TITLE
Increased gfx90a stack size expectation to 320 in unit tests

### DIFF
--- a/test/common/StandaloneUtils.hpp
+++ b/test/common/StandaloneUtils.hpp
@@ -28,7 +28,7 @@
 #define MAX_STACK_SIZE 448
 
 #ifdef ENABLE_LL128
-#define MAX_STACK_SIZE_gfx90a 296
+#define MAX_STACK_SIZE_gfx90a 320
 #else
 #define MAX_STACK_SIZE_gfx90a MAX_STACK_SIZE
 #endif


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** Internal

**What were the changes?**  
Increased gfx90a stack size expectation to 320 in unit tests

**Why were the changes made?**  
Stack size changed on this platform in latest compiler mainline.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
