### PR TITLE
Switched from `cmake_host_system_information` feature to a manual parse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # CMake version minimum requirements
 #==================================================================================================
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 # CMake Toolchain file to define compilers and path to ROCm
 #==================================================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,12 @@ if (ENABLE_MSCCLPP AND ROCM_VERSION VERSION_LESS "60200")
   set(ENABLE_MSCCLPP OFF)
   message(WARNING "MSCCL++ integration only supported on ROCm 6.2 or greater; disabling MSCCL++ build")
 endif()
-cmake_host_system_information(RESULT HOST_OS_ID QUERY DISTRIB_ID)
+# cmake_host_system_information(RESULT HOST_OS_ID QUERY DISTRIB_ID) ## Requires cmake 3.22
+execute_process(
+  COMMAND bash -c "grep '^ID=' /etc/os-release | cut -d'=' -f2"
+  OUTPUT_VARIABLE HOST_OS_ID
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 if (ENABLE_MSCCLPP AND NOT(${HOST_OS_ID} STREQUAL "ubuntu" OR ${HOST_OS_ID} STREQUAL "centos"))
   set(ENABLE_MSCCLPP OFF)
   message(WARNING "MSCCL++ integration not supported on this OS (${HOST_OS_ID}); disabling MSCCL++ build")


### PR DESCRIPTION
## Details

**What were the changes?**  
Removed use of `cmake_host_system_information`, replaced with manual bash parse of os-release file. Also updated the minimum cmake version to 3.16.

**Why were the changes made?**  
`cmake_host_system_information` is a cmake feature added in 3.22, but we want to remain compliant with cmake 3.16.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
