### PR TITLE
Enable GDRCopy only on gfx94x

### DIFF
--- a/src/include/gdrwrap.h
+++ b/src/include/gdrwrap.h
@@ -164,7 +164,11 @@ static gdr_t ncclGdrInit() {
   cudaDeviceProp devProp;
   char gcnArchNameSubstr[128];
   cudaError_t err = cudaGetDeviceProperties(&devProp, 0);
-  if (err != cudaSuccess) return NULL;
+  if (err != cudaSuccess) {
+    WARN("Failed to GetDeviceProperties for device");
+    return NULL;
+  }
+ return NULL;
   GcnArchNameFormat(devProp.gcnArchName, gcnArchNameSubstr);
   if (IsArchMatch(gcnArchNameSubstr, "gfx94")) {
     INFO(NCCL_INIT, "Enabled GDRCopy equivalent memory allocation on %s", gcnArchNameSubstr);

--- a/src/include/gdrwrap.h
+++ b/src/include/gdrwrap.h
@@ -220,7 +220,7 @@ static ncclResult_t ncclGdrCudaCopy(void *gdrHandle, T* dst, T* src, size_t nele
 
 static ncclResult_t ncclGdrCudaFree(void* gdrHandle) {
   gdr_mem_desc_t *md = (gdr_mem_desc_t*)gdrHandle;
-  CUDACHECK(hipFree(md->gdrDevMem));
+  CUDACHECK(cudaFree(md->gdrDevMem));
   free(md);
 
   return ncclSuccess;

--- a/src/include/gdrwrap.h
+++ b/src/include/gdrwrap.h
@@ -168,7 +168,6 @@ static gdr_t ncclGdrInit() {
     WARN("Failed to GetDeviceProperties for device");
     return NULL;
   }
- return NULL;
   GcnArchNameFormat(devProp.gcnArchName, gcnArchNameSubstr);
   if (IsArchMatch(gcnArchNameSubstr, "gfx94")) {
     INFO(NCCL_INIT, "Enabled GDRCopy equivalent memory allocation on %s", gcnArchNameSubstr);

--- a/src/include/gdrwrap.h
+++ b/src/include/gdrwrap.h
@@ -13,6 +13,7 @@
 #include <stdint.h> // for standard [u]intX_t types
 #include <stdio.h>
 #include <stdlib.h>
+#include "archinfo.h"
 
 // These can be used if the GDR library isn't thread safe
 #include <pthread.h>
@@ -160,8 +161,18 @@ typedef struct gdr_mem_desc {
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 static gdr_t ncclGdrInit() {
-  INFO(NCCL_INIT, "Enabled GDRCopy equivalent memory allocation");
-  return (gdr_t)0x12345678L;
+  cudaDeviceProp devProp;
+  char gcnArchNameSubstr[128];
+  cudaError_t err = cudaGetDeviceProperties(&devProp, 0);
+  if (err != cudaSuccess) return NULL;
+  GcnArchNameFormat(devProp.gcnArchName, gcnArchNameSubstr);
+  if (IsArchMatch(gcnArchNameSubstr, "gfx94")) {
+    INFO(NCCL_INIT, "Enabled GDRCopy equivalent memory allocation on %s", gcnArchNameSubstr);
+    return (gdr_t)0x12345678L;
+  } else {
+    INFO(NCCL_INIT, "Disabled GDRCopy equivalent memory allocation on %s due to GPU architecture", gcnArchNameSubstr);
+    return NULL;
+  }
 }
 
 template <typename T>


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal

**What were the changes?**  
Enable GDRCopy only on gfx94x

**Why were the changes made?**  
It appears to be unsafe to enable this feature on older GPU architectures, i.e. gfx90a

**How was the outcome achieved?**  
Check GPU architecture and decide

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
