### PR TITLE
[MSCCLPP] Use boost/filesystem on SLES15

### DIFF
--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -85,6 +85,14 @@ if(ENABLE_MSCCLPP)
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
 
+        cmake_host_system_information(RESULT HOST_OS_NAME QUERY DISTRIB_NAME)
+        if(${HOST_OS_NAME} STREQUAL "SLES")
+            execute_process(
+                COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/sles-cpp-filesystem.patch
+                WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+            )
+        endif()
+
         message(STATUS "Building mscclpp only for gfx942.")
         mscclpp_cmake_arg(CMAKE_PREFIX_PATH)
         mscclpp_cmake_arg(CMAKE_INSTALL_RPATH_USE_LINK_PATH)
@@ -128,6 +136,12 @@ if(ENABLE_MSCCLPP)
             COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mem-reg.patch
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
+        if(${HOST_OS_NAME} STREQUAL "SLES")
+            execute_process(
+                COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/sles-cpp-filesystem.patch
+                WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+            )
+        endif()
 
     #endif()
 

--- a/ext-src/sles-cpp-filesystem.patch
+++ b/ext-src/sles-cpp-filesystem.patch
@@ -1,0 +1,31 @@
+diff --git a/apps/nccl/src/nccl.cu b/apps/nccl/src/nccl.cu
+index 3daadf8..6b6aa83 100644
+--- a/apps/nccl/src/nccl.cu
++++ b/apps/nccl/src/nccl.cu
+@@ -2,7 +2,7 @@
+ // Licensed under the MIT license.
+ 
+ #include <algorithm>
+-#include <filesystem>
++#include <boost/filesystem.hpp>
+ #include <mscclpp/concurrency_device.hpp>
+ #include <mscclpp/core.hpp>
+ #include <mscclpp/env.hpp>
+@@ -417,13 +417,13 @@ NCCL_API ncclResult_t ncclCommInitRank(ncclComm_t* comm, int nranks, ncclUniqueI
+ 
+   const std::string& collectiveDir = mscclpp::env()->executionPlanDir;
+   if (collectiveDir != "") {
+-    if (!std::filesystem::is_directory(collectiveDir)) {
++    if (!boost::filesystem::is_directory(collectiveDir)) {
+       WARN("The value of the environment variable %s is not a directory", collectiveDir.c_str());
+       return ncclInvalidArgument;
+     }
+-    for (const auto& entry : std::filesystem::directory_iterator(collectiveDir)) {
+-      if (entry.is_regular_file()) {
+-        auto plan = loadExecutionPlan(entry.path());
++    for (const auto& entry : boost::filesystem::directory_iterator(collectiveDir)) {
++      if (boost::filesystem::is_regular_file(entry.status())) {
++        auto plan = loadExecutionPlan(entry.path().string());
+         commPtr->executionPlans[plan.first].push_back(plan.second);
+       }
+     }


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Use `boost/filesystem` instead of C++ 17 `filesystem` in MSCCLPP on SLES 15.

**Why were the changes made?**  
SLES 15.5 does not support C++ 17, so we cannot use `filesystem` methods. As an alternative, `boost/filesystem` can be used, but some modifications to MSCCLPP src are required.

**How was the outcome achieved?**  
Apply `sles-cpp-filesystem.patch` to MSCCLPP src if CMake determines that the OS is SLES.


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
