### PR TITLE
replacing rccl_float8 with hip_fp8 and address compatibility issue

### DIFF
--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -38,7 +38,9 @@ typedef struct
     uint8_t data;
 } rccl_bfloat8;
 
-#elif ROCM_VERSION >= 60300 // __cplusplus < 201103L || (!defined(__HCC__) && !defined(__HIPCC__))
+// __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
+#elif ROCM_VERSION >= 60300
+
 #include <hip/hip_fp8.h>
 
 #if HIP_FP8_TYPE_OCP
@@ -78,9 +80,9 @@ inline __host__ __device__ float operator*(rccl_bfloat8 a, float b)
 {
     return float(a) * float(b);
 }
+
 // For older versions of ROCm that do not include hip_fp8.h,
 // we provide a local version of the header file as a fallback.
-
 #else
 
 #define HIP_HOST_DEVICE __host__ __device__
@@ -1059,6 +1061,6 @@ inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng)
 
 // =================================================================================================
 
-#endif // __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
+#endif
 
 #endif // ROCBLAS_FLOAT8_H

--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -25,7 +25,7 @@
 
 #include <stdint.h>
 
-#if __cplusplus < 201103L || (!defined(__HCC__) && !defined(__HIPCC__))
+#if __cplusplus < 201103L || !defined(__HIP__)
 /*! \brief Struct to represent a 8 bit floating-point number. */
 
 typedef struct
@@ -38,7 +38,50 @@ typedef struct
     uint8_t data;
 } rccl_bfloat8;
 
-#else // __cplusplus < 201103L || (!defined(__HCC__) && !defined(__HIPCC__))
+#elif ROCM_VERSION >= 60300 // __cplusplus < 201103L || (!defined(__HCC__) && !defined(__HIPCC__))
+#include <hip/hip_fp8.h>
+
+#if HIP_FP8_TYPE_OCP
+typedef __hip_fp8_e4m3 rccl_float8;
+typedef __hip_fp8_e5m2 rccl_bfloat8;
+#else
+typedef __hip_fp8_e4m3_fnuz rccl_float8;
+typedef __hip_fp8_e5m2_fnuz rccl_bfloat8;
+#endif
+    
+inline std::ostream& operator<<(std::ostream& os, const rccl_float8& f8)
+{
+    return os << float(f8);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const rccl_bfloat8& bf8)
+{
+    return os << float(bf8);
+}
+
+inline __host__ __device__ float operator*(rccl_float8 a, rccl_float8 b)
+{
+    return float(a) * float(b);
+}
+
+inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_bfloat8 b)
+{
+    return float(a) * float(b);
+}
+
+inline __host__ __device__ float operator*(rccl_float8 a, float b)
+{
+    return float(a) * float(b);
+}
+
+inline __host__ __device__ float operator*(rccl_bfloat8 a, float b)
+{
+    return float(a) * float(b);
+}
+// For older versions of ROCm that do not include hip_fp8.h,
+// we provide a local version of the header file as a fallback.
+
+#else
 
 #define HIP_HOST_DEVICE __host__ __device__
 #define HIP_HOST __host__
@@ -1016,6 +1059,6 @@ inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng)
 
 // =================================================================================================
 
-#endif // __cplusplus < 201103L || (!defined(__HCC__) && !defined(__HIPCC__))
+#endif
 
-#endif // ROCBLAS_FLOAT8_H
+#endif  // ROCBLAS_FLOAT8_H

--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -25,7 +25,7 @@
 
 #include <stdint.h>
 
-#if __cplusplus < 201103L || !defined(__HIP__)
+#if __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
 /*! \brief Struct to represent a 8 bit floating-point number. */
 
 typedef struct
@@ -1059,6 +1059,6 @@ inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng)
 
 // =================================================================================================
 
-#endif
+#endif // __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
 
 #endif // ROCBLAS_FLOAT8_H

--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -1061,4 +1061,4 @@ inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng)
 
 #endif
 
-#endif  // ROCBLAS_FLOAT8_H
+#endif // ROCBLAS_FLOAT8_H

--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -39,7 +39,7 @@ typedef struct
 } rccl_bfloat8;
 
 // __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
-#elif ROCM_VERSION >= 60300
+#elif ROCM_VERSION >= 60200
 
 #include <hip/hip_fp8.h>
 


### PR DESCRIPTION
## Details


**Work item:** _ [LWPCOMMLIBS-576]

**What were the changes?**  
move to HIP FP8 header file 

**Why were the changes made?**  
RCCL needs to switch over to HIP FP8 header file which has become available in recent ROCm releases.

**How was the outcome achieved?**  
RCCL-UT and rccl-tests have been tested and passed with datatype=FP8.

**Additional Documentation:**  
_What else should the reviewer know?_
For gfx942, we need to support FP8_FNUZ, as the OCP type is currently unsupported. Additionally, we should retain the current RCCL internal header file to ensure compatibility with older ROCm releases that lack the HIP FP8 header. 
## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
