### PR TITLE
Create internal thread to dump proxy information at given interval.

### DIFF
--- a/src/include/proxy.h
+++ b/src/include/proxy.h
@@ -74,8 +74,7 @@ struct ncclProxyOp {
   uint8_t* sendbuff;
   uint8_t* recvbuff;
 
-  int nextRank;
-  int prevRank;
+  int peer;
 
   union ncclProxyOpSpecifics specifics;
 
@@ -149,8 +148,7 @@ struct ncclProxyArgs {
 
   union ncclProxyOpSpecifics specifics;
 
-  int prevRank;
-  int nextRank;
+  int peer;
   int send;
   int retry_total;
 };

--- a/src/include/proxy.h
+++ b/src/include/proxy.h
@@ -76,6 +76,8 @@ struct ncclProxyOp {
 
   int peer;
   int rank;
+  uint64_t tail;
+  uint64_t gputail;
 
   union ncclProxyOpSpecifics specifics;
 
@@ -152,6 +154,8 @@ struct ncclProxyArgs {
   int peer;
   int rank;
   int send;
+  uint64_t tail;
+  uint64_t gputail;
   int retry_total;
 };
 #define NCCL_MAX_NETDEVS 128

--- a/src/include/proxy.h
+++ b/src/include/proxy.h
@@ -75,6 +75,7 @@ struct ncclProxyOp {
   uint8_t* recvbuff;
 
   int peer;
+  int rank;
 
   union ncclProxyOpSpecifics specifics;
 
@@ -149,6 +150,7 @@ struct ncclProxyArgs {
   union ncclProxyOpSpecifics specifics;
 
   int peer;
+  int rank;
   int send;
   int retry_total;
 };

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -21,6 +21,10 @@
 #include <unistd.h>
 #include <sys/time.h>
 
+static ncclProxyProgressState* ncclLastProxyState;
+static pthread_t proxyMonitorThread;
+int proxyMonitorInit = 0;
+
 static bool NeedProxy(int type, int pattern, int root, struct ncclRing* ring, int nranks) {
   if (pattern == ncclPatternRing || pattern == ncclPatternRingTwice) return true;
 
@@ -767,7 +771,6 @@ process_nextops:
 }
 
 #include <signal.h>
-static ncclProxyProgressState* ncclLastProxyState;
 void ncclDumpProxyState(int signal) {
   fprintf(stderr, "received signal %d...\n", signal);
   dumpProxyState(ncclLastProxyState);
@@ -915,6 +918,38 @@ ncclResult_t ncclProxyProgressDestroy(struct ncclProxyState* proxyState) {
   TIME_PRINT("Proxy");
   return ncclSuccess;
 }
+
+void *ncclProxyMonitor(void *args) {
+  int interval = *(int*) args;
+  int elapsed = 0;
+  while (proxyMonitorInit) {
+    if (elapsed > interval) {
+      dumpProxyState(ncclLastProxyState);
+      elapsed = 0;
+    }
+    sleep(3);
+    elapsed += 3;
+  }
+  return args;
+}
+
+static ncclResult_t ncclProxyMonitorCreate() {
+  int *interval = (int*) malloc(sizeof(int));
+  *interval = 1;
+  if(proxyMonitorInit == 1) return ncclSuccess;
+
+  proxyMonitorInit = 1;
+  pthread_create(&proxyMonitorThread, NULL, ncclProxyMonitor, interval);
+  INFO(NCCL_INIT, "created proxy monitoring thread...");
+  return ncclSuccess;
+}
+
+ncclResult_t ncclProxyMonitorDestroy() {
+  proxyMonitorInit = 0;
+  pthread_join(proxyMonitorThread, NULL);
+  return ncclSuccess;
+}
+
 
 #define NCCL_PROXY_CONN_POOL_SIZE_POW2 7
 #define NCCL_PROXY_CONN_POOL_SIZE (1<<(NCCL_PROXY_CONN_POOL_SIZE_POW2))
@@ -1674,6 +1709,9 @@ ncclResult_t ncclProxyCreate(struct ncclComm* comm) {
     INFO(NCCL_PROXY, "UDS: Creating service thread comm %p rank %d", comm, comm->rank);
     pthread_create(&comm->proxyState->threadUDS, NULL, ncclProxyServiceUDS, comm->proxyState);
     ncclSetThreadName(comm->proxyState->threadUDS, "NCCL UDS Service %2d", comm->cudaDev);
+
+    // Monitoring
+    ncclProxyMonitorCreate();
   }
   return ncclSuccess;
 }
@@ -1721,6 +1759,7 @@ ncclResult_t ncclProxyStop(struct ncclComm* comm) {
     }
   }
 
+  ncclProxyMonitorDestroy();
   return ncclSuccess;
 }
 

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -935,7 +935,7 @@ void *ncclProxyMonitor(void *args) {
 
 static ncclResult_t ncclProxyMonitorCreate() {
   int *interval = (int*) malloc(sizeof(int));
-  *interval = 1;
+  *interval = 60;
   if(proxyMonitorInit == 1) return ncclSuccess;
 
   proxyMonitorInit = 1;

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -21,9 +21,12 @@
 #include <unistd.h>
 #include <sys/time.h>
 
+/* RCCL Proxy Monitor */
+RCCL_PARAM(ProxyMonitorInterval, "PROXY_MONITOR_INTERVAL", 0);
 static ncclProxyProgressState* ncclLastProxyState;
 static pthread_t proxyMonitorThread;
 int proxyMonitorInit = 0;
+/**/
 
 static bool NeedProxy(int type, int pattern, int root, struct ncclRing* ring, int nranks) {
   if (pattern == ncclPatternRing || pattern == ncclPatternRingTwice) return true;
@@ -273,7 +276,7 @@ ncclResult_t printProxyOp(struct ncclProxyArgs* op, int poolIndex, int opIndex) 
 	// Send or recv within a collective. Dump raw state data.
 	fprintf(stderr, " nb:%zd ns:%d p:%lu t:%lu r:%lu, d:%lu ",sub->nbytes,sub->nsteps, sub->posted, sub->transmitted, sub->received, sub->done);
       }
-      fprintf(stderr, "%c peer:%d chan:%d myrank:%d", status, peer, sub->channelId, op->rank);
+      fprintf(stderr, "%c peer:%d chan:%d myrank:%d tail=%zd gputail=%zd proto=%d ", status, peer, sub->channelId, op->rank, op->tail, op->gputail, op->protocol);
     } else {
         if (op->state == ncclProxyOpNone) fprintf(stderr, "\t[]");
         else if (op->state == ncclProxyOpReady) fprintf(stderr, "\t[R]");
@@ -549,6 +552,8 @@ static ncclResult_t SaveProxy(struct ncclComm* comm, struct ncclChannel* channel
   else {
     op->peer = peer;
     op->rank = comm->rank;
+    op->tail = 0;
+    op->gputail = 0;
     NCCLCHECK(ncclLocalOpAppend(comm, &connector->proxyConn, op));
   }
   return ncclSuccess;
@@ -919,32 +924,38 @@ ncclResult_t ncclProxyProgressDestroy(struct ncclProxyState* proxyState) {
   return ncclSuccess;
 }
 
-void *ncclProxyMonitor(void *args) {
+void *rcclProxyMonitor(void *args) {
   int interval = *(int*) args;
   int elapsed = 0;
+
   while (proxyMonitorInit) {
     if (elapsed > interval) {
       dumpProxyState(ncclLastProxyState);
       elapsed = 0;
     }
-    sleep(3);
-    elapsed += 3;
+    sleep(1);
+    elapsed += 1;
   }
-  return args;
+
+  free(args);
+  return NULL;
 }
 
-static ncclResult_t ncclProxyMonitorCreate() {
-  int *interval = (int*) malloc(sizeof(int));
-  *interval = 60;
+static ncclResult_t rcclProxyMonitorCreate() {
+  if(rcclParamProxyMonitorInterval() <= 0) return ncclSuccess;
   if(proxyMonitorInit == 1) return ncclSuccess;
 
+  int *interval = (int*) malloc(sizeof(int));
+
+  *interval = rcclParamProxyMonitorInterval();
+
   proxyMonitorInit = 1;
-  pthread_create(&proxyMonitorThread, NULL, ncclProxyMonitor, interval);
+  pthread_create(&proxyMonitorThread, NULL, rcclProxyMonitor, interval);
   INFO(NCCL_INIT, "created proxy monitoring thread...");
   return ncclSuccess;
 }
 
-ncclResult_t ncclProxyMonitorDestroy() {
+ncclResult_t rcclProxyMonitorDestroy() {
   proxyMonitorInit = 0;
   pthread_join(proxyMonitorThread, NULL);
   return ncclSuccess;
@@ -1711,7 +1722,7 @@ ncclResult_t ncclProxyCreate(struct ncclComm* comm) {
     ncclSetThreadName(comm->proxyState->threadUDS, "NCCL UDS Service %2d", comm->cudaDev);
 
     // Monitoring
-    ncclProxyMonitorCreate();
+    rcclProxyMonitorCreate();
   }
   return ncclSuccess;
 }
@@ -1759,7 +1770,7 @@ ncclResult_t ncclProxyStop(struct ncclComm* comm) {
     }
   }
 
-  ncclProxyMonitorDestroy();
+  rcclProxyMonitorDestroy();
   return ncclSuccess;
 }
 

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -269,7 +269,7 @@ ncclResult_t printProxyOp(struct ncclProxyArgs* op, int poolIndex, int opIndex) 
 	// Send or recv within a collective. Dump raw state data.
 	fprintf(stderr, " nb:%zd ns:%d p:%lu t:%lu r:%lu, d:%lu ",sub->nbytes,sub->nsteps, sub->posted, sub->transmitted, sub->received, sub->done);
       }
-      fprintf(stderr, "%c peer:%d chan:%d ", status, peer, sub->channelId);
+      fprintf(stderr, "%c peer:%d chan:%d myrank:%d", status, peer, sub->channelId, op->rank);
     } else {
         if (op->state == ncclProxyOpNone) fprintf(stderr, "\t[]");
         else if (op->state == ncclProxyOpReady) fprintf(stderr, "\t[R]");
@@ -544,6 +544,7 @@ static ncclResult_t SaveProxy(struct ncclComm* comm, struct ncclChannel* channel
   if (justInquire) *justInquire = true;
   else {
     op->peer = peer;
+    op->rank = comm->rank;
     NCCLCHECK(ncclLocalOpAppend(comm, &connector->proxyConn, op));
   }
   return ncclSuccess;

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -244,7 +244,7 @@ ncclResult_t getOpIndex(struct ncclProxyArgs* op, struct ncclProxyProgressState*
 }
 
 ncclResult_t printProxyOp(struct ncclProxyArgs* op, int poolIndex, int opIndex) {
-  int peer = op->send ? op->nextRank : op->prevRank;
+  int peer = op->peer;
   bool isColl = (op->pattern != ncclPatternRecv) && (op->pattern != ncclPatternSend);
 
   fprintf(stderr, "%p [%d-%d|%ld| %s",op, poolIndex, opIndex, op->opCount, isColl ? "Coll->" : "");
@@ -412,8 +412,7 @@ static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyAr
   args->progress = op->connection->tcomm->proxyProgress;
   args->proxyAppendPtr = op->connection->proxyAppendPtr;
   args->send = op->connection->send;
-  args->prevRank = op->prevRank;
-  args->nextRank = op->nextRank;
+  args->peer = op->peer;
   args->retry_total = 0;
   return ncclSuccess;
 }
@@ -544,6 +543,7 @@ static ncclResult_t SaveProxy(struct ncclComm* comm, struct ncclChannel* channel
 
   if (justInquire) *justInquire = true;
   else {
+    op->peer = peer;
     NCCLCHECK(ncclLocalOpAppend(comm, &connector->proxyConn, op));
   }
   return ncclSuccess;
@@ -566,13 +566,9 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
   case ncclPatternPipelineTo: {
       struct ncclRing* ring = &channel->ring;
       if (NeedProxy(proxyRecv, op->pattern, op->root, ring, comm->nRanks)) {
-        op->prevRank = ring->prev;
-        op->nextRank = ring->next;
         NCCLCHECK(SaveProxy(comm, channel, proxyRecv, ring->prev, op, op->connIndex, justInquire));
       }
       if (NeedProxy(proxySend, op->pattern, op->root, ring, comm->nRanks)) {
-        op->prevRank = ring->prev;
-        op->nextRank = ring->next;
         NCCLCHECK(SaveProxy(comm, channel, proxySend, ring->next, op, op->connIndex, justInquire));
       }
     } break;

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1200,6 +1200,8 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
         int buffSlot = (sub->base+sub->transmitted)%NCCL_STEPS;
         volatile uint64_t* recvTail = &resources->recvMem->tail;
         uint64_t tail = sub->base + (sub->reg ? 0 : sub->transmitted);
+	args->tail = tail;
+	args->gputail = *recvTail;
         if ((sub->reg || connFifo[buffSlot].size != -1) && ((*recvTail > tail) || p == NCCL_PROTO_LL)) {
           // We have something to receive, let's check if it's completely ready.
           int size = sub->reg ? std::min(MAX_NET_SIZE, sub->nbytes) : connFifo[buffSlot].size;


### PR DESCRIPTION
## Details
This PR creates a helper thread to dump out proxy operations at every given interval. This is useful to debug hangs in multi-node scenario. The thread is not created by default. It is controlled via param `RCCL_PROXY_MONITOR_INTERVAL`. If set to > 0, the thread will attempt to dump proxy info at that interval (seconds).

This should have minimal/no impact to the default mode of operation.

![image](https://github.com/user-attachments/assets/773fc1e6-b704-465c-a099-cd9c490a8d4b)


**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
More debugging tool for developers.

**How was the outcome achieved?**  
Create a helper thread that dump out information.



## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
