### PR TITLE
[UT] Include iomanip if not defined

### DIFF
--- a/test/common/TestBed.hpp
+++ b/test/common/TestBed.hpp
@@ -10,9 +10,7 @@
 #include "TestBedChild.hpp"
 #include "EnvVars.hpp"
 #include <gtest/gtest.h>
-#ifndef _GLIBCXX_IOMANIP
 #include <iomanip>
-#endif
 
 namespace RcclUnitTesting
 {

--- a/test/common/TestBed.hpp
+++ b/test/common/TestBed.hpp
@@ -10,6 +10,9 @@
 #include "TestBedChild.hpp"
 #include "EnvVars.hpp"
 #include <gtest/gtest.h>
+#ifndef _GLIBCXX_IOMANIP
+#include <iomanip>
+#endif
 
 namespace RcclUnitTesting
 {


### PR DESCRIPTION
## Details

**Work item:**
https://github.com/ROCm/rccl/issues/1455

**What were the changes?**  
If undefined, include the `iomanip` header file in RCCL UnitTests

**Why were the changes made?**  
Newer versions of GTest (like 1.15) do not include `iomanip` as part of `gtest/internal/gtest-internal.h`.
This can cause build failures for RCCL UnitTests (due to lack of symbols `std::setfill` and `std::setw`) if one uses pre-installed GTest (and does not build release-1.11.0 as part of RCCL dependencies).

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
