### PR TITLE
modify determination of physical memory size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -819,10 +819,11 @@ if (${memory_max_string} MATCHES "^[0-9]+")
   math(EXPR memory_in_gb "${memory_max_string} / (1024 * 1024 * 1024)")
 else()
   execute_process(
-    COMMAND bash "-c" "cat /sys/fs/cgroup/memory/memory.limit_in_bytes"
+    COMMAND bash "-c" "free | grep -o '[[:digit:]]*' | head -1"
     OUTPUT_VARIABLE memory_max_string)
+  ## memory_max_string holds the free memory in KB  
   if (${memory_max_string} MATCHES "^[0-9]+")
-    math(EXPR memory_in_gb "${memory_max_string} / (1024 * 1024 * 1024)")
+    math(EXPR memory_in_gb "${memory_max_string} / (1024 * 1024)") ## KB to GB conversion
   else()
     cmake_host_system_information(RESULT memory_max_string QUERY AVAILABLE_PHYSICAL_MEMORY )
     math(EXPR memory_in_gb "${memory_max_string} / 1024")


### PR DESCRIPTION
## Details
Change memory size determination to avoid linux default, which can result in max linker parallelism (16) and in turn cause out of memory crashes on systems with limited memory (<32GB)

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Modifies calculation of max memory in the build.

**Why were the changes made?**  
Existing use of cgroups memory limit can cause linker to incorrectly use max parallelism because linux defaults the memory.limit_in_bytes to be the span of virtual memory rounded to page size (PAGE_COUNTER_MAX in the kernel). This means the platform erroneously reports 2^64-4096 available bytes rather than the platform physical memory. The problem was observed in WSL ubuntu 24.04.

**How was the outcome achieved?**  
Modified cmake to determine physical memory from 'free'. Total physical memory in KB is the first number in the output from 'free'.

**Additional Documentation:**  
Alternatively, we could provide a cmake option to set the linker parallelism at the command line.


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.