### PR TITLE
[BUILD] Fix unsupported arguments in generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,7 +639,7 @@ set(GEN_DIR "${HIPIFY_DIR}/gensrc")
 
 # Execute the python script to generate required files
 execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/device/generate.py ${GEN_DIR} ${IFC_ENABLED} ${COLLTRACE} ${ENABLE_MSCCL_KERNEL} ${BUILD_LOCAL_GPU_TARGET_ONLY} ${ONLY_FUNCS}
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/device/generate.py ${GEN_DIR} ${IFC_ENABLED} ${COLLTRACE} ${ENABLE_MSCCL_KERNEL} ${BUILD_LOCAL_GPU_TARGET_ONLY} ${ONLY_FUNCS}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     RESULT_VARIABLE gen_py_result
     ERROR_VARIABLE gen_py_error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ if(NOT DEFINED ROCM_PATH)
 else()
   message(STATUS "ROCM_PATH found: ${ROCM_PATH}")
 endif()
+set(ENV{ROCM_PATH} ${ROCM_PATH})
 
 if("${CMAKE_CXX_COMPILER}" MATCHES ".*amdclang\\+\\+")
   message(STATUS "Compiling with amdclang++")

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -137,7 +137,7 @@ def calc_unroll_for_local_arch():
   if not is_local_arch_only: 
     return
 
-  res = subprocess.run(['rocminfo'], capture_output=True, text=True)
+  res = subprocess.run(['rocminfo'], stdout=subprocess.PIPE, universal_newlines=True)
   rocminfo_output = res.stdout
   
   # Parse rocminfo binary output

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -137,7 +137,9 @@ def calc_unroll_for_local_arch():
   if not is_local_arch_only: 
     return
 
-  res = subprocess.run(['rocminfo'], stdout=subprocess.PIPE, universal_newlines=True)
+  rocminfo_path = os.environ.get('ROCM_PATH') + "/bin/rocminfo"
+
+  res = subprocess.run([rocminfo_path], stdout=subprocess.PIPE, universal_newlines=True)
   rocminfo_output = res.stdout
   
   # Parse rocminfo binary output


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal.

**What were the changes?**  
_One sentence describing the work done._
1) Forcing CMake to use the correct Python executable to ensure it doesn't default to an older system Python version during execution.

2) Add support for Python versions < 3.7 in generator script.

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._
Build can fail due to version mismatch and unsupported arguments in the generator script.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
