### PR TITLE
Hide all warnings when compiling the mscclpp project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option(ENABLE_MSCCL_KERNEL                     "Enable MSCCL while compiling"   
 option(ENABLE_MSCCLPP                          "Enable MSCCL++"                                ON)
 option(ENABLE_IFC                              "Enable indirect function call"                 OFF)
 option(INSTALL_DEPENDENCIES                    "Force install dependencies"                    OFF)
+option(MSCCLPP_HIDE_WARNINGS                   "Silence warnings when building mscclpp"        ON)
 option(ROCTX                                   "Enable ROCTX"                                  OFF)
 option(PROFILE                                 "Enable profiling"                              OFF)
 option(TIMETRACE                               "Enable time-trace during compilation"          OFF)

--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -64,6 +64,14 @@ if(ENABLE_MSCCLPP)
             )
         endif()
 
+        if(MSCCLPP_HIDE_WARNINGS)
+            execute_process(
+                COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/no_cpp_warnings.patch
+                WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+            )
+            set(HIDE_WARNINGS_ARG "-DCMAKE_CXX_FLAGS=-Wno-everything")
+        endif()
+
         execute_process(
            COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/cpx.patch
            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
@@ -98,7 +106,7 @@ if(ENABLE_MSCCLPP)
                          #GIT_REPOSITORY      https://github.com/microsoft/mscclpp.git
                          #GIT_TAG             4ee15b7ad085daaf74349d4c49c9b8480d28f0dc
                          INSTALL_DIR         ${MSCCLPP_ROOT}
-                         CMAKE_ARGS          -DAMDGPU_TARGETS=${GFX942_VARIANT} -DGPU_TARGETS=${GFX942_VARIANT} -DMSCCLPP_BYPASS_GPU_CHECK=ON -DMSCCLPP_USE_ROCM=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DMSCCLPP_BUILD_APPS_NCCL=ON -DMSCCLPP_BUILD_PYTHON_BINDINGS=OFF -DMSCCLPP_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> "${CMAKE_PREFIX_PATH_ARG}" -DCMAKE_VERBOSE_MAKEFILE=1 "${CMAKE_INSTALL_RPATH_USE_LINK_PATH_ARG}" "${HIP_COMPILER_ARG}" -DFETCHCONTENT_SOURCE_DIR_JSON=${CMAKE_CURRENT_SOURCE_DIR}/ext-src/json
+                         CMAKE_ARGS          "${HIDE_WARNINGS_ARG}" -DAMDGPU_TARGETS=${GFX942_VARIANT} -DGPU_TARGETS=${GFX942_VARIANT} -DMSCCLPP_BYPASS_GPU_CHECK=ON -DMSCCLPP_USE_ROCM=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DMSCCLPP_BUILD_APPS_NCCL=ON -DMSCCLPP_BUILD_PYTHON_BINDINGS=OFF -DMSCCLPP_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> "${CMAKE_PREFIX_PATH_ARG}" -DCMAKE_VERBOSE_MAKEFILE=1 "${CMAKE_INSTALL_RPATH_USE_LINK_PATH_ARG}" "${HIP_COMPILER_ARG}" -DFETCHCONTENT_SOURCE_DIR_JSON=${CMAKE_CURRENT_SOURCE_DIR}/ext-src/json
                          LOG_DOWNLOAD        FALSE
                          LOG_CONFIGURE       FALSE
                          LOG_BUILD           FALSE
@@ -109,6 +117,13 @@ if(ENABLE_MSCCLPP)
 
      
         find_package(mscclpp_nccl REQUIRED)
+        if(MSCCLPP_HIDE_WARNINGS)
+            execute_process(
+                COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/no_cpp_warnings.patch
+                WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+            )
+        endif()
+
 	    execute_process(
            COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/cpx.patch
            WORKING_DIRECTORY ${MSCCLPP_SOURCE}

--- a/ext-src/no_cpp_warnings.patch
+++ b/ext-src/no_cpp_warnings.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a94b634..cc5d948 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -58,7 +58,7 @@ endif()
+ 
+ # Declare project
+ set(CMAKE_CXX_STANDARD 17)
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
++#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+ if(MSCCLPP_USE_CUDA)
+     set(CMAKE_CUDA_STANDARD 17)
+     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wall,-Wextra")
+@@ -92,7 +92,7 @@ else()
+ endif()
+ 
+ # Format targets
+-include(${PROJECT_SOURCE_DIR}/cmake/AddFormatTargets.cmake)
++#include(${PROJECT_SOURCE_DIR}/cmake/AddFormatTargets.cmake)
+ 
+ # Find ibverbs and libnuma
+ find_package(IBVerbs)


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**What were the changes?**  
Added a patch and cmake flags to hide all warnings generated when compiling mscclpp project. Switched this behaviour on the MSCCLPP_HIDE_WARNINGS flag in rccl cmake.

**Why were the changes made?**  
The build of mscclpp generated many warnings that added noise to the rccl build process. Since we do not maintain mscclpp, it may not be important to see these warnings.

**How was the outcome achieved?**  
Passed `CMAKE_CXX_FLAGS=-Wno-everything` to mscclpp cmake process. Used another patch to disable lines in mscclpp CMakeLists.txt that enabled or created warnings.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
