### PR TITLE
fix crash for scatter_perf

### DIFF
--- a/ext-src/mem-reg.patch
+++ b/ext-src/mem-reg.patch
@@ -1,26 +1,28 @@
 diff --git a/apps/nccl/include/nccl.h b/apps/nccl/include/nccl.h
-index 7f50792..b8b146d 100644
+index bfdb226..1f0cc74 100644
 --- a/apps/nccl/include/nccl.h
 +++ b/apps/nccl/include/nccl.h
-@@ -344,6 +344,13 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
- ncclResult_t pncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
-                             ncclComm_t comm, cudaStream_t stream);
+@@ -78,6 +78,15 @@ ncclResult_t pncclMemAlloc(void** ptr, size_t size);
+ ncclResult_t ncclMemFree(void* ptr);
+ ncclResult_t pncclMemFree(void* ptr);
  
 +/*
 + * Register/Deregister
 + */
 +ncclResult_t ncclCommRegister(ncclComm_t comm, void* buff, size_t size, void** handle);
 +ncclResult_t ncclCommDeregister(ncclComm_t comm, void* handle);
-+bool mscclpp_BuffIsRegistered(ncclComm_t comm, const void* buff, size_t count);
++bool mscclpp_BuffIsRegistered(ncclComm_t comm, const void* buff);
 +size_t mscclpp_BufferSize(ncclComm_t comm, void* handle);
- /*
-  * Send
-  *
++
++
+ /* Return the NCCL_VERSION_CODE of the NCCL library in the supplied integer.
+  * This integer is coded with the MAJOR, MINOR and PATCH level of the
+  * NCCL library
 diff --git a/apps/nccl/src/nccl.cu b/apps/nccl/src/nccl.cu
-index a697be2..1d4af61 100644
+index 022d398..468fcf2 100644
 --- a/apps/nccl/src/nccl.cu
 +++ b/apps/nccl/src/nccl.cu
-@@ -65,6 +65,7 @@ struct ncclComm {
+@@ -85,6 +85,7 @@ struct ncclComm {
    std::unordered_map<channelKey, ChannelInfo> channelInInfos;
    std::unordered_map<channelKey, ChannelInfo> channelOutInfos;
    std::unordered_map<channelKey, ChannelInfo> channelScratchInfos;
@@ -28,7 +30,7 @@ index a697be2..1d4af61 100644
    std::shared_ptr<char> scratchBuff;
    std::vector<mscclpp::RegisteredMemory> remoteScratchRegMemories;
  
-@@ -73,6 +74,11 @@ struct ncclComm {
+@@ -92,6 +93,11 @@ struct ncclComm {
    uint32_t buffFlag;
  };
  
@@ -40,8 +42,8 @@ index a697be2..1d4af61 100644
  static size_t ncclTypeSize(ncclDataType_t type) {
    switch (type) {
      case ncclInt8:
-@@ -577,6 +583,104 @@ NCCL_API ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t
-   return ncclSuccess;
+@@ -561,6 +567,107 @@ NCCL_API ncclResult_t ncclRedOpDestroy(ncclRedOp_t, ncclComm_t) {
+   return ncclInternalError;
  }
  
 +NCCL_API ncclResult_t ncclCommRegister(ncclComm_t comm, void* buff, size_t size, void** handle) {
@@ -125,7 +127,9 @@ index a697be2..1d4af61 100644
 +  return ncclSuccess;
 +}
 +
-+bool mscclpp_BuffIsRegistered(ncclComm_t comm, const void* buff, size_t count){
++bool mscclpp_BuffIsRegistered(ncclComm_t comm, const void* buff){
++  if(buff == nullptr)
++    return false;
 +  size_t buffBytes;
 +  CUdeviceptr buffBasePtr;
 +  MSCCLPP_CUTHROW(cuMemGetAddressRange(&buffBasePtr, &buffBytes, (CUdeviceptr)buff));
@@ -142,6 +146,7 @@ index a697be2..1d4af61 100644
 +  auto buffKeyIt = comm->handleKeys.find(handle);
 +  return buffKeyIt != comm->handleKeys.end() ? buffKeyIt->second.bytes : 0;
 +}
- NCCL_API ncclResult_t ncclSend(const void*, size_t, ncclDataType_t, int, ncclComm_t, cudaStream_t) {
++
+ NCCL_API ncclResult_t ncclReduce(const void*, void*, size_t, ncclDataType_t, ncclRedOp_t, int, ncclComm_t,
+                                  cudaStream_t) {
    // TODO: implement this function
-   return ncclInternalError;

--- a/src/include/mscclpp/mscclpp_nccl.h
+++ b/src/include/mscclpp/mscclpp_nccl.h
@@ -43,7 +43,7 @@ extern "C" {
 
   ncclResult_t mscclpp_ncclCommDeregister(mscclppComm_t comm, void* handle);
 
-  bool mscclpp_BuffIsRegistered(mscclppComm_t comm, const void* buff, size_t count);
+  bool mscclpp_BuffIsRegistered(mscclppComm_t comm, const void* buff);
 
   size_t mscclpp_BufferSize(mscclppComm_t comm, void* handle);
 }

--- a/src/misc/msccl/msccl_lifecycle.cc
+++ b/src/misc/msccl/msccl_lifecycle.cc
@@ -524,8 +524,8 @@ ncclResult_t mscclEnqueueCheck(
           NCCLCHECK(mscclGetCaptureStatus(comm->rank, stream));
         }
 
-        const bool sendBuffRegistered = mscclpp_BuffIsRegistered(comm->mscclpp_comm, sendBuff, count); 
-        const bool recvBuffRegistered = mscclpp_BuffIsRegistered(comm->mscclpp_comm, recvBuff, count);
+        const bool sendBuffRegistered = mscclpp_BuffIsRegistered(comm->mscclpp_comm, sendBuff); 
+        const bool recvBuffRegistered = mscclpp_BuffIsRegistered(comm->mscclpp_comm, recvBuff);
         const bool graphMode = threadLocalStatus.captureStatus != mscclNoCapture;
         const bool buffsRegistedNonGraphMode = !graphMode && sendBuffRegistered && recvBuffRegistered;
 
@@ -570,8 +570,8 @@ ncclResult_t mscclEnqueueCheck(
           NCCLCHECK(mscclGetCaptureStatus(comm->rank, stream));
         }
 
-        const bool sendBuffRegistered = mscclpp_BuffIsRegistered(comm->mscclpp_comm, sendBuff, count); 
-        const bool recvBuffRegistered = mscclpp_BuffIsRegistered(comm->mscclpp_comm, recvBuff, count);
+        const bool sendBuffRegistered = mscclpp_BuffIsRegistered(comm->mscclpp_comm, sendBuff); 
+        const bool recvBuffRegistered = mscclpp_BuffIsRegistered(comm->mscclpp_comm, recvBuff);
         const bool graphMode = threadLocalStatus.captureStatus != mscclNoCapture;
         const bool buffsRegistedNonGraphMode = !graphMode && sendBuffRegistered && recvBuffRegistered;
 


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Updated a routine in MSCCL++ that is introduced through the mem-reg.patch

**Why were the changes made?**  
In rccl-tests, scatter_perf was crashing.

**How was the outcome achieved?**  
The crash occured in mscclpp_BuffIsRegistered. The issue was caused by send buffer that was set to null, which was then passed to mscclpp_BuffIsRegistered. Now the routine checks if the buffer is null and returns false if that is the case. I also removed an unused parameter.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
