### PR TITLE
Cherry-pick to docs/6.3.2: Fix broken link to install instructions (#1515)

### DIFF
--- a/docs/install/installation.rst
+++ b/docs/install/installation.rst
@@ -24,7 +24,7 @@ Quick start RCCL build
 ======================
 
 RCCL directly depends on the HIP runtime plus the HIP-Clang compiler, which are part of the ROCm software stack.
-For ROCm installation instructions, see :doc:`rocm-install-on-linux:install/native-install/index`.
+For ROCm installation instructions, see the :doc:`package manager installation guide <rocm-install-on-linux:install/install-methods/package-manager-index>`.
 
 Use the `install.sh helper script <https://github.com/ROCm/rccl/blob/develop/install.sh>`_,
 located in the root directory of the RCCL repository,


### PR DESCRIPTION
(cherry picked from commit 134f7368824b0fdbf6baa9206301969bb09ead44)

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** "Internal"

**What were the changes?**  
Fixed a broken link to installation guide

**Why were the changes made?**  
The original target link had changed and the redirect wasn't working

**How was the outcome achieved?**  
Pointed the link to the correct target

**Additional Documentation:**  
No other changes. No functional changes.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
