### PR TITLE
ext-src: fix mscclpp allreduce for non-multiple of 128 message sizes

### DIFF
--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -85,6 +85,11 @@ if(ENABLE_MSCCLPP)
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
 
+	execute_process(
+            COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/non-multiple-128-fix.patch
+            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+        )
+
         message(STATUS "Building mscclpp only for gfx942.")
         mscclpp_cmake_arg(CMAKE_PREFIX_PATH)
         mscclpp_cmake_arg(CMAKE_INSTALL_RPATH_USE_LINK_PATH)
@@ -126,6 +131,10 @@ if(ENABLE_MSCCLPP)
         )
         execute_process(
             COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mem-reg.patch
+            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+        )
+	execute_process(
+            COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/non-multiple-128-fix.patch
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
 

--- a/ext-src/non-multiple-128-fix.patch
+++ b/ext-src/non-multiple-128-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/apps/nccl/src/allreduce.hpp b/apps/nccl/src/allreduce.hpp
+index 76674ba..7a2cd4a 100644
+--- a/apps/nccl/src/allreduce.hpp
++++ b/apps/nccl/src/allreduce.hpp
+@@ -368,7 +368,10 @@ __global__ void __launch_bounds__(512, 1)
+   const size_t chanOffset = nPeer * blockIdx.x;
+   // assume (nelems * sizeof(T)) is divisible by (16 * worldSize)
+   const size_t nInt4 = nelems * sizeof(T) / sizeof(int4);
+-  const size_t nInt4PerRank = nInt4 / worldSize;
++  size_t nInt4PerRank = nInt4 / worldSize;
++  if (nInt4 % worldSize)
++        nInt4PerRank = nInt4PerRank + 1;
++
+   auto smChans = smChannels + chanOffset;
+   auto smOutChans = smOutChannels + chanOffset;
+ 


### PR DESCRIPTION
## Details
MSCCLPP allreduce8 currently assumes that the message size is a multiple of 128. This PR fixes the data corruption for message sizes that are not a multiple of 128.

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
