### PR TITLE
Disabled MSCCL++ feature except when building on Ubuntu or CentOS host systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,7 @@ if (HAVE_PARALLEL_JOBS)
 endif()
 
 ## Disable building MSCCL++ if the build environment is invalid
-## Currently MSCCL++ is supported only on gfx942
+## Currently MSCCL++ is supported only on gfx942, and only on Ubuntu
 if (ENABLE_MSCCLPP AND NOT ("gfx942" IN_LIST COMPILING_TARGETS OR "gfx942:xnack-" IN_LIST COMPILING_TARGETS OR "gfx942:xnack+" IN_LIST COMPILING_TARGETS))
   set(ENABLE_MSCCLPP OFF)
   message(WARNING "Can only build MSCCL++ for gfx942; disabling MSCCL++ build")
@@ -313,6 +313,11 @@ endif()
 if (ENABLE_MSCCLPP AND ROCM_VERSION VERSION_LESS "60200")
   set(ENABLE_MSCCLPP OFF)
   message(WARNING "MSCCL++ integration only supported on ROCm 6.2 or greater; disabling MSCCL++ build")
+endif()
+cmake_host_system_information(RESULT HOST_OS_NAME QUERY DISTRIB_NAME)
+if (ENABLE_MSCCLPP AND NOT(${HOST_OS_NAME} STREQUAL "Ubuntu"))
+  set(ENABLE_MSCCLPP OFF)
+  message(WARNING "MSCCL++ integration only supported on Ubuntu; disabling MSCCL++ build")
 endif()
 
 # Determine version from makefiles/version.mk and fill in templates

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,7 @@ if (HAVE_PARALLEL_JOBS)
 endif()
 
 ## Disable building MSCCL++ if the build environment is invalid
-## Currently MSCCL++ is supported only on gfx942, and only on Ubuntu
+## Currently MSCCL++ is supported only on gfx942, and only on Ubuntu and CentOS
 if (ENABLE_MSCCLPP AND NOT ("gfx942" IN_LIST COMPILING_TARGETS OR "gfx942:xnack-" IN_LIST COMPILING_TARGETS OR "gfx942:xnack+" IN_LIST COMPILING_TARGETS))
   set(ENABLE_MSCCLPP OFF)
   message(WARNING "Can only build MSCCL++ for gfx942; disabling MSCCL++ build")
@@ -314,10 +314,10 @@ if (ENABLE_MSCCLPP AND ROCM_VERSION VERSION_LESS "60200")
   set(ENABLE_MSCCLPP OFF)
   message(WARNING "MSCCL++ integration only supported on ROCm 6.2 or greater; disabling MSCCL++ build")
 endif()
-cmake_host_system_information(RESULT HOST_OS_NAME QUERY DISTRIB_NAME)
-if (ENABLE_MSCCLPP AND NOT(${HOST_OS_NAME} STREQUAL "Ubuntu"))
+cmake_host_system_information(RESULT HOST_OS_ID QUERY DISTRIB_ID)
+if (ENABLE_MSCCLPP AND NOT(${HOST_OS_ID} STREQUAL "ubuntu" OR ${HOST_OS_ID} STREQUAL "centos"))
   set(ENABLE_MSCCLPP OFF)
-  message(WARNING "MSCCL++ integration only supported on Ubuntu; disabling MSCCL++ build")
+  message(WARNING "MSCCL++ integration not supported on this OS (${HOST_OS_ID}); disabling MSCCL++ build")
 endif()
 
 # Determine version from makefiles/version.mk and fill in templates


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Added condition for MSCCL++ to only build on an Ubuntu or CentOS host system. Sets `ENABLE_MSCCLPP` flag to `OFF`.

**Why were the changes made?**  
Microsoft has said mscclpp is only supported on Ubuntu, so this removes unsupported configurations. CentOS has also been tested, so we will support it as well.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
