### PR TITLE
Replace atomicAdd with _hip_atmoc_fetch_add in colltrace tail counter

### DIFF
--- a/src/device/common.h
+++ b/src/device/common.h
@@ -43,7 +43,7 @@
 #endif
 #ifdef ENABLE_COLLTRACE
   #define INC_COLL_TRACE \
-    uint32_t pos = atomicAdd(&ncclShmem.collTraceTail->tail, 1)%COLLTRACE_NUM_ITEMS; \
+    uint32_t pos = __hip_atomic_fetch_add(&ncclShmem.collTraceTail->tail, 1, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_WORKGROUP)%COLLTRACE_NUM_ITEMS; \
     struct ncclCollTrace* collTrace = ncclShmem.collTrace+pos; \
     collTrace->timeStamp = wall_clock64(); \
     collTrace->bid = blockIdx.x;


### PR DESCRIPTION
## Details
We suspect atomicAdd() is not atomic on AMD devices. In one particular example, this function is used to access the tail counter of kernel trace records. This caused problems. When multiple threads tries to log collTrace concurrently, their logs may got overwritten if tail counter is not atomic.

For example, when using atomicAdd(), we see missing kernel traces for a ncclWork
```
NCCL INFO ## [921624.588880] [44:16:42] 000656-000656 CL ncclDevFunc_SendRecv_RING_SIMPLE_Sum_i8 61 -> 1/2/0/2 conn/nw/ws/ng 1/2/2/2 -> 27 busId e9000 nRanks 128
NCCL INFO ## [921624.588902] [44:16:42] L:0729 DT 000000ff 0000000000000001 0000000000020000
NCCL INFO ## [921624.588902] [44:16:42] L:0729 DT 00000080 0000000000040cc5 0000000000020000
NCCL INFO ## [921624.588902] [44:16:42] L:0729 DT 00000000 0000000000040459 0000000000020000
NCCL INFO ## [921624.588923] [44:16:42] L:0117 DT 00000080 0000000000040ccd 0000000000040cce
NCCL INFO ## [921624.588923] [44:16:42] L:0185 DT 000000ff 00007f8d4da0f000 0000000000040cce
NCCL INFO ## [921624.588923] [44:16:42] L:0117 DT 00000000 0000000000040459 000000000004045a
NCCL INFO ## [921624.588986] [44:16:42] L:0136 DT 00000080 0000000000040cce 0000000000000000
NCCL INFO ## [921624.589072] [44:16:42] L:0136 DT 00000000 000000000004045a 0000000000000000
NCCL INFO ## [921624.589091] [44:16:42] 65600000656 KE busId e9000 nRanks 128
```
With __hip_atomic_fetch_add(), we see complete collTrace of a ncclWork:

```
NCCL INFO ## [1029593.393379] [43:11:44] 00242a-00242a CL ncclDevFunc_SendRecv_RING_SIMPLE_Sum_i8 60 -> 1/2/0/2 conn/nw/ws/ng 1/2/2/2 -> 26 busId 28000 nRanks 64
NCCL INFO ## [1029593.393393] [43:11:44] L:0729 DT 00000080 000000000021f983 0000000000020000
NCCL INFO ## [1029593.393394] [43:11:44] L:0729 DT 00000000 0000000000211465 0000000000020000
NCCL INFO ## [1029593.393399] [43:11:44] L:0117 DT 00000080 000000000021f98b 000000000021f98c
NCCL INFO ## [1029593.393401] [43:11:44] L:0117 DT 00000000 0000000000211465 0000000000211466
NCCL INFO ## [1029593.393401] [43:11:44] L:0353 DT 000000ff 00007f01a0c3c2c0 00007f2117200000
NCCL INFO ## [1029593.393413] [43:11:44] L:0185 DT 000000ff 00007f24fba09000 000000000021f98c
NCCL INFO ## [1029593.393422] [43:11:44] L:0353 DT 000000ff 00007f01a0c3c2c0 00007f2117200000
NCCL INFO ## [1029593.393426] [43:11:44] L:0185 DT 000000ff 00007f24fba09000 000000000021f98d
NCCL INFO ## [1029593.393433] [43:11:44] L:0353 DT 000000ff 00007f01a0c3c2c0 00007f2117200000
NCCL INFO ## [1029593.393437] [43:11:44] L:0185 DT 000000ff 00007f24fba09000 000000000021f98e
NCCL INFO ## [1029593.393454] [43:11:44] L:0136 DT 00000080 000000000021f98c 0000000000008000
NCCL INFO ## [1029593.393462] [43:11:44] L:0240 DT 00000080 0000000000000000 0000000000008000
NCCL INFO ## [1029593.393467] [43:11:44] L:0353 DT 000000ff 00007f01a0c442c0 00007f2117200000
NCCL INFO ## [1029593.393470] [43:11:44] L:0117 DT 00000080 000000000021f98c 000000000021f98d
NCCL INFO ## [1029593.393472] [43:11:44] L:0185 DT 000000ff 00007f24fba09000 000000000021f98f
NCCL INFO ## [1029593.393485] [43:11:44] L:0136 DT 00000000 0000000000211466 0000000000000840
NCCL INFO ## [1029593.393485] [43:11:44] L:0136 DT 00000080 000000000021f98d 0000000000008000
NCCL INFO ## [1029593.393494] [43:11:44] L:0240 DT 00000000 0000000000000000 0000000000000840
NCCL INFO ## [1029593.393497] [43:11:44] L:0240 DT 00000080 0000000000000000 0000000000008000
NCCL INFO ## [1029593.393506] [43:11:44] L:0117 DT 00000080 000000000021f98d 000000000021f98e
NCCL INFO ## [1029593.393517] [43:11:44] L:0136 DT 00000080 000000000021f98e 0000000000008000
NCCL INFO ## [1029593.393525] [43:11:44] L:0240 DT 00000080 0000000000000000 0000000000008000
NCCL INFO ## [1029593.393532] [43:11:44] L:0117 DT 00000080 000000000021f98e 000000000021f98f
NCCL INFO ## [1029593.393556] [43:11:44] L:0136 DT 00000080 000000000021f98f 00000000000066c0
NCCL INFO ## [1029593.393562] [43:11:44] L:0240 DT 00000080 0000000000000000 00000000000066c0
NCCL INFO ## [1029593.393571] [43:11:44] 242a0000242a KE busId 28000 nRanks 64
```

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.


## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
