### PR TITLE
[P2P] Have connIdx for both send and recv

### DIFF
--- a/src/device/common.h
+++ b/src/device/common.h
@@ -63,7 +63,8 @@
       collTrace->p2p.nSendChannels = p2pWork->nSendChannels; \
       collTrace->p2p.nRecvChannels = p2pWork->nRecvChannels; \
       collTrace->p2p.channelBase = p2pWork->channelBase; \
-      collTrace->p2p.connIndex = p2pWork->connIndex; \
+      collTrace->p2p.sendConnIndex = p2pWork->sendConnIndex; \
+      collTrace->p2p.recvConnIndex = p2pWork->recvConnIndex; \
       collTrace->p2p.sendProtoLL = p2pWork->sendProtoLL; \
       collTrace->p2p.recvProtoLL = p2pWork->recvProtoLL; \
       collTrace->p2pOpCount[0] = p2pWork->sendOpCount; \

--- a/src/device/sendrecv.h
+++ b/src/device/sendrecv.h
@@ -42,7 +42,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 
     Primitives<T, RedOp, FanAsymmetric<0, 1>, 0, Proto, 1>
       prims(tid, tn, nullptr, &work->sendRank, work->sendAddr, nullptr,
-            /*redOpArg(ignored)=*/0, group, work->connIndex, work->connIndex, nullptr,
+            /*redOpArg(ignored)=*/0, group, work->sendConnIndex, work->sendConnIndex, nullptr,
             /*userBufferMode=*/work->sendRegistered, ncclShmem.comm.p2pChunkSize);
 
 #if defined(ENABLE_NPKIT)
@@ -100,7 +100,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 
     Primitives<T, RedOp, FanAsymmetric<1, 0>, 0, Proto, 1>
       prims(tid, tn, &work->recvRank, nullptr, nullptr, work->recvAddr,
-            /*redOpArg(ignored)=*/0, group, work->connIndex, work->connIndex, nullptr,
+            /*redOpArg(ignored)=*/0, group, work->recvConnIndex, work->recvConnIndex, nullptr,
             /*userBufferMode=*/work->recvRegistered, ncclShmem.comm.p2pChunkSize);
 
 #if defined(ENABLE_NPKIT)

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -247,7 +247,7 @@ struct alignas(16) ncclDevWorkP2p {
   uint8_t sendProtoLL:1, recvProtoLL:1;
   uint8_t sendRegistered:1, recvRegistered:1;
 
-  uint8_t connIndex:2;
+  uint8_t sendConnIndex:2, recvConnIndex:2;
 };
 
 // Compute the subset of the data transfer corresponding to the given part index.
@@ -441,7 +441,8 @@ struct ncclCollTrace {
       uint8_t nSendChannels;
       uint8_t nRecvChannels;
       uint8_t channelBase;
-      uint8_t connIndex;
+      uint8_t sendConnIndex:2;
+      uint8_t recvConnIndex:2;
       uint8_t sendProtoLL:1;
       uint8_t recvProtoLL:1;
     } p2p;

--- a/src/init.cc
+++ b/src/init.cc
@@ -260,9 +260,9 @@ void *ncclCommThreadMain(void *arg) {
           if (type == ncclCollTraceCollElemType) {
             sprintf(line+offset, " CE %s nw %d bi %d nc %d root %d busId %lx nRanks %d", funcNames[fIdx], td->coll.nWarps, td->coll.bid, td->coll.nChannels, td->coll.root, comm->busId, comm->nRanks);
           } else if (type == ncclCollTraceP2pElemType) {
-            sprintf(line+offset, " Send %d -> Recv %d connIdx/nc/cb/sLL/rLL %d/%d/%d/%d/%d busId %lx nRanks %d",
-              td->p2p.sendRank, td->p2p.recvRank, td->p2p.connIndex, td->p2p.nP2pChannels, td->p2p.channelBase,
-              td->p2p.sendProtoLL, td->p2p.recvProtoLL, comm->busId, comm->nRanks);
+            sprintf(line+offset, " Send %d -> %d/%d connIdx/LL %d/%d -> Recv %d nc %d cb %d busId %lx nRanks %d",
+              td->p2p.sendRank, td->p2p.sendConnIndex, td->p2p.sendProtoLL, td->p2p.recvConnIndex, td->p2p.recvProtoLL, td->p2p.recvRank, td->p2p.nP2pChannels, td->p2p.channelBase,
+              comm->busId, comm->nRanks);
           } else {
             switch (type&0xf) {
               case ncclCollTraceKernelLaunchType:
@@ -275,9 +275,9 @@ void *ncclCommThreadMain(void *arg) {
                 if ((type&0xf0) == ncclCollTraceCollElemType)
                   sprintf(line+offset, " nw %d bi %d nc %d root %d busId %lx nRanks %d", td->coll.nWarps, td->coll.bid, td->coll.nChannels, td->coll.root, comm->busId, comm->nRanks);
                 else if ((type&0xf0) == ncclCollTraceP2pElemType)
-                  sprintf(line+offset, " Send %d -> Recv %d connIdx/nc/cb/sLL/rLL %d/%d/%d/%d/%d busId %lx nRanks %d",
-                    td->p2p.sendRank, td->p2p.recvRank, td->p2p.connIndex, td->p2p.nP2pChannels, td->p2p.channelBase,
-                    td->p2p.sendProtoLL, td->p2p.recvProtoLL, comm->busId, comm->nRanks);
+                  sprintf(line+offset, " Send %d -> %d/%d ConnIdx/LL %d/%d -> Recv %d nc %d cb %d busId %lx nRanks %d",
+                    td->p2p.sendRank, td->p2p.sendConnIndex, td->p2p.sendProtoLL, td->p2p.recvConnIndex, td->p2p.recvProtoLL, td->p2p.recvRank, td->p2p.nP2pChannels, td->p2p.channelBase,
+                    comm->busId, comm->nRanks);
                 break;
               case ncclCollTraceKernelEndType:
                 sprintf(line+offset, " KE busId %lx nRanks %d", comm->busId, comm->nRanks);


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._
Send/recv need different connIdx since they can have different sizes.

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._
They started sharing the same connIdx after 2.22. This fixes it.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
