### PR TITLE
ext-src: add initial RoCE support for MSCCLPP and Ethernet bootstrapping

### DIFF
--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -127,7 +127,7 @@ if(ENABLE_MSCCLPP)
 
         find_package(mscclpp_nccl REQUIRED)
 
-    	  execute_process(
+    	execute_process(
            COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/cpx.patch
            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )

--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -90,6 +90,10 @@ if(ENABLE_MSCCLPP)
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
 
+        execute_process(
+            COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/roce-support.patch
+            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+        )
         message(STATUS "Building mscclpp only for gfx942.")
         mscclpp_cmake_arg(CMAKE_PREFIX_PATH)
         mscclpp_cmake_arg(CMAKE_INSTALL_RPATH_USE_LINK_PATH)
@@ -113,18 +117,18 @@ if(ENABLE_MSCCLPP)
                          SOURCE_DIR          ${MSCCLPP_SOURCE}
         )
 
-     
+
         find_package(mscclpp_nccl REQUIRED)
         execute_process(
            COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/cpx.patch
            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
-        
+
         execute_process(
             COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/read-allred.patch
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
-        
+
         execute_process(
             COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mscclpp_ibv_access_relaxed_ordering.patch
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}

--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -85,7 +85,7 @@ if(ENABLE_MSCCLPP)
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
 
-   	    execute_process(
+   	execute_process(
             COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/non-multiple-128-fix.patch
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
@@ -95,10 +95,10 @@ if(ENABLE_MSCCLPP)
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
 
-	      execute_process(
-	          COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/bf16-tuning.patch
-	          WORKING_DIRECTORY ${MSCCLPP_SOURCE}
-	      )
+	execute_process(
+	    COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/bf16-tuning.patch
+	    WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+	)
 
 
         message(STATUS "Building mscclpp only for gfx942.")

--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -85,7 +85,7 @@ if(ENABLE_MSCCLPP)
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
 
-	execute_process(
+	    execute_process(
             COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/non-multiple-128-fix.patch
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
@@ -137,11 +137,16 @@ if(ENABLE_MSCCLPP)
             COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mem-reg.patch
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
-	execute_process(
+
+        execute_process(
             COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/non-multiple-128-fix.patch
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
 
+        execute_process(
+            COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/roce-support.patch
+            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+        )
     #endif()
 
     execute_process(COMMAND objcopy

--- a/ext-src/roce-support.patch
+++ b/ext-src/roce-support.patch
@@ -57,10 +57,10 @@ index 625de0a..bcb847e 100644
    return globalEnv;
  }
 diff --git a/src/ib.cc b/src/ib.cc
-index 542527e..36a34e8 100644
+index 542527e..7c939df 100644
 --- a/src/ib.cc
 +++ b/src/ib.cc
-@@ -20,26 +20,199 @@
+@@ -20,26 +20,200 @@
  #include "debug.h"
  #if defined(USE_IBVERBS)
  #include "ibverbs_wrapper.hpp"
@@ -146,7 +146,8 @@ index 542527e..36a34e8 100644
 +  }
 +  for (int i = 0; i < count; ++i) {
 +    IbCtx ctx(devices[i]->name);
-+    if(ctx.getAnyActivePort() < 0) continue;
++    struct ibv_port_attr portAttr;
++    if(ctx.getAnyActivePort(portAttr) < 0) continue;
 +    activeDevices.push_back(devices[i]->name);
 +  }
 +  numActiveDevices = activeDevices.size();
@@ -267,16 +268,29 @@ index 542527e..36a34e8 100644
  IbMr::IbMr(ibv_pd* pd, void* buff, std::size_t size) : buff(buff) {
    if (size == 0) {
      throw std::invalid_argument("invalid size: " + std::to_string(size));
-@@ -106,7 +279,7 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
-   struct ibv_port_attr portAttr;
-   if (IBVerbs::ibv_query_port_w(ctx, port, &portAttr) != 0) {
-     std::stringstream err;
--    err << "ibv_query_port failed (errno " << errno << ")";
-+    err << "ibv_query_port failed (errno " << errno << ", port << " << port << ")";
+@@ -74,7 +248,7 @@ const void* IbMr::getBuff() const { return this->buff; }
+ 
+ uint32_t IbMr::getLkey() const { return this->mr->lkey; }
+ 
+-IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollNum, int maxSendWr, int maxRecvWr,
++IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, ibv_port_attr& portAttr, int maxCqSize, int maxCqPollNum, int maxSendWr, int maxRecvWr,
+            int maxWrPerSend)
+     : numSignaledPostedItems(0), numSignaledStagedItems(0), maxCqPollNum(maxCqPollNum), maxWrPerSend(maxWrPerSend) {
+   this->cq = IBVerbs::ibv_create_cq(ctx, maxCqSize, nullptr, nullptr, 0);
+@@ -103,12 +277,6 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
      throw mscclpp::IbError(err.str(), errno);
    }
+ 
+-  struct ibv_port_attr portAttr;
+-  if (IBVerbs::ibv_query_port_w(ctx, port, &portAttr) != 0) {
+-    std::stringstream err;
+-    err << "ibv_query_port failed (errno " << errno << ")";
+-    throw mscclpp::IbError(err.str(), errno);
+-  }
    this->info.lid = portAttr.lid;
-@@ -117,8 +290,9 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
+   this->info.port = port;
+   this->info.linkLayer = portAttr.link_layer;
+@@ -117,8 +285,9 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
    this->info.is_grh = (portAttr.flags & IBV_QPF_GRH_REQUIRED);
  
    if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND || this->info.is_grh) {
@@ -287,7 +301,7 @@ index 542527e..36a34e8 100644
        std::stringstream err;
        err << "ibv_query_gid failed (errno " << errno << ")";
        throw mscclpp::IbError(err.str(), errno);
-@@ -164,7 +338,7 @@ void IbQp::rtr(const IbQpInfo& info) {
+@@ -164,7 +333,7 @@ void IbQp::rtr(const IbQpInfo& info) {
      qp_attr.ah_attr.grh.dgid.global.subnet_prefix = info.spn;
      qp_attr.ah_attr.grh.dgid.global.interface_id = info.iid;
      qp_attr.ah_attr.grh.flow_label = 0;
@@ -296,7 +310,7 @@ index 542527e..36a34e8 100644
      qp_attr.ah_attr.grh.hop_limit = 255;
      qp_attr.ah_attr.grh.traffic_class = 0;
    } else {
-@@ -290,7 +464,19 @@ void IbQp::postSend() {
+@@ -290,7 +459,19 @@ void IbQp::postSend() {
  int IbQp::pollCq() {
    int wcNum = IBVerbs::ibv_poll_cq(this->cq, this->maxCqPollNum, this->wcs->data());
    if (wcNum > 0) {
@@ -311,13 +325,13 @@ index 542527e..36a34e8 100644
 +      this->numSignaledPostedItems--;
 +    }
 +  } else if (wcNum < 0) {
-+    std::stringstream err;
-+    err << "ibv_poll_cq failed with negative completion";
-+    throw mscclpp::IbError(err.str(), errno);
++      std::stringstream err;
++      err << "ibv_poll_cq failed with negative completion";
++      throw mscclpp::IbError(err.str(), errno);
    }
    return wcNum;
  }
-@@ -300,11 +486,10 @@ int IbQp::getWcStatus(int idx) const { return (*this->wcs)[idx].status; }
+@@ -300,11 +481,10 @@ int IbQp::getWcStatus(int idx) const { return (*this->wcs)[idx].status; }
  int IbQp::getNumCqItems() const { return this->numSignaledPostedItems; }
  
  IbCtx::IbCtx(const std::string& devName) : devName(devName) {
@@ -332,7 +346,55 @@ index 542527e..36a34e8 100644
    int num;
    struct ibv_device** devices = IBVerbs::ibv_get_device_list(&num);
    for (int i = 0; i < num; ++i) {
-@@ -385,7 +570,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
+@@ -338,8 +518,7 @@ IbCtx::~IbCtx() {
+   }
+ }
+ 
+-bool IbCtx::isPortUsable(int port) const {
+-  struct ibv_port_attr portAttr;
++bool IbCtx::isPortUsable(int port, struct ibv_port_attr& portAttr) const {
+   if (IBVerbs::ibv_query_port_w(this->ctx, port, &portAttr) != 0) {
+     std::stringstream err;
+     err << "ibv_query_port failed (errno " << errno << ", port << " << port << ")";
+@@ -349,7 +528,7 @@ bool IbCtx::isPortUsable(int port) const {
+          (portAttr.link_layer == IBV_LINK_LAYER_ETHERNET || portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND);
+ }
+ 
+-int IbCtx::getAnyActivePort() const {
++int IbCtx::getAnyActivePort(struct ibv_port_attr& portAttr) const {
+   struct ibv_device_attr devAttr;
+   if (IBVerbs::ibv_query_device(this->ctx, &devAttr) != 0) {
+     std::stringstream err;
+@@ -357,7 +536,7 @@ int IbCtx::getAnyActivePort() const {
+     throw mscclpp::IbError(err.str(), errno);
+   }
+   for (uint8_t port = 1; port <= devAttr.phys_port_cnt; ++port) {
+-    if (this->isPortUsable(port)) {
++    if (this->isPortUsable(port, portAttr)) {
+       return port;
+     }
+   }
+@@ -366,15 +545,16 @@ int IbCtx::getAnyActivePort() const {
+ 
+ IbQp* IbCtx::createQp(int maxCqSize, int maxCqPollNum, int maxSendWr, int maxRecvWr, int maxWrPerSend,
+                       int port /*=-1*/) {
++  struct ibv_port_attr portAttr;
+   if (port == -1) {
+-    port = this->getAnyActivePort();
++    port = this->getAnyActivePort(portAttr);
+     if (port == -1) {
+       throw mscclpp::Error("No active port found", ErrorCode::InvalidUsage);
+     }
+-  } else if (!this->isPortUsable(port)) {
++  } else if (!this->isPortUsable(port, portAttr)) {
+     throw mscclpp::Error("invalid IB port: " + std::to_string(port), ErrorCode::InvalidUsage);
+   }
+-  qps.emplace_back(new IbQp(this->ctx, this->pd, port, maxCqSize, maxCqPollNum, maxSendWr, maxRecvWr, maxWrPerSend));
++  qps.emplace_back(new IbQp(this->ctx, this->pd, port, portAttr, maxCqSize, maxCqPollNum, maxSendWr, maxRecvWr, maxWrPerSend));
+   return qps.back().get();
+ }
+ 
+@@ -385,7 +565,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
  
  MSCCLPP_API_CPP int getIBDeviceCount() {
    int num;
@@ -341,7 +403,7 @@ index 542527e..36a34e8 100644
    return num;
  }
  
-@@ -442,20 +627,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
+@@ -442,20 +622,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
    }
  
    int num;
@@ -367,10 +429,18 @@ index 542527e..36a34e8 100644
          case 0:
            return Transport::IB0;
 diff --git a/src/include/ib.hpp b/src/include/ib.hpp
-index 4d85299..3018d54 100644
+index 4d85299..51a71ba 100644
 --- a/src/include/ib.hpp
 +++ b/src/include/ib.hpp
-@@ -54,6 +54,7 @@ struct IbQpInfo {
+@@ -18,6 +18,7 @@ struct ibv_cq;
+ struct ibv_wc;
+ struct ibv_send_wr;
+ struct ibv_sge;
++struct ibv_port_attr;
+ 
+ namespace mscclpp {
+ 
+@@ -54,6 +55,7 @@ struct IbQpInfo {
    int mtu;
    uint64_t iid;
    bool is_grh;
@@ -378,18 +448,28 @@ index 4d85299..3018d54 100644
  };
  
  enum class WsStatus {
-@@ -132,9 +133,9 @@ class IbCtx {
+@@ -90,7 +92,7 @@ class IbQp {
+     ibv_sge* sge;
+   };
+ 
+-  IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollNum, int maxSendWr, int maxRecvWr,
++  IbQp(ibv_context* ctx, ibv_pd* pd, int port, ibv_port_attr& portAttr, int maxCqSize, int maxCqPollNum, int maxSendWr, int maxRecvWr,
+        int maxWrPerSend);
+   WrInfo getNewWrInfo();
+ 
+@@ -132,9 +134,9 @@ class IbCtx {
  
    const std::string& getDevName() const { return this->devName; };
  
-+  int getAnyActivePort() const;
++  int getAnyActivePort(struct ibv_port_attr& portAttr) const;
   private:
-   bool isPortUsable(int port) const;
+-  bool isPortUsable(int port) const;
 -  int getAnyActivePort() const;
++  bool isPortUsable(int port, struct ibv_port_attr& portAttr) const;
  
    const std::string devName;
    ibv_context* ctx;
-@@ -142,7 +143,21 @@ class IbCtx {
+@@ -142,7 +144,21 @@ class IbCtx {
    std::list<std::unique_ptr<IbQp>> qps;
    std::list<std::unique_ptr<IbMr>> mrs;
  };

--- a/ext-src/roce-support.patch
+++ b/ext-src/roce-support.patch
@@ -1,13 +1,14 @@
 diff --git a/include/mscclpp/env.hpp b/include/mscclpp/env.hpp
-index 6708628..3131b9f 100644
+index 6708628..ea9eedc 100644
 --- a/include/mscclpp/env.hpp
 +++ b/include/mscclpp/env.hpp
-@@ -30,6 +30,8 @@ class Env {
+@@ -30,6 +30,9 @@ class Env {
    const std::string executionPlanDir;
    const std::string npkitDumpDir;
    const bool cudaIpcUseDefaultStream;
 +  const int ibGidIndex;
 +  const int ibTrafficClass;
++  const bool ibAllowLinkLocalGid;
  
   private:
    Env();
@@ -25,7 +26,7 @@ index 8c012c2..5dc43b6 100644
      if (nIfs == 0) nIfs = findInterfaces("^docker,lo", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
      // Finally look for docker, then lo.
 diff --git a/src/env.cpp b/src/env.cpp
-index 625de0a..d42de37 100644
+index 625de0a..89baa8b 100644
 --- a/src/env.cpp
 +++ b/src/env.cpp
 @@ -19,8 +19,9 @@ T readEnv(const std::string &envName, const T &defaultValue) {
@@ -39,31 +40,33 @@ index 625de0a..d42de37 100644
  }
  
  template <typename T>
-@@ -61,7 +62,9 @@ Env::Env()
+@@ -61,7 +62,10 @@ Env::Env()
        commId(readEnv<std::string>("MSCCLPP_COMM_ID", "")),
        executionPlanDir(readEnv<std::string>("MSCCLPP_EXECUTION_PLAN_DIR", "")),
        npkitDumpDir(readEnv<std::string>("MSCCLPP_NPKIT_DUMP_DIR", "")),
 -      cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)) {}
 +      cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)),
 +      ibGidIndex(readEnv<int>("MSCCLPP_IB_GID_INDEX", -1)),
-+      ibTrafficClass(readEnv<int>("MSCCLPP_IB_TC", 0)) {}
++      ibTrafficClass(readEnv<int>("MSCCLPP_IB_TC", 0)),
++      ibAllowLinkLocalGid(readEnv<bool>("MSCCLPP_IB_ALLOW_LINKLOCAL_GID", false)) {}
  
  std::shared_ptr<Env> env() {
    static std::shared_ptr<Env> globalEnv = std::shared_ptr<Env>(new Env());
-@@ -80,6 +83,8 @@ std::shared_ptr<Env> env() {
+@@ -80,6 +84,9 @@ std::shared_ptr<Env> env() {
      logEnv("MSCCLPP_EXECUTION_PLAN_DIR", globalEnv->executionPlanDir);
      logEnv("MSCCLPP_NPKIT_DUMP_DIR", globalEnv->npkitDumpDir);
      logEnv("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", globalEnv->cudaIpcUseDefaultStream);
 +    logEnv("MSCCLPP_IB_GID_INDEX", globalEnv->ibGidIndex);
 +    logEnv("MSCCLPP_IB_TC", globalEnv->ibTrafficClass);
++    logEnv("MSCCLPP_IB_ALLOW_LINKLOCAL_GID", globalEnv->ibAllowLinkLocalGid);
    }
    return globalEnv;
  }
 diff --git a/src/ib.cc b/src/ib.cc
-index 542527e..7ebfa3f 100644
+index 542527e..89b2bec 100644
 --- a/src/ib.cc
 +++ b/src/ib.cc
-@@ -20,26 +20,200 @@
+@@ -20,26 +20,201 @@
  #include "debug.h"
  #if defined(USE_IBVERBS)
  #include "ibverbs_wrapper.hpp"
@@ -251,6 +254,7 @@ index 542527e..7ebfa3f 100644
 +    } else {
 +      currPriority = (gidCurrRoceVersion == 2) ? GidPriority::ROCEV2_LINK_LOCAL : GidPriority::ROCEV1_LINK_LOCAL;
 +    }
++    if(!env()->ibAllowLinkLocalGid && currPriority <= GidPriority::ROCEV2_LINK_LOCAL) continue;
 +    if(currPriority > highestPriority) {
 +      highestPriority = currPriority;
 +      gidIndex = i;
@@ -271,7 +275,7 @@ index 542527e..7ebfa3f 100644
  IbMr::IbMr(ibv_pd* pd, void* buff, std::size_t size) : buff(buff) {
    if (size == 0) {
      throw std::invalid_argument("invalid size: " + std::to_string(size));
-@@ -74,7 +248,7 @@ const void* IbMr::getBuff() const { return this->buff; }
+@@ -74,7 +249,7 @@ const void* IbMr::getBuff() const { return this->buff; }
  
  uint32_t IbMr::getLkey() const { return this->mr->lkey; }
  
@@ -280,7 +284,7 @@ index 542527e..7ebfa3f 100644
             int maxWrPerSend)
      : numSignaledPostedItems(0), numSignaledStagedItems(0), maxCqPollNum(maxCqPollNum), maxWrPerSend(maxWrPerSend) {
    this->cq = IBVerbs::ibv_create_cq(ctx, maxCqSize, nullptr, nullptr, 0);
-@@ -103,12 +277,6 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
+@@ -103,12 +278,6 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
      throw mscclpp::IbError(err.str(), errno);
    }
  
@@ -293,7 +297,7 @@ index 542527e..7ebfa3f 100644
    this->info.lid = portAttr.lid;
    this->info.port = port;
    this->info.linkLayer = portAttr.link_layer;
-@@ -117,8 +285,9 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
+@@ -117,8 +286,9 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
    this->info.is_grh = (portAttr.flags & IBV_QPF_GRH_REQUIRED);
  
    if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND || this->info.is_grh) {
@@ -304,7 +308,7 @@ index 542527e..7ebfa3f 100644
        std::stringstream err;
        err << "ibv_query_gid failed (errno " << errno << ")";
        throw mscclpp::IbError(err.str(), errno);
-@@ -164,9 +333,9 @@ void IbQp::rtr(const IbQpInfo& info) {
+@@ -164,9 +334,9 @@ void IbQp::rtr(const IbQpInfo& info) {
      qp_attr.ah_attr.grh.dgid.global.subnet_prefix = info.spn;
      qp_attr.ah_attr.grh.dgid.global.interface_id = info.iid;
      qp_attr.ah_attr.grh.flow_label = 0;
@@ -316,7 +320,7 @@ index 542527e..7ebfa3f 100644
    } else {
      qp_attr.ah_attr.is_global = 0;
    }
-@@ -290,7 +459,19 @@ void IbQp::postSend() {
+@@ -290,7 +460,19 @@ void IbQp::postSend() {
  int IbQp::pollCq() {
    int wcNum = IBVerbs::ibv_poll_cq(this->cq, this->maxCqPollNum, this->wcs->data());
    if (wcNum > 0) {
@@ -337,7 +341,7 @@ index 542527e..7ebfa3f 100644
    }
    return wcNum;
  }
-@@ -300,11 +481,10 @@ int IbQp::getWcStatus(int idx) const { return (*this->wcs)[idx].status; }
+@@ -300,11 +482,10 @@ int IbQp::getWcStatus(int idx) const { return (*this->wcs)[idx].status; }
  int IbQp::getNumCqItems() const { return this->numSignaledPostedItems; }
  
  IbCtx::IbCtx(const std::string& devName) : devName(devName) {
@@ -352,7 +356,7 @@ index 542527e..7ebfa3f 100644
    int num;
    struct ibv_device** devices = IBVerbs::ibv_get_device_list(&num);
    for (int i = 0; i < num; ++i) {
-@@ -338,8 +518,7 @@ IbCtx::~IbCtx() {
+@@ -338,8 +519,7 @@ IbCtx::~IbCtx() {
    }
  }
  
@@ -362,7 +366,7 @@ index 542527e..7ebfa3f 100644
    if (IBVerbs::ibv_query_port_w(this->ctx, port, &portAttr) != 0) {
      std::stringstream err;
      err << "ibv_query_port failed (errno " << errno << ", port << " << port << ")";
-@@ -349,7 +528,7 @@ bool IbCtx::isPortUsable(int port) const {
+@@ -349,7 +529,7 @@ bool IbCtx::isPortUsable(int port) const {
           (portAttr.link_layer == IBV_LINK_LAYER_ETHERNET || portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND);
  }
  
@@ -371,7 +375,7 @@ index 542527e..7ebfa3f 100644
    struct ibv_device_attr devAttr;
    if (IBVerbs::ibv_query_device(this->ctx, &devAttr) != 0) {
      std::stringstream err;
-@@ -357,7 +536,7 @@ int IbCtx::getAnyActivePort() const {
+@@ -357,7 +537,7 @@ int IbCtx::getAnyActivePort() const {
      throw mscclpp::IbError(err.str(), errno);
    }
    for (uint8_t port = 1; port <= devAttr.phys_port_cnt; ++port) {
@@ -380,7 +384,7 @@ index 542527e..7ebfa3f 100644
        return port;
      }
    }
-@@ -366,15 +545,16 @@ int IbCtx::getAnyActivePort() const {
+@@ -366,15 +546,16 @@ int IbCtx::getAnyActivePort() const {
  
  IbQp* IbCtx::createQp(int maxCqSize, int maxCqPollNum, int maxSendWr, int maxRecvWr, int maxWrPerSend,
                        int port /*=-1*/) {
@@ -400,7 +404,7 @@ index 542527e..7ebfa3f 100644
    return qps.back().get();
  }
  
-@@ -385,7 +565,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
+@@ -385,7 +566,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
  
  MSCCLPP_API_CPP int getIBDeviceCount() {
    int num;
@@ -409,7 +413,7 @@ index 542527e..7ebfa3f 100644
    return num;
  }
  
-@@ -442,20 +622,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
+@@ -442,20 +623,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
    }
  
    int num;

--- a/ext-src/roce-support.patch
+++ b/ext-src/roce-support.patch
@@ -57,7 +57,7 @@ index 625de0a..bcb847e 100644
    return globalEnv;
  }
 diff --git a/src/ib.cc b/src/ib.cc
-index 542527e..64bee94 100644
+index 542527e..7cddc55 100644
 --- a/src/ib.cc
 +++ b/src/ib.cc
 @@ -20,6 +20,8 @@
@@ -69,7 +69,7 @@ index 542527e..64bee94 100644
  #endif  // defined(USE_IBVERBS)
  
  #if !defined(__HIP_PLATFORM_AMD__)
-@@ -40,6 +42,166 @@ namespace mscclpp {
+@@ -40,6 +42,134 @@ namespace mscclpp {
  
  #if defined(USE_IBVERBS)
  
@@ -164,65 +164,33 @@ index 542527e..64bee94 100644
 +          gid.raw[11]              == 0xff);
 +}
 +
++
 +static uint8_t getGidIndex(struct ibv_context* context, int const& ibPort, int const& gidTblLen)
 +{
 +  union ibv_gid gid;
-+  int roceV2Ipv4MappedIndex = -1;
-+  int roceV1Ipv4MappedIndex = -1;
-+  int roceV2Ipv6Index = -1;
-+  int roceV1Ipv6Index = -1;
-+  int rocev2LinkLocalIndex = -1;
-+  int rocev1LinkLocalIndex = -1;
-+
++  GidPriority highestPriority = GidPriority::UNKNOWN;
++  int gidIndex = -1;
 +  for (int i = 0; i < gidTblLen; ++i) {
 +    if (ibv_query_gid(context, ibPort , i, &gid) != 0) continue;
 +    if (!isConfiguredGid(&gid)) continue;
 +    int gidCurrRoceVersion;
 +    gidCurrRoceVersion = getRoceVersionNumber(context, ibPort, i);
 +    if(gidCurrRoceVersion < 1) continue;
++    GidPriority currPriority;
 +    if (isIPv4MappedIPv6(gid)) {
-+      if (gidCurrRoceVersion == 2) {
-+        roceV2Ipv4MappedIndex = i;  // Highest priority
-+      } else {
-+        roceV1Ipv4MappedIndex = i;
-+      }
++      currPriority = (gidCurrRoceVersion == 2) ? GidPriority::ROCEV2_IPV4 : GidPriority::ROCEV1_IPV4;
 +    } else if (!isLinkLocalGid(gid)) {
-+      if (gidCurrRoceVersion == 2) {
-+        roceV2Ipv6Index = i;
-+      } else {
-+        roceV1Ipv6Index = i;
-+      }
++      currPriority = (gidCurrRoceVersion == 2) ? GidPriority::ROCEV2_IPV6 : GidPriority::ROCEV1_IPV6;
 +    } else {
-+      if (gidCurrRoceVersion == 2) {
-+        rocev2LinkLocalIndex = i;
-+      } else {
-+        rocev1LinkLocalIndex = i;
-+      }
++      currPriority = (gidCurrRoceVersion == 2) ? GidPriority::ROCEV2_LINK_LOCAL : GidPriority::ROCEV1_LINK_LOCAL;
++    }
++    if(currPriority > highestPriority) {
++      highestPriority = currPriority;
++      gidIndex = i;
 +    }
 +  }
 +
-+  // Select the best available GID based on priority
-+  // * Priority Order:
-+  // * 1. RoCE v2 (IPv4-mapped): ::ffff:192.168.x.x
-+  // * 2. RoCE v2 (Not IPv4-mapped)
-+  // * 3. RoCE v1 (IPv4-mapped)
-+  // * 4. RoCE v1 (Not IPv4-mapped)
-+  // * 5. RoCE v2 (Link-local): fe80::/10
-+  // * 6. RoCE v1 (Link-local)
-+  int gidIndex = -1;
-+  if (roceV2Ipv4MappedIndex != -1) {
-+    gidIndex = roceV2Ipv4MappedIndex;
-+  } else if (roceV2Ipv6Index != -1) {
-+    gidIndex = roceV2Ipv6Index;
-+  } else if (roceV1Ipv4MappedIndex != -1) {
-+    gidIndex = roceV1Ipv4MappedIndex;
-+  } else if (roceV1Ipv6Index != -1) {
-+    gidIndex = roceV1Ipv6Index;
-+  } else if (rocev2LinkLocalIndex != -1) {
-+    gidIndex = rocev2LinkLocalIndex;
-+  } else if (rocev1LinkLocalIndex != -1) {
-+    gidIndex = rocev1LinkLocalIndex;
-+  } else {
++  if(highestPriority == GidPriority::UNKNOWN){
 +    std::stringstream err;
 +    err << "Auto GetGidIndex failed. Try setting MSCCLPP_IB_GID_INDEX directly";
 +    throw mscclpp::Error(err.str(), ErrorCode::SystemError);
@@ -236,7 +204,7 @@ index 542527e..64bee94 100644
  IbMr::IbMr(ibv_pd* pd, void* buff, std::size_t size) : buff(buff) {
    if (size == 0) {
      throw std::invalid_argument("invalid size: " + std::to_string(size));
-@@ -117,8 +279,9 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
+@@ -117,8 +247,9 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
    this->info.is_grh = (portAttr.flags & IBV_QPF_GRH_REQUIRED);
  
    if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND || this->info.is_grh) {
@@ -247,7 +215,7 @@ index 542527e..64bee94 100644
        std::stringstream err;
        err << "ibv_query_gid failed (errno " << errno << ")";
        throw mscclpp::IbError(err.str(), errno);
-@@ -164,7 +327,7 @@ void IbQp::rtr(const IbQpInfo& info) {
+@@ -164,7 +295,7 @@ void IbQp::rtr(const IbQpInfo& info) {
      qp_attr.ah_attr.grh.dgid.global.subnet_prefix = info.spn;
      qp_attr.ah_attr.grh.dgid.global.interface_id = info.iid;
      qp_attr.ah_attr.grh.flow_label = 0;
@@ -256,7 +224,7 @@ index 542527e..64bee94 100644
      qp_attr.ah_attr.grh.hop_limit = 255;
      qp_attr.ah_attr.grh.traffic_class = 0;
    } else {
-@@ -385,7 +548,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
+@@ -385,7 +516,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
  
  MSCCLPP_API_CPP int getIBDeviceCount() {
    int num;
@@ -265,7 +233,7 @@ index 542527e..64bee94 100644
    return num;
  }
  
-@@ -442,20 +605,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
+@@ -442,20 +573,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
    }
  
    int num;
@@ -291,7 +259,7 @@ index 542527e..64bee94 100644
          case 0:
            return Transport::IB0;
 diff --git a/src/include/ib.hpp b/src/include/ib.hpp
-index 4d85299..cca642f 100644
+index 4d85299..3018d54 100644
 --- a/src/include/ib.hpp
 +++ b/src/include/ib.hpp
 @@ -54,6 +54,7 @@ struct IbQpInfo {
@@ -313,3 +281,26 @@ index 4d85299..cca642f 100644
  
    const std::string devName;
    ibv_context* ctx;
+@@ -142,7 +143,21 @@ class IbCtx {
+   std::list<std::unique_ptr<IbQp>> qps;
+   std::list<std::unique_ptr<IbMr>> mrs;
+ };
+-
++/**
++  * Enumeration of GID priority
++  *
++  * @note These are the GID types ordered in priority from lowest (0) to highest
++  */
++enum GidPriority
++{
++  UNKNOWN           = -1,                      ///< Default
++  ROCEV1_LINK_LOCAL = 0,                       ///< RoCEv1 Link-local
++  ROCEV2_LINK_LOCAL = 1,                       ///< RoCEv2 Link-local fe80::/10
++  ROCEV1_IPV6       = 2,                       ///< RoCEv1 IPv6
++  ROCEV2_IPV6       = 3,                       ///< RoCEv2 IPv6
++  ROCEV1_IPV4       = 4,                       ///< RoCEv1 IPv4-mapped IPv6
++  ROCEV2_IPV4       = 5,                       ///< RoCEv2 IPv4-mapped IPv6 ::ffff:192.168.x.x
++};
+ }  // namespace mscclpp
+ 
+ #endif  // MSCCLPP_IB_HPP_

--- a/ext-src/roce-support.patch
+++ b/ext-src/roce-support.patch
@@ -1,0 +1,594 @@
+diff --git a/include/mscclpp/env.hpp b/include/mscclpp/env.hpp
+index 6708628b..3f96b31f 100644
+--- a/include/mscclpp/env.hpp
++++ b/include/mscclpp/env.hpp
+@@ -30,6 +30,7 @@ class Env {
+   const std::string executionPlanDir;
+   const std::string npkitDumpDir;
+   const bool cudaIpcUseDefaultStream;
++  const int ibGidIndex;
+
+  private:
+   Env();
+diff --git a/src/env.cpp b/src/env.cpp
+index 625de0ad..bc08274c 100644
+--- a/src/env.cpp
++++ b/src/env.cpp
+@@ -19,8 +19,9 @@ T readEnv(const std::string &envName, const T &defaultValue) {
+     return atoi(envCstr);
+   } else if constexpr (std::is_same_v<T, bool>) {
+     return (std::string(envCstr) != "0");
++  } else {
++    return T(envCstr);
+   }
+-  return T(envCstr);
+ }
+
+ template <typename T>
+@@ -61,7 +62,8 @@ Env::Env()
+       commId(readEnv<std::string>("MSCCLPP_COMM_ID", "")),
+       executionPlanDir(readEnv<std::string>("MSCCLPP_EXECUTION_PLAN_DIR", "")),
+       npkitDumpDir(readEnv<std::string>("MSCCLPP_NPKIT_DUMP_DIR", "")),
+-      cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)) {}
++      cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)),
++      ibGidIndex(readEnv<int>("MSCCLPP_IB_GID_INDEX", 0))  {}
+
+ std::shared_ptr<Env> env() {
+   static std::shared_ptr<Env> globalEnv = std::shared_ptr<Env>(new Env());
+@@ -80,6 +82,7 @@ std::shared_ptr<Env> env() {
+     logEnv("MSCCLPP_EXECUTION_PLAN_DIR", globalEnv->executionPlanDir);
+     logEnv("MSCCLPP_NPKIT_DUMP_DIR", globalEnv->npkitDumpDir);
+     logEnv("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", globalEnv->cudaIpcUseDefaultStream);
++    logEnv("MSCCLPP_IB_GID_INDEX", globalEnv->ibGidIndex);
+   }
+   return globalEnv;
+ }
+diff --git a/src/ib.cc b/src/ib.cc
+index 542527e3..3dcac674 100644
+--- a/src/ib.cc
++++ b/src/ib.cc
+@@ -40,6 +40,42 @@ namespace mscclpp {
+
+ #if defined(USE_IBVERBS)
+
++MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int* numDevices) {
++  struct ibv_device** devices = IBVerbs::ibv_get_device_list(numDevices);
++  int count = *numDevices;
++  std::vector<std::string> activeDevices;
++  for (int i = 0; i < count; ++i) {
++    struct ibv_context* ctx = IBVerbs::ibv_open_device(devices[i]);
++    if (ctx == nullptr) {
++      continue;
++    }
++
++    struct ibv_device_attr devAttr;
++    if (IBVerbs::ibv_query_device(ctx, &devAttr) != 0) {
++      IBVerbs::ibv_close_device(ctx);
++      continue;
++    }
++
++    bool hasActivePort = false;
++    for (uint8_t port = 1; port <= devAttr.phys_port_cnt; ++port) {
++      struct ibv_port_attr portAttr;
++      if (IBVerbs::ibv_query_port_w(ctx, port, &portAttr) == 0 &&
++          portAttr.state == IBV_PORT_ACTIVE &&
++          (portAttr.link_layer == IBV_LINK_LAYER_ETHERNET || portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND)) {
++        hasActivePort = true;
++        break;
++      }
++    }
++
++    if (hasActivePort) {
++      activeDevices.push_back(devices[i]->name);
++    }
++    IBVerbs::ibv_close_device(ctx);
++  }
++  IBVerbs::ibv_free_device_list(devices);
++  return activeDevices;
++}
++
+ IbMr::IbMr(ibv_pd* pd, void* buff, std::size_t size) : buff(buff) {
+   if (size == 0) {
+     throw std::invalid_argument("invalid size: " + std::to_string(size));
+@@ -118,7 +154,7 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
+
+   if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND || this->info.is_grh) {
+     union ibv_gid gid;
+-    if (IBVerbs::ibv_query_gid(ctx, port, 0, &gid) != 0) {
++    if (IBVerbs::ibv_query_gid(ctx, port, env()->ibGidIndex, &gid) != 0) {
+       std::stringstream err;
+       err << "ibv_query_gid failed (errno " << errno << ")";
+       throw mscclpp::IbError(err.str(), errno);
+@@ -164,7 +200,7 @@ void IbQp::rtr(const IbQpInfo& info) {
+     qp_attr.ah_attr.grh.dgid.global.subnet_prefix = info.spn;
+     qp_attr.ah_attr.grh.dgid.global.interface_id = info.iid;
+     qp_attr.ah_attr.grh.flow_label = 0;
+-    qp_attr.ah_attr.grh.sgid_index = 0;
++    qp_attr.ah_attr.grh.sgid_index = env()->ibGidIndex;
+     qp_attr.ah_attr.grh.hop_limit = 255;
+     qp_attr.ah_attr.grh.traffic_class = 0;
+   } else {
+@@ -313,6 +349,7 @@ IbCtx::IbCtx(const std::string& devName) : devName(devName) {
+       break;
+     }
+   }
++  //freeIbDeviceListWithActivePorts(devices, num);
+   IBVerbs::ibv_free_device_list(devices);
+   if (this->ctx == nullptr) {
+     std::stringstream err;
+@@ -385,7 +422,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
+
+ MSCCLPP_API_CPP int getIBDeviceCount() {
+   int num;
+-  IBVerbs::ibv_get_device_list(&num);
++  auto const& dev = getActiveIbDeviceNames(&num);
+   return num;
+ }
+
+@@ -442,20 +479,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
+   }
+
+   int num;
+-  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&num);
++  auto const& devices = getActiveIbDeviceNames(&num);
+   if (ibTransportIndex >= num) {
+     std::stringstream ss;
+     ss << "IB transport out of range: " << ibTransportIndex << " >= " << num;
+     throw Error(ss.str(), ErrorCode::InvalidUsage);
+   }
+-  return devices[ibTransportIndex]->name;
++  return devices[ibTransportIndex];
+ }
+
+ MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string& ibDeviceName) {
+   int num;
+-  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&num);
++  auto const& devices = getActiveIbDeviceNames(&num);
+   for (int i = 0; i < num; ++i) {
+-    if (ibDeviceName == devices[i]->name) {
++    if (ibDeviceName == devices[i]) {
+       switch (i) {  // TODO: get rid of this ugly switch
+         case 0:
+           return Transport::IB0;
+@@ -489,6 +526,10 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport) { return ""; }
+
+ MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string&) { return Transport::Unknown; }
+
++MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int* numDevices) { *numDevices = 0; return std::vector<std::string>(); }
++
++MSCCLPP_API_CPP void freeIbDeviceListWithActivePorts(ibv_device** list, int numDevices) { }
++
+ #endif  // !defined(USE_IBVERBS)
+
+ }  // namespace mscclpp
+
+From 38c2fdeb1c256dd16453dd91454498664322423c Mon Sep 17 00:00:00 2001
+From: Mustafa Abduljabbar <mustafa.abduljabbar@amd.com>
+Date: Thu, 20 Feb 2025 12:52:13 -0600
+Subject: [PATCH 2/6] Remove unused function
+
+---
+ src/ib.cc | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/ib.cc b/src/ib.cc
+index 3dcac674..14b50837 100644
+--- a/src/ib.cc
++++ b/src/ib.cc
+@@ -528,8 +528,6 @@ MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string&) { retur
+
+ MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int* numDevices) { *numDevices = 0; return std::vector<std::string>(); }
+
+-MSCCLPP_API_CPP void freeIbDeviceListWithActivePorts(ibv_device** list, int numDevices) { }
+-
+ #endif  // !defined(USE_IBVERBS)
+
+ }  // namespace mscclpp
+
+From db3a0e167e086a20778c6f5fccb180cb60a78f3e Mon Sep 17 00:00:00 2001
+From: Mustafa Abduljabbar <mustafa.abduljabbar@amd.com>
+Date: Thu, 20 Feb 2025 13:03:27 -0600
+Subject: [PATCH 3/6] Simplify active ports device logic
+
+---
+ src/ib.cc          | 45 +++++++++++----------------------------------
+ src/include/ib.hpp |  2 +-
+ 2 files changed, 12 insertions(+), 35 deletions(-)
+
+diff --git a/src/ib.cc b/src/ib.cc
+index 14b50837..2f251850 100644
+--- a/src/ib.cc
++++ b/src/ib.cc
+@@ -40,38 +40,16 @@ namespace mscclpp {
+
+ #if defined(USE_IBVERBS)
+
+-MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int* numDevices) {
+-  struct ibv_device** devices = IBVerbs::ibv_get_device_list(numDevices);
+-  int count = *numDevices;
++MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) {
++  int count;
++  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&count);
+   std::vector<std::string> activeDevices;
+   for (int i = 0; i < count; ++i) {
+-    struct ibv_context* ctx = IBVerbs::ibv_open_device(devices[i]);
+-    if (ctx == nullptr) {
+-      continue;
+-    }
+-
+-    struct ibv_device_attr devAttr;
+-    if (IBVerbs::ibv_query_device(ctx, &devAttr) != 0) {
+-      IBVerbs::ibv_close_device(ctx);
+-      continue;
+-    }
+-
+-    bool hasActivePort = false;
+-    for (uint8_t port = 1; port <= devAttr.phys_port_cnt; ++port) {
+-      struct ibv_port_attr portAttr;
+-      if (IBVerbs::ibv_query_port_w(ctx, port, &portAttr) == 0 &&
+-          portAttr.state == IBV_PORT_ACTIVE &&
+-          (portAttr.link_layer == IBV_LINK_LAYER_ETHERNET || portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND)) {
+-        hasActivePort = true;
+-        break;
+-      }
+-    }
+-
+-    if (hasActivePort) {
+-      activeDevices.push_back(devices[i]->name);
+-    }
+-    IBVerbs::ibv_close_device(ctx);
++    IbCtx ctx(devices[i]->name);
++    if(ctx.getAnyActivePort() < 0) continue;
++    activeDevices.push_back(devices[i]->name);
+   }
++  numActiveDevices = activeDevices.size();
+   IBVerbs::ibv_free_device_list(devices);
+   return activeDevices;
+ }
+@@ -349,7 +327,6 @@ IbCtx::IbCtx(const std::string& devName) : devName(devName) {
+       break;
+     }
+   }
+-  //freeIbDeviceListWithActivePorts(devices, num);
+   IBVerbs::ibv_free_device_list(devices);
+   if (this->ctx == nullptr) {
+     std::stringstream err;
+@@ -422,7 +399,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
+
+ MSCCLPP_API_CPP int getIBDeviceCount() {
+   int num;
+-  auto const& dev = getActiveIbDeviceNames(&num);
++  auto const& dev = getActiveIbDeviceNames(num);
+   return num;
+ }
+
+@@ -479,7 +456,7 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
+   }
+
+   int num;
+-  auto const& devices = getActiveIbDeviceNames(&num);
++  auto const& devices = getActiveIbDeviceNames(num);
+   if (ibTransportIndex >= num) {
+     std::stringstream ss;
+     ss << "IB transport out of range: " << ibTransportIndex << " >= " << num;
+@@ -490,7 +467,7 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
+
+ MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string& ibDeviceName) {
+   int num;
+-  auto const& devices = getActiveIbDeviceNames(&num);
++  auto const& devices = getActiveIbDeviceNames(num);
+   for (int i = 0; i < num; ++i) {
+     if (ibDeviceName == devices[i]) {
+       switch (i) {  // TODO: get rid of this ugly switch
+@@ -526,7 +503,7 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport) { return ""; }
+
+ MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string&) { return Transport::Unknown; }
+
+-MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int* numDevices) { *numDevices = 0; return std::vector<std::string>(); }
++MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) { *numDevices = 0; return std::vector<std::string>(); }
+
+ #endif  // !defined(USE_IBVERBS)
+
+diff --git a/src/include/ib.hpp b/src/include/ib.hpp
+index 4d852998..643e9d3b 100644
+--- a/src/include/ib.hpp
++++ b/src/include/ib.hpp
+@@ -132,9 +132,9 @@ class IbCtx {
+
+   const std::string& getDevName() const { return this->devName; };
+
++  int getAnyActivePort() const;
+  private:
+   bool isPortUsable(int port) const;
+-  int getAnyActivePort() const;
+
+   const std::string devName;
+   ibv_context* ctx;
+
+From 55432f765ed680a891292218d88ee0a99040bdc4 Mon Sep 17 00:00:00 2001
+From: Mustafa Abduljabbar <mustafa.abduljabbar@amd.com>
+Date: Fri, 21 Feb 2025 07:37:25 -0600
+Subject: [PATCH 4/6] Add support for bootstrapping over Ethernet interface
+
+---
+ src/bootstrap/socket.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/bootstrap/socket.cc b/src/bootstrap/socket.cc
+index 8c012c28..5dc43b6f 100644
+--- a/src/bootstrap/socket.cc
++++ b/src/bootstrap/socket.cc
+@@ -327,6 +327,8 @@ int FindInterfaces(char* ifNames, union SocketAddress* ifAddrs, int ifNameMaxSiz
+         nIfs = FindInterfaceMatchSubnet(ifNames, ifAddrs, &idAddr, ifNameMaxSize, maxIfs);
+       }
+     }
++    // Look for Ethernet if no IB interface was found
++    if (nIfs == 0) nIfs = findInterfaces("en", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
+     // Then look for anything else (but not docker or lo)
+     if (nIfs == 0) nIfs = findInterfaces("^docker,lo", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
+     // Finally look for docker, then lo.
+
+From d7b9b00d0a1644de24eb803e41ca25de0a4f43cb Mon Sep 17 00:00:00 2001
+From: Mustafa Abduljabbar <mustafa.abduljabbar@amd.com>
+Date: Fri, 21 Feb 2025 08:57:06 -0600
+Subject: [PATCH 5/6] handle case when ibverbs is not available
+
+---
+ src/ib.cc | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/ib.cc b/src/ib.cc
+index 2f251850..6e53b55b 100644
+--- a/src/ib.cc
++++ b/src/ib.cc
+@@ -42,8 +42,12 @@ namespace mscclpp {
+
+ MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) {
+   int count;
+-  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&count);
+   std::vector<std::string> activeDevices;
++  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&count);
++  if(!devices) {
++    numActiveDevices = 0;
++    return activeDevices;
++  }
+   for (int i = 0; i < count; ++i) {
+     IbCtx ctx(devices[i]->name);
+     if(ctx.getAnyActivePort() < 0) continue;
+
+From 995751f777abec0c2a516d9b60b78b2ae00ccd9b Mon Sep 17 00:00:00 2001
+From: Mustafa Abduljabbar <mustafa.abduljabbar@amd.com>
+Date: Fri, 21 Feb 2025 16:16:51 -0600
+Subject: [PATCH 6/6] Add auto GID index detection
+
+---
+ src/env.cpp        |   2 +-
+ src/ib.cc          | 153 +++++++++++++++++++++++++++++++++++++++++++--
+ src/include/ib.hpp |   1 +
+ 3 files changed, 150 insertions(+), 6 deletions(-)
+
+diff --git a/src/env.cpp b/src/env.cpp
+index bc08274c..bcb847e5 100644
+--- a/src/env.cpp
++++ b/src/env.cpp
+@@ -63,7 +63,7 @@ Env::Env()
+       executionPlanDir(readEnv<std::string>("MSCCLPP_EXECUTION_PLAN_DIR", "")),
+       npkitDumpDir(readEnv<std::string>("MSCCLPP_NPKIT_DUMP_DIR", "")),
+       cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)),
+-      ibGidIndex(readEnv<int>("MSCCLPP_IB_GID_INDEX", 0))  {}
++      ibGidIndex(readEnv<int>("MSCCLPP_IB_GID_INDEX", -1))  {}
+
+ std::shared_ptr<Env> env() {
+   static std::shared_ptr<Env> globalEnv = std::shared_ptr<Env>(new Env());
+diff --git a/src/ib.cc b/src/ib.cc
+index 6e53b55b..64bee944 100644
+--- a/src/ib.cc
++++ b/src/ib.cc
+@@ -20,6 +20,8 @@
+ #include "debug.h"
+ #if defined(USE_IBVERBS)
+ #include "ibverbs_wrapper.hpp"
++#include <arpa/inet.h>
++#include <fcntl.h>
+ #endif  // defined(USE_IBVERBS)
+
+ #if !defined(__HIP_PLATFORM_AMD__)
+@@ -40,7 +42,7 @@ namespace mscclpp {
+
+ #if defined(USE_IBVERBS)
+
+-MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) {
++static std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) {
+   int count;
+   std::vector<std::string> activeDevices;
+   struct ibv_device** devices = IBVerbs::ibv_get_device_list(&count);
+@@ -58,6 +60,148 @@ MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDe
+   return activeDevices;
+ }
+
++static bool isConfiguredGid(union ibv_gid* gid)
++{
++  const struct in6_addr *a = (struct in6_addr *)gid->raw;
++  int trailer = (a->s6_addr32[1] | a->s6_addr32[2] | a->s6_addr32[3]);
++  if (((a->s6_addr32[0] | trailer) == 0UL) ||
++      ((a->s6_addr32[0] == htonl(0xfe800000)) && (trailer == 0UL))) {
++    return false;
++  }
++  return true;
++}
++
++static bool isLinkLocalGid(union ibv_gid const& gid)
++{
++  const struct in6_addr *a = (struct in6_addr *) gid.raw;
++  if (a->s6_addr32[0] == htonl(0xfe800000) && a->s6_addr32[1] == 0UL) {
++    return true;
++  }
++  return false;
++}
++
++static int getRoceVersionNumber(struct ibv_context* const& context, int const& portNum, int const& gidIndex)
++{
++  char const* deviceName = ibv_get_device_name(context->device);
++  char gidRoceVerStr[16]      = {};
++  char roceTypePath[PATH_MAX] = {};
++
++  sprintf(roceTypePath, "/sys/class/infiniband/%s/ports/%d/gid_attrs/types/%d",
++          deviceName, portNum, gidIndex);
++
++
++  int fd = open(roceTypePath, O_RDONLY);
++  if (fd == -1) {
++    std::stringstream err;
++    err << "Failed while opening RoCE file path " << roceTypePath;
++    throw mscclpp::Error(err.str(), ErrorCode::InternalError);
++  }
++
++  int ret = read(fd, gidRoceVerStr, 15);
++  close(fd);
++
++  if (ret == -1) {
++    std::stringstream err;
++    err << "Failed while reading RoCE version";
++    throw mscclpp::Error(err.str(), ErrorCode::InternalError);
++  }
++
++  if (strlen(gidRoceVerStr)) {
++    if (strncmp(gidRoceVerStr, "IB/RoCE v1", strlen("IB/RoCE v1")) == 0
++        || strncmp(gidRoceVerStr, "RoCE v1", strlen("RoCE v1")) == 0) {
++      return 1;
++    }
++    else if (strncmp(gidRoceVerStr, "RoCE v2", strlen("RoCE v2")) == 0) {
++      return 2;
++    }
++  }
++  return -1;
++}
++
++static bool isIPv4MappedIPv6(const union ibv_gid &gid)
++{
++  // look for ::ffff:x.x.x.x format
++  // From Broadcom documentation
++  // https://techdocs.broadcom.com/us/en/storage-and-ethernet-connectivity/ethernet-nic-controllers/bcm957xxx/adapters/frequently-asked-questions1.html
++  // "The IPv4 address is really an IPv4 address mapped into the IPv6 address space.
++  // This can be identified by 80 “0” bits, followed by 16 “1” bits (“FFFF” in hexadecimal)
++  // followed by the original 32-bit IPv4 address."
++  return (gid.global.subnet_prefix == 0    &&
++          gid.raw[8]               == 0    &&
++          gid.raw[9]               == 0    &&
++          gid.raw[10]              == 0xff &&
++          gid.raw[11]              == 0xff);
++}
++
++static uint8_t getGidIndex(struct ibv_context* context, int const& ibPort, int const& gidTblLen)
++{
++  union ibv_gid gid;
++  int roceV2Ipv4MappedIndex = -1;
++  int roceV1Ipv4MappedIndex = -1;
++  int roceV2Ipv6Index = -1;
++  int roceV1Ipv6Index = -1;
++  int rocev2LinkLocalIndex = -1;
++  int rocev1LinkLocalIndex = -1;
++
++  for (int i = 0; i < gidTblLen; ++i) {
++    if (ibv_query_gid(context, ibPort , i, &gid) != 0) continue;
++    if (!isConfiguredGid(&gid)) continue;
++    int gidCurrRoceVersion;
++    gidCurrRoceVersion = getRoceVersionNumber(context, ibPort, i);
++    if(gidCurrRoceVersion < 1) continue;
++    if (isIPv4MappedIPv6(gid)) {
++      if (gidCurrRoceVersion == 2) {
++        roceV2Ipv4MappedIndex = i;  // Highest priority
++      } else {
++        roceV1Ipv4MappedIndex = i;
++      }
++    } else if (!isLinkLocalGid(gid)) {
++      if (gidCurrRoceVersion == 2) {
++        roceV2Ipv6Index = i;
++      } else {
++        roceV1Ipv6Index = i;
++      }
++    } else {
++      if (gidCurrRoceVersion == 2) {
++        rocev2LinkLocalIndex = i;
++      } else {
++        rocev1LinkLocalIndex = i;
++      }
++    }
++  }
++
++  // Select the best available GID based on priority
++  // * Priority Order:
++  // * 1. RoCE v2 (IPv4-mapped): ::ffff:192.168.x.x
++  // * 2. RoCE v2 (Not IPv4-mapped)
++  // * 3. RoCE v1 (IPv4-mapped)
++  // * 4. RoCE v1 (Not IPv4-mapped)
++  // * 5. RoCE v2 (Link-local): fe80::/10
++  // * 6. RoCE v1 (Link-local)
++  int gidIndex = -1;
++  if (roceV2Ipv4MappedIndex != -1) {
++    gidIndex = roceV2Ipv4MappedIndex;
++  } else if (roceV2Ipv6Index != -1) {
++    gidIndex = roceV2Ipv6Index;
++  } else if (roceV1Ipv4MappedIndex != -1) {
++    gidIndex = roceV1Ipv4MappedIndex;
++  } else if (roceV1Ipv6Index != -1) {
++    gidIndex = roceV1Ipv6Index;
++  } else if (rocev2LinkLocalIndex != -1) {
++    gidIndex = rocev2LinkLocalIndex;
++  } else if (rocev1LinkLocalIndex != -1) {
++    gidIndex = rocev1LinkLocalIndex;
++  } else {
++    std::stringstream err;
++    err << "Auto GetGidIndex failed. Try setting MSCCLPP_IB_GID_INDEX directly";
++    throw mscclpp::Error(err.str(), ErrorCode::SystemError);
++  }
++  if(gidIndex >= UINT8_MAX || gidIndex < 0) {
++    throw mscclpp::Error("Invalid auto-deteced gidIndex : " + std::to_string(gidIndex), ErrorCode::SystemError);
++  }
++  return static_cast<uint8_t>(gidIndex);
++}
++
+ IbMr::IbMr(ibv_pd* pd, void* buff, std::size_t size) : buff(buff) {
+   if (size == 0) {
+     throw std::invalid_argument("invalid size: " + std::to_string(size));
+@@ -135,8 +279,9 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
+   this->info.is_grh = (portAttr.flags & IBV_QPF_GRH_REQUIRED);
+
+   if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND || this->info.is_grh) {
++    this->info.gidIndex = (env()->ibGidIndex < 0) ? getGidIndex(ctx, port, portAttr.gid_tbl_len) : env()->ibGidIndex;
+     union ibv_gid gid;
+-    if (IBVerbs::ibv_query_gid(ctx, port, env()->ibGidIndex, &gid) != 0) {
++    if (IBVerbs::ibv_query_gid(ctx, port, this->info.gidIndex, &gid) != 0) {
+       std::stringstream err;
+       err << "ibv_query_gid failed (errno " << errno << ")";
+       throw mscclpp::IbError(err.str(), errno);
+@@ -182,7 +327,7 @@ void IbQp::rtr(const IbQpInfo& info) {
+     qp_attr.ah_attr.grh.dgid.global.subnet_prefix = info.spn;
+     qp_attr.ah_attr.grh.dgid.global.interface_id = info.iid;
+     qp_attr.ah_attr.grh.flow_label = 0;
+-    qp_attr.ah_attr.grh.sgid_index = env()->ibGidIndex;
++    qp_attr.ah_attr.grh.sgid_index = this->info.gidIndex;
+     qp_attr.ah_attr.grh.hop_limit = 255;
+     qp_attr.ah_attr.grh.traffic_class = 0;
+   } else {
+@@ -507,8 +652,6 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport) { return ""; }
+
+ MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string&) { return Transport::Unknown; }
+
+-MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) { *numDevices = 0; return std::vector<std::string>(); }
+-
+ #endif  // !defined(USE_IBVERBS)
+
+ }  // namespace mscclpp
+diff --git a/src/include/ib.hpp b/src/include/ib.hpp
+index 643e9d3b..cca642f6 100644
+--- a/src/include/ib.hpp
++++ b/src/include/ib.hpp
+@@ -54,6 +54,7 @@ struct IbQpInfo {
+   int mtu;
+   uint64_t iid;
+   bool is_grh;
++  uint8_t gidIndex;
+ };
+
+ enum class WsStatus {

--- a/ext-src/roce-support.patch
+++ b/ext-src/roce-support.patch
@@ -1,19 +1,32 @@
-diff --git a/include/mscclpp/env.hpp b/include/mscclpp/env.hpp
-index 6708628b..3f96b31f 100644
---- a/include/mscclpp/env.hpp
-+++ b/include/mscclpp/env.hpp
+diff --git include/mscclpp/env.hpp include/mscclpp/env.hpp
+index 6708628..3f96b31 100644
+--- include/mscclpp/env.hpp
++++ include/mscclpp/env.hpp
 @@ -30,6 +30,7 @@ class Env {
    const std::string executionPlanDir;
    const std::string npkitDumpDir;
    const bool cudaIpcUseDefaultStream;
 +  const int ibGidIndex;
-
+ 
   private:
    Env();
-diff --git a/src/env.cpp b/src/env.cpp
-index 625de0ad..bc08274c 100644
---- a/src/env.cpp
-+++ b/src/env.cpp
+diff --git src/bootstrap/socket.cc src/bootstrap/socket.cc
+index 8c012c2..5dc43b6 100644
+--- src/bootstrap/socket.cc
++++ src/bootstrap/socket.cc
+@@ -327,6 +327,8 @@ int FindInterfaces(char* ifNames, union SocketAddress* ifAddrs, int ifNameMaxSiz
+         nIfs = FindInterfaceMatchSubnet(ifNames, ifAddrs, &idAddr, ifNameMaxSize, maxIfs);
+       }
+     }
++    // Look for Ethernet if no IB interface was found
++    if (nIfs == 0) nIfs = findInterfaces("en", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
+     // Then look for anything else (but not docker or lo)
+     if (nIfs == 0) nIfs = findInterfaces("^docker,lo", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
+     // Finally look for docker, then lo.
+diff --git src/env.cpp src/env.cpp
+index 625de0a..bcb847e 100644
+--- src/env.cpp
++++ src/env.cpp
 @@ -19,8 +19,9 @@ T readEnv(const std::string &envName, const T &defaultValue) {
      return atoi(envCstr);
    } else if constexpr (std::is_same_v<T, bool>) {
@@ -23,7 +36,7 @@ index 625de0ad..bc08274c 100644
    }
 -  return T(envCstr);
  }
-
+ 
  template <typename T>
 @@ -61,7 +62,8 @@ Env::Env()
        commId(readEnv<std::string>("MSCCLPP_COMM_ID", "")),
@@ -31,8 +44,8 @@ index 625de0ad..bc08274c 100644
        npkitDumpDir(readEnv<std::string>("MSCCLPP_NPKIT_DUMP_DIR", "")),
 -      cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)) {}
 +      cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)),
-+      ibGidIndex(readEnv<int>("MSCCLPP_IB_GID_INDEX", 0))  {}
-
++      ibGidIndex(readEnv<int>("MSCCLPP_IB_GID_INDEX", -1))  {}
+ 
  std::shared_ptr<Env> env() {
    static std::shared_ptr<Env> globalEnv = std::shared_ptr<Env>(new Env());
 @@ -80,6 +82,7 @@ std::shared_ptr<Env> env() {
@@ -43,347 +56,10 @@ index 625de0ad..bc08274c 100644
    }
    return globalEnv;
  }
-diff --git a/src/ib.cc b/src/ib.cc
-index 542527e3..3dcac674 100644
---- a/src/ib.cc
-+++ b/src/ib.cc
-@@ -40,6 +40,42 @@ namespace mscclpp {
-
- #if defined(USE_IBVERBS)
-
-+MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int* numDevices) {
-+  struct ibv_device** devices = IBVerbs::ibv_get_device_list(numDevices);
-+  int count = *numDevices;
-+  std::vector<std::string> activeDevices;
-+  for (int i = 0; i < count; ++i) {
-+    struct ibv_context* ctx = IBVerbs::ibv_open_device(devices[i]);
-+    if (ctx == nullptr) {
-+      continue;
-+    }
-+
-+    struct ibv_device_attr devAttr;
-+    if (IBVerbs::ibv_query_device(ctx, &devAttr) != 0) {
-+      IBVerbs::ibv_close_device(ctx);
-+      continue;
-+    }
-+
-+    bool hasActivePort = false;
-+    for (uint8_t port = 1; port <= devAttr.phys_port_cnt; ++port) {
-+      struct ibv_port_attr portAttr;
-+      if (IBVerbs::ibv_query_port_w(ctx, port, &portAttr) == 0 &&
-+          portAttr.state == IBV_PORT_ACTIVE &&
-+          (portAttr.link_layer == IBV_LINK_LAYER_ETHERNET || portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND)) {
-+        hasActivePort = true;
-+        break;
-+      }
-+    }
-+
-+    if (hasActivePort) {
-+      activeDevices.push_back(devices[i]->name);
-+    }
-+    IBVerbs::ibv_close_device(ctx);
-+  }
-+  IBVerbs::ibv_free_device_list(devices);
-+  return activeDevices;
-+}
-+
- IbMr::IbMr(ibv_pd* pd, void* buff, std::size_t size) : buff(buff) {
-   if (size == 0) {
-     throw std::invalid_argument("invalid size: " + std::to_string(size));
-@@ -118,7 +154,7 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
-
-   if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND || this->info.is_grh) {
-     union ibv_gid gid;
--    if (IBVerbs::ibv_query_gid(ctx, port, 0, &gid) != 0) {
-+    if (IBVerbs::ibv_query_gid(ctx, port, env()->ibGidIndex, &gid) != 0) {
-       std::stringstream err;
-       err << "ibv_query_gid failed (errno " << errno << ")";
-       throw mscclpp::IbError(err.str(), errno);
-@@ -164,7 +200,7 @@ void IbQp::rtr(const IbQpInfo& info) {
-     qp_attr.ah_attr.grh.dgid.global.subnet_prefix = info.spn;
-     qp_attr.ah_attr.grh.dgid.global.interface_id = info.iid;
-     qp_attr.ah_attr.grh.flow_label = 0;
--    qp_attr.ah_attr.grh.sgid_index = 0;
-+    qp_attr.ah_attr.grh.sgid_index = env()->ibGidIndex;
-     qp_attr.ah_attr.grh.hop_limit = 255;
-     qp_attr.ah_attr.grh.traffic_class = 0;
-   } else {
-@@ -313,6 +349,7 @@ IbCtx::IbCtx(const std::string& devName) : devName(devName) {
-       break;
-     }
-   }
-+  //freeIbDeviceListWithActivePorts(devices, num);
-   IBVerbs::ibv_free_device_list(devices);
-   if (this->ctx == nullptr) {
-     std::stringstream err;
-@@ -385,7 +422,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
-
- MSCCLPP_API_CPP int getIBDeviceCount() {
-   int num;
--  IBVerbs::ibv_get_device_list(&num);
-+  auto const& dev = getActiveIbDeviceNames(&num);
-   return num;
- }
-
-@@ -442,20 +479,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
-   }
-
-   int num;
--  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&num);
-+  auto const& devices = getActiveIbDeviceNames(&num);
-   if (ibTransportIndex >= num) {
-     std::stringstream ss;
-     ss << "IB transport out of range: " << ibTransportIndex << " >= " << num;
-     throw Error(ss.str(), ErrorCode::InvalidUsage);
-   }
--  return devices[ibTransportIndex]->name;
-+  return devices[ibTransportIndex];
- }
-
- MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string& ibDeviceName) {
-   int num;
--  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&num);
-+  auto const& devices = getActiveIbDeviceNames(&num);
-   for (int i = 0; i < num; ++i) {
--    if (ibDeviceName == devices[i]->name) {
-+    if (ibDeviceName == devices[i]) {
-       switch (i) {  // TODO: get rid of this ugly switch
-         case 0:
-           return Transport::IB0;
-@@ -489,6 +526,10 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport) { return ""; }
-
- MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string&) { return Transport::Unknown; }
-
-+MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int* numDevices) { *numDevices = 0; return std::vector<std::string>(); }
-+
-+MSCCLPP_API_CPP void freeIbDeviceListWithActivePorts(ibv_device** list, int numDevices) { }
-+
- #endif  // !defined(USE_IBVERBS)
-
- }  // namespace mscclpp
-
-From 38c2fdeb1c256dd16453dd91454498664322423c Mon Sep 17 00:00:00 2001
-From: Mustafa Abduljabbar <mustafa.abduljabbar@amd.com>
-Date: Thu, 20 Feb 2025 12:52:13 -0600
-Subject: [PATCH 2/6] Remove unused function
-
----
- src/ib.cc | 2 --
- 1 file changed, 2 deletions(-)
-
-diff --git a/src/ib.cc b/src/ib.cc
-index 3dcac674..14b50837 100644
---- a/src/ib.cc
-+++ b/src/ib.cc
-@@ -528,8 +528,6 @@ MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string&) { retur
-
- MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int* numDevices) { *numDevices = 0; return std::vector<std::string>(); }
-
--MSCCLPP_API_CPP void freeIbDeviceListWithActivePorts(ibv_device** list, int numDevices) { }
--
- #endif  // !defined(USE_IBVERBS)
-
- }  // namespace mscclpp
-
-From db3a0e167e086a20778c6f5fccb180cb60a78f3e Mon Sep 17 00:00:00 2001
-From: Mustafa Abduljabbar <mustafa.abduljabbar@amd.com>
-Date: Thu, 20 Feb 2025 13:03:27 -0600
-Subject: [PATCH 3/6] Simplify active ports device logic
-
----
- src/ib.cc          | 45 +++++++++++----------------------------------
- src/include/ib.hpp |  2 +-
- 2 files changed, 12 insertions(+), 35 deletions(-)
-
-diff --git a/src/ib.cc b/src/ib.cc
-index 14b50837..2f251850 100644
---- a/src/ib.cc
-+++ b/src/ib.cc
-@@ -40,38 +40,16 @@ namespace mscclpp {
-
- #if defined(USE_IBVERBS)
-
--MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int* numDevices) {
--  struct ibv_device** devices = IBVerbs::ibv_get_device_list(numDevices);
--  int count = *numDevices;
-+MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) {
-+  int count;
-+  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&count);
-   std::vector<std::string> activeDevices;
-   for (int i = 0; i < count; ++i) {
--    struct ibv_context* ctx = IBVerbs::ibv_open_device(devices[i]);
--    if (ctx == nullptr) {
--      continue;
--    }
--
--    struct ibv_device_attr devAttr;
--    if (IBVerbs::ibv_query_device(ctx, &devAttr) != 0) {
--      IBVerbs::ibv_close_device(ctx);
--      continue;
--    }
--
--    bool hasActivePort = false;
--    for (uint8_t port = 1; port <= devAttr.phys_port_cnt; ++port) {
--      struct ibv_port_attr portAttr;
--      if (IBVerbs::ibv_query_port_w(ctx, port, &portAttr) == 0 &&
--          portAttr.state == IBV_PORT_ACTIVE &&
--          (portAttr.link_layer == IBV_LINK_LAYER_ETHERNET || portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND)) {
--        hasActivePort = true;
--        break;
--      }
--    }
--
--    if (hasActivePort) {
--      activeDevices.push_back(devices[i]->name);
--    }
--    IBVerbs::ibv_close_device(ctx);
-+    IbCtx ctx(devices[i]->name);
-+    if(ctx.getAnyActivePort() < 0) continue;
-+    activeDevices.push_back(devices[i]->name);
-   }
-+  numActiveDevices = activeDevices.size();
-   IBVerbs::ibv_free_device_list(devices);
-   return activeDevices;
- }
-@@ -349,7 +327,6 @@ IbCtx::IbCtx(const std::string& devName) : devName(devName) {
-       break;
-     }
-   }
--  //freeIbDeviceListWithActivePorts(devices, num);
-   IBVerbs::ibv_free_device_list(devices);
-   if (this->ctx == nullptr) {
-     std::stringstream err;
-@@ -422,7 +399,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
-
- MSCCLPP_API_CPP int getIBDeviceCount() {
-   int num;
--  auto const& dev = getActiveIbDeviceNames(&num);
-+  auto const& dev = getActiveIbDeviceNames(num);
-   return num;
- }
-
-@@ -479,7 +456,7 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
-   }
-
-   int num;
--  auto const& devices = getActiveIbDeviceNames(&num);
-+  auto const& devices = getActiveIbDeviceNames(num);
-   if (ibTransportIndex >= num) {
-     std::stringstream ss;
-     ss << "IB transport out of range: " << ibTransportIndex << " >= " << num;
-@@ -490,7 +467,7 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
-
- MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string& ibDeviceName) {
-   int num;
--  auto const& devices = getActiveIbDeviceNames(&num);
-+  auto const& devices = getActiveIbDeviceNames(num);
-   for (int i = 0; i < num; ++i) {
-     if (ibDeviceName == devices[i]) {
-       switch (i) {  // TODO: get rid of this ugly switch
-@@ -526,7 +503,7 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport) { return ""; }
-
- MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string&) { return Transport::Unknown; }
-
--MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int* numDevices) { *numDevices = 0; return std::vector<std::string>(); }
-+MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) { *numDevices = 0; return std::vector<std::string>(); }
-
- #endif  // !defined(USE_IBVERBS)
-
-diff --git a/src/include/ib.hpp b/src/include/ib.hpp
-index 4d852998..643e9d3b 100644
---- a/src/include/ib.hpp
-+++ b/src/include/ib.hpp
-@@ -132,9 +132,9 @@ class IbCtx {
-
-   const std::string& getDevName() const { return this->devName; };
-
-+  int getAnyActivePort() const;
-  private:
-   bool isPortUsable(int port) const;
--  int getAnyActivePort() const;
-
-   const std::string devName;
-   ibv_context* ctx;
-
-From 55432f765ed680a891292218d88ee0a99040bdc4 Mon Sep 17 00:00:00 2001
-From: Mustafa Abduljabbar <mustafa.abduljabbar@amd.com>
-Date: Fri, 21 Feb 2025 07:37:25 -0600
-Subject: [PATCH 4/6] Add support for bootstrapping over Ethernet interface
-
----
- src/bootstrap/socket.cc | 2 ++
- 1 file changed, 2 insertions(+)
-
-diff --git a/src/bootstrap/socket.cc b/src/bootstrap/socket.cc
-index 8c012c28..5dc43b6f 100644
---- a/src/bootstrap/socket.cc
-+++ b/src/bootstrap/socket.cc
-@@ -327,6 +327,8 @@ int FindInterfaces(char* ifNames, union SocketAddress* ifAddrs, int ifNameMaxSiz
-         nIfs = FindInterfaceMatchSubnet(ifNames, ifAddrs, &idAddr, ifNameMaxSize, maxIfs);
-       }
-     }
-+    // Look for Ethernet if no IB interface was found
-+    if (nIfs == 0) nIfs = findInterfaces("en", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
-     // Then look for anything else (but not docker or lo)
-     if (nIfs == 0) nIfs = findInterfaces("^docker,lo", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
-     // Finally look for docker, then lo.
-
-From d7b9b00d0a1644de24eb803e41ca25de0a4f43cb Mon Sep 17 00:00:00 2001
-From: Mustafa Abduljabbar <mustafa.abduljabbar@amd.com>
-Date: Fri, 21 Feb 2025 08:57:06 -0600
-Subject: [PATCH 5/6] handle case when ibverbs is not available
-
----
- src/ib.cc | 6 +++++-
- 1 file changed, 5 insertions(+), 1 deletion(-)
-
-diff --git a/src/ib.cc b/src/ib.cc
-index 2f251850..6e53b55b 100644
---- a/src/ib.cc
-+++ b/src/ib.cc
-@@ -42,8 +42,12 @@ namespace mscclpp {
-
- MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) {
-   int count;
--  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&count);
-   std::vector<std::string> activeDevices;
-+  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&count);
-+  if(!devices) {
-+    numActiveDevices = 0;
-+    return activeDevices;
-+  }
-   for (int i = 0; i < count; ++i) {
-     IbCtx ctx(devices[i]->name);
-     if(ctx.getAnyActivePort() < 0) continue;
-
-From 995751f777abec0c2a516d9b60b78b2ae00ccd9b Mon Sep 17 00:00:00 2001
-From: Mustafa Abduljabbar <mustafa.abduljabbar@amd.com>
-Date: Fri, 21 Feb 2025 16:16:51 -0600
-Subject: [PATCH 6/6] Add auto GID index detection
-
----
- src/env.cpp        |   2 +-
- src/ib.cc          | 153 +++++++++++++++++++++++++++++++++++++++++++--
- src/include/ib.hpp |   1 +
- 3 files changed, 150 insertions(+), 6 deletions(-)
-
-diff --git a/src/env.cpp b/src/env.cpp
-index bc08274c..bcb847e5 100644
---- a/src/env.cpp
-+++ b/src/env.cpp
-@@ -63,7 +63,7 @@ Env::Env()
-       executionPlanDir(readEnv<std::string>("MSCCLPP_EXECUTION_PLAN_DIR", "")),
-       npkitDumpDir(readEnv<std::string>("MSCCLPP_NPKIT_DUMP_DIR", "")),
-       cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)),
--      ibGidIndex(readEnv<int>("MSCCLPP_IB_GID_INDEX", 0))  {}
-+      ibGidIndex(readEnv<int>("MSCCLPP_IB_GID_INDEX", -1))  {}
-
- std::shared_ptr<Env> env() {
-   static std::shared_ptr<Env> globalEnv = std::shared_ptr<Env>(new Env());
-diff --git a/src/ib.cc b/src/ib.cc
-index 6e53b55b..64bee944 100644
---- a/src/ib.cc
-+++ b/src/ib.cc
+diff --git src/ib.cc src/ib.cc
+index 542527e..64bee94 100644
+--- src/ib.cc
++++ src/ib.cc
 @@ -20,6 +20,8 @@
  #include "debug.h"
  #if defined(USE_IBVERBS)
@@ -391,21 +67,30 @@ index 6e53b55b..64bee944 100644
 +#include <arpa/inet.h>
 +#include <fcntl.h>
  #endif  // defined(USE_IBVERBS)
-
+ 
  #if !defined(__HIP_PLATFORM_AMD__)
-@@ -40,7 +42,7 @@ namespace mscclpp {
-
+@@ -40,6 +42,166 @@ namespace mscclpp {
+ 
  #if defined(USE_IBVERBS)
-
--MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) {
+ 
 +static std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) {
-   int count;
-   std::vector<std::string> activeDevices;
-   struct ibv_device** devices = IBVerbs::ibv_get_device_list(&count);
-@@ -58,6 +60,148 @@ MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDe
-   return activeDevices;
- }
-
++  int count;
++  std::vector<std::string> activeDevices;
++  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&count);
++  if(!devices) {
++    numActiveDevices = 0;
++    return activeDevices;
++  }
++  for (int i = 0; i < count; ++i) {
++    IbCtx ctx(devices[i]->name);
++    if(ctx.getAnyActivePort() < 0) continue;
++    activeDevices.push_back(devices[i]->name);
++  }
++  numActiveDevices = activeDevices.size();
++  IBVerbs::ibv_free_device_list(devices);
++  return activeDevices;
++}
++
 +static bool isConfiguredGid(union ibv_gid* gid)
 +{
 +  const struct in6_addr *a = (struct in6_addr *)gid->raw;
@@ -551,44 +236,80 @@ index 6e53b55b..64bee944 100644
  IbMr::IbMr(ibv_pd* pd, void* buff, std::size_t size) : buff(buff) {
    if (size == 0) {
      throw std::invalid_argument("invalid size: " + std::to_string(size));
-@@ -135,8 +279,9 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
+@@ -117,8 +279,9 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
    this->info.is_grh = (portAttr.flags & IBV_QPF_GRH_REQUIRED);
-
+ 
    if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND || this->info.is_grh) {
 +    this->info.gidIndex = (env()->ibGidIndex < 0) ? getGidIndex(ctx, port, portAttr.gid_tbl_len) : env()->ibGidIndex;
      union ibv_gid gid;
--    if (IBVerbs::ibv_query_gid(ctx, port, env()->ibGidIndex, &gid) != 0) {
+-    if (IBVerbs::ibv_query_gid(ctx, port, 0, &gid) != 0) {
 +    if (IBVerbs::ibv_query_gid(ctx, port, this->info.gidIndex, &gid) != 0) {
        std::stringstream err;
        err << "ibv_query_gid failed (errno " << errno << ")";
        throw mscclpp::IbError(err.str(), errno);
-@@ -182,7 +327,7 @@ void IbQp::rtr(const IbQpInfo& info) {
+@@ -164,7 +327,7 @@ void IbQp::rtr(const IbQpInfo& info) {
      qp_attr.ah_attr.grh.dgid.global.subnet_prefix = info.spn;
      qp_attr.ah_attr.grh.dgid.global.interface_id = info.iid;
      qp_attr.ah_attr.grh.flow_label = 0;
--    qp_attr.ah_attr.grh.sgid_index = env()->ibGidIndex;
+-    qp_attr.ah_attr.grh.sgid_index = 0;
 +    qp_attr.ah_attr.grh.sgid_index = this->info.gidIndex;
      qp_attr.ah_attr.grh.hop_limit = 255;
      qp_attr.ah_attr.grh.traffic_class = 0;
    } else {
-@@ -507,8 +652,6 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport) { return ""; }
-
- MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string&) { return Transport::Unknown; }
-
--MSCCLPP_API_CPP std::vector<std::string> getActiveIbDeviceNames(int& numActiveDevices) { *numDevices = 0; return std::vector<std::string>(); }
--
- #endif  // !defined(USE_IBVERBS)
-
- }  // namespace mscclpp
-diff --git a/src/include/ib.hpp b/src/include/ib.hpp
-index 643e9d3b..cca642f6 100644
---- a/src/include/ib.hpp
-+++ b/src/include/ib.hpp
+@@ -385,7 +548,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
+ 
+ MSCCLPP_API_CPP int getIBDeviceCount() {
+   int num;
+-  IBVerbs::ibv_get_device_list(&num);
++  auto const& dev = getActiveIbDeviceNames(num);
+   return num;
+ }
+ 
+@@ -442,20 +605,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
+   }
+ 
+   int num;
+-  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&num);
++  auto const& devices = getActiveIbDeviceNames(num);
+   if (ibTransportIndex >= num) {
+     std::stringstream ss;
+     ss << "IB transport out of range: " << ibTransportIndex << " >= " << num;
+     throw Error(ss.str(), ErrorCode::InvalidUsage);
+   }
+-  return devices[ibTransportIndex]->name;
++  return devices[ibTransportIndex];
+ }
+ 
+ MSCCLPP_API_CPP Transport getIBTransportByDeviceName(const std::string& ibDeviceName) {
+   int num;
+-  struct ibv_device** devices = IBVerbs::ibv_get_device_list(&num);
++  auto const& devices = getActiveIbDeviceNames(num);
+   for (int i = 0; i < num; ++i) {
+-    if (ibDeviceName == devices[i]->name) {
++    if (ibDeviceName == devices[i]) {
+       switch (i) {  // TODO: get rid of this ugly switch
+         case 0:
+           return Transport::IB0;
+diff --git src/include/ib.hpp src/include/ib.hpp
+index 4d85299..cca642f 100644
+--- src/include/ib.hpp
++++ src/include/ib.hpp
 @@ -54,6 +54,7 @@ struct IbQpInfo {
    int mtu;
    uint64_t iid;
    bool is_grh;
 +  uint8_t gidIndex;
  };
-
+ 
  enum class WsStatus {
+@@ -132,9 +133,9 @@ class IbCtx {
+ 
+   const std::string& getDevName() const { return this->devName; };
+ 
++  int getAnyActivePort() const;
+  private:
+   bool isPortUsable(int port) const;
+-  int getAnyActivePort() const;
+ 
+   const std::string devName;
+   ibv_context* ctx;

--- a/ext-src/roce-support.patch
+++ b/ext-src/roce-support.patch
@@ -57,10 +57,10 @@ index 625de0a..bcb847e 100644
    return globalEnv;
  }
 diff --git a/src/ib.cc b/src/ib.cc
-index 542527e..7da3708 100644
+index 542527e..36a34e8 100644
 --- a/src/ib.cc
 +++ b/src/ib.cc
-@@ -20,6 +20,8 @@
+@@ -20,26 +20,199 @@
  #include "debug.h"
  #if defined(USE_IBVERBS)
  #include "ibverbs_wrapper.hpp"
@@ -68,8 +68,71 @@ index 542527e..7da3708 100644
 +#include <fcntl.h>
  #endif  // defined(USE_IBVERBS)
  
- #if !defined(__HIP_PLATFORM_AMD__)
-@@ -40,6 +42,134 @@ namespace mscclpp {
+-#if !defined(__HIP_PLATFORM_AMD__)
++// Check if nvidia/amd_peermem kernel module is loaded
++static bool checkPeerMemLoaded() {
++#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
++  static int moduleLoaded = -1;
++  if (moduleLoaded == -1) {
++    // Check for `memory_peers` directory containing `amdkfd/version`
++    // This `memory_peers` directory is created by NIC-GPU driver interaction
++    // On Linux kernel 5.15.0 (e.g. Ubuntu 22.04), `memory_peers` is created under `/sys/kernel/mm/`
++    // However, on newer kernels like Ubuntu 24.04.1 (Linux kernel 6.8.0) or Ubuntu 22.04.4 HWE (Linux kernel 6.5.0),
++    // this `memory_peers` directory is either not created (go to else-if condition)
++    // or created under a different path like `/sys/kernel/` or `/sys/` (depending on your ib_peer_mem module)
++    std::vector<std::string> memory_peers_paths = {"/sys/kernel/mm/memory_peers/amdkfd/version",
++                                                   "/sys/kernel/memory_peers/amdkfd/version",
++                                                   "/sys/memory_peers/amdkfd/version"};
++
++    moduleLoaded = 0;
++    for (const auto& path : memory_peers_paths) {
++      if (access(path.c_str(), F_OK) == 0) {
++        moduleLoaded = 1;
++        INFO(MSCCLPP_NET,"Found %s", path.c_str());
++        break;
++      }
++    }
+ 
+-// Check if nvidia_peermem kernel module is loaded
+-static bool checkNvPeerMemLoaded() {
++    if (moduleLoaded == 0) {
++      // Check for `ib_register_peer_memory_client` symbol in `/proc/kallsyms`
++      // if your system uses native OS ib_peer module
++      char buf[256];
++      FILE *fp = NULL;
++      fp = fopen("/proc/kallsyms", "r");
++
++      if (fp == NULL) {
++        INFO(MSCCLPP_NET,"Could not open /proc/kallsyms");
++      } else {
++        while (fgets(buf, sizeof(buf), fp) != NULL) {
++          if (strstr(buf, "t ib_register_peer_memory_client") != NULL ||
++              strstr(buf, "T ib_register_peer_memory_client") != NULL) {
++            moduleLoaded = 1;
++            INFO(MSCCLPP_NET,"Found ib_register_peer_memory_client in /proc/kallsyms");
++            break;
++          }
++        }
++      }
++    }
++  }
++  return (moduleLoaded == 1);
++#else
+   std::ifstream file("/proc/modules");
+   std::string line;
+   while (std::getline(file, line)) {
+-    if (line.find("nvidia_peermem") != std::string::npos) return true;
++    if (line.find("nvidia_peermem") != std::string::npos) {
++      return true;
++    }
+   }
+   return false;
++#endif
+ }
+-
+-#endif  // !defined(__HIP_PLATFORM_AMD__)
+-
+ namespace mscclpp {
  
  #if defined(USE_IBVERBS)
  
@@ -204,7 +267,16 @@ index 542527e..7da3708 100644
  IbMr::IbMr(ibv_pd* pd, void* buff, std::size_t size) : buff(buff) {
    if (size == 0) {
      throw std::invalid_argument("invalid size: " + std::to_string(size));
-@@ -117,8 +247,9 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
+@@ -106,7 +279,7 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
+   struct ibv_port_attr portAttr;
+   if (IBVerbs::ibv_query_port_w(ctx, port, &portAttr) != 0) {
+     std::stringstream err;
+-    err << "ibv_query_port failed (errno " << errno << ")";
++    err << "ibv_query_port failed (errno " << errno << ", port << " << port << ")";
+     throw mscclpp::IbError(err.str(), errno);
+   }
+   this->info.lid = portAttr.lid;
+@@ -117,8 +290,9 @@ IbQp::IbQp(ibv_context* ctx, ibv_pd* pd, int port, int maxCqSize, int maxCqPollN
    this->info.is_grh = (portAttr.flags & IBV_QPF_GRH_REQUIRED);
  
    if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND || this->info.is_grh) {
@@ -215,7 +287,7 @@ index 542527e..7da3708 100644
        std::stringstream err;
        err << "ibv_query_gid failed (errno " << errno << ")";
        throw mscclpp::IbError(err.str(), errno);
-@@ -164,7 +295,7 @@ void IbQp::rtr(const IbQpInfo& info) {
+@@ -164,7 +338,7 @@ void IbQp::rtr(const IbQpInfo& info) {
      qp_attr.ah_attr.grh.dgid.global.subnet_prefix = info.spn;
      qp_attr.ah_attr.grh.dgid.global.interface_id = info.iid;
      qp_attr.ah_attr.grh.flow_label = 0;
@@ -224,7 +296,7 @@ index 542527e..7da3708 100644
      qp_attr.ah_attr.grh.hop_limit = 255;
      qp_attr.ah_attr.grh.traffic_class = 0;
    } else {
-@@ -290,7 +421,19 @@ void IbQp::postSend() {
+@@ -290,7 +464,19 @@ void IbQp::postSend() {
  int IbQp::pollCq() {
    int wcNum = IBVerbs::ibv_poll_cq(this->cq, this->maxCqPollNum, this->wcs->data());
    if (wcNum > 0) {
@@ -245,7 +317,22 @@ index 542527e..7da3708 100644
    }
    return wcNum;
  }
-@@ -385,7 +528,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
+@@ -300,11 +486,10 @@ int IbQp::getWcStatus(int idx) const { return (*this->wcs)[idx].status; }
+ int IbQp::getNumCqItems() const { return this->numSignaledPostedItems; }
+ 
+ IbCtx::IbCtx(const std::string& devName) : devName(devName) {
+-#if !defined(__HIP_PLATFORM_AMD__)
+-  if (!checkNvPeerMemLoaded()) {
+-    throw mscclpp::Error("nvidia_peermem kernel module is not loaded", ErrorCode::InternalError);
++  if (!checkPeerMemLoaded()) {
++    throw mscclpp::Error("nvidia/amd_peermem kernel module is not loaded", ErrorCode::InternalError);
+   }
+-#endif  // !defined(__HIP_PLATFORM_AMD__)
++
+   int num;
+   struct ibv_device** devices = IBVerbs::ibv_get_device_list(&num);
+   for (int i = 0; i < num; ++i) {
+@@ -385,7 +570,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
  
  MSCCLPP_API_CPP int getIBDeviceCount() {
    int num;
@@ -254,7 +341,7 @@ index 542527e..7da3708 100644
    return num;
  }
  
-@@ -442,20 +585,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
+@@ -442,20 +627,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
    }
  
    int num;

--- a/ext-src/roce-support.patch
+++ b/ext-src/roce-support.patch
@@ -1,7 +1,7 @@
-diff --git include/mscclpp/env.hpp include/mscclpp/env.hpp
+diff --git a/include/mscclpp/env.hpp b/include/mscclpp/env.hpp
 index 6708628..3f96b31 100644
---- include/mscclpp/env.hpp
-+++ include/mscclpp/env.hpp
+--- a/include/mscclpp/env.hpp
++++ b/include/mscclpp/env.hpp
 @@ -30,6 +30,7 @@ class Env {
    const std::string executionPlanDir;
    const std::string npkitDumpDir;
@@ -10,10 +10,10 @@ index 6708628..3f96b31 100644
  
   private:
    Env();
-diff --git src/bootstrap/socket.cc src/bootstrap/socket.cc
+diff --git a/src/bootstrap/socket.cc b/src/bootstrap/socket.cc
 index 8c012c2..5dc43b6 100644
---- src/bootstrap/socket.cc
-+++ src/bootstrap/socket.cc
+--- a/src/bootstrap/socket.cc
++++ b/src/bootstrap/socket.cc
 @@ -327,6 +327,8 @@ int FindInterfaces(char* ifNames, union SocketAddress* ifAddrs, int ifNameMaxSiz
          nIfs = FindInterfaceMatchSubnet(ifNames, ifAddrs, &idAddr, ifNameMaxSize, maxIfs);
        }
@@ -23,10 +23,10 @@ index 8c012c2..5dc43b6 100644
      // Then look for anything else (but not docker or lo)
      if (nIfs == 0) nIfs = findInterfaces("^docker,lo", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
      // Finally look for docker, then lo.
-diff --git src/env.cpp src/env.cpp
+diff --git a/src/env.cpp b/src/env.cpp
 index 625de0a..bcb847e 100644
---- src/env.cpp
-+++ src/env.cpp
+--- a/src/env.cpp
++++ b/src/env.cpp
 @@ -19,8 +19,9 @@ T readEnv(const std::string &envName, const T &defaultValue) {
      return atoi(envCstr);
    } else if constexpr (std::is_same_v<T, bool>) {
@@ -56,10 +56,10 @@ index 625de0a..bcb847e 100644
    }
    return globalEnv;
  }
-diff --git src/ib.cc src/ib.cc
+diff --git a/src/ib.cc b/src/ib.cc
 index 542527e..64bee94 100644
---- src/ib.cc
-+++ src/ib.cc
+--- a/src/ib.cc
++++ b/src/ib.cc
 @@ -20,6 +20,8 @@
  #include "debug.h"
  #if defined(USE_IBVERBS)
@@ -290,10 +290,10 @@ index 542527e..64bee94 100644
        switch (i) {  // TODO: get rid of this ugly switch
          case 0:
            return Transport::IB0;
-diff --git src/include/ib.hpp src/include/ib.hpp
+diff --git a/src/include/ib.hpp b/src/include/ib.hpp
 index 4d85299..cca642f 100644
---- src/include/ib.hpp
-+++ src/include/ib.hpp
+--- a/src/include/ib.hpp
++++ b/src/include/ib.hpp
 @@ -54,6 +54,7 @@ struct IbQpInfo {
    int mtu;
    uint64_t iid;

--- a/ext-src/roce-support.patch
+++ b/ext-src/roce-support.patch
@@ -57,7 +57,7 @@ index 625de0a..bcb847e 100644
    return globalEnv;
  }
 diff --git a/src/ib.cc b/src/ib.cc
-index 542527e..7cddc55 100644
+index 542527e..7da3708 100644
 --- a/src/ib.cc
 +++ b/src/ib.cc
 @@ -20,6 +20,8 @@
@@ -224,7 +224,28 @@ index 542527e..7cddc55 100644
      qp_attr.ah_attr.grh.hop_limit = 255;
      qp_attr.ah_attr.grh.traffic_class = 0;
    } else {
-@@ -385,7 +516,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
+@@ -290,7 +421,19 @@ void IbQp::postSend() {
+ int IbQp::pollCq() {
+   int wcNum = IBVerbs::ibv_poll_cq(this->cq, this->maxCqPollNum, this->wcs->data());
+   if (wcNum > 0) {
+-    this->numSignaledPostedItems -= wcNum;
++    for (int i = 0; i < wcNum; ++i) {
++      if ((*this->wcs)[i].status != IBV_WC_SUCCESS) {
++        std::stringstream err;
++        err << "Work completion at index " << i << " failed with status " << (*this->wcs)[i].status
++            << " (" << IBVerbs::ibv_wc_status_str((*this->wcs)[i].status) << ")";
++        throw mscclpp::IbError(err.str(), (*this->wcs)[i].status);
++      }
++      this->numSignaledPostedItems--;
++    }
++  } else if (wcNum < 0) {
++    std::stringstream err;
++    err << "ibv_poll_cq failed with negative completion";
++    throw mscclpp::IbError(err.str(), errno);
+   }
+   return wcNum;
+ }
+@@ -385,7 +528,7 @@ const IbMr* IbCtx::registerMr(void* buff, std::size_t size) {
  
  MSCCLPP_API_CPP int getIBDeviceCount() {
    int num;
@@ -233,7 +254,7 @@ index 542527e..7cddc55 100644
    return num;
  }
  
-@@ -442,20 +573,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
+@@ -442,20 +585,20 @@ MSCCLPP_API_CPP std::string getIBDeviceName(Transport ibTransport) {
    }
  
    int num;
@@ -304,3 +325,53 @@ index 4d85299..3018d54 100644
  }  // namespace mscclpp
  
  #endif  // MSCCLPP_IB_HPP_
+diff --git a/src/include/ibverbs_wrapper.hpp b/src/include/ibverbs_wrapper.hpp
+index fe67268..76f948a 100644
+--- a/src/include/ibverbs_wrapper.hpp
++++ b/src/include/ibverbs_wrapper.hpp
+@@ -40,11 +40,12 @@ struct IBVerbs {
+     ibv_destroy_qp_lib = (ibv_destroy_qp_t)dlsym(handle, "ibv_destroy_qp");
+     ibv_query_port_lib = (ibv_query_port_t)dlsym(handle, "ibv_query_port");
+     ibv_reg_mr_iova2_lib = (ibv_reg_mr_iova2_t)dlsym(handle, "ibv_reg_mr_iova2");
++    ibv_wc_status_str_lib = (ibv_wc_status_str_t)dlsym(handle, "ibv_wc_status_str");
+ 
+     if (!ibv_get_device_list_lib || !ibv_free_device_list_lib || !ibv_alloc_pd_lib || !ibv_dealloc_pd_lib ||
+         !ibv_open_device_lib || !ibv_close_device_lib || !ibv_query_device_lib || !ibv_create_cq_lib ||
+         !ibv_create_qp_lib || !ibv_destroy_cq_lib || !ibv_reg_mr_lib || !ibv_dereg_mr_lib || !ibv_query_gid_lib ||
+-        !ibv_reg_mr_iova2_lib || !ibv_modify_qp_lib || !ibv_destroy_qp_lib || !ibv_query_port_lib) {
++        !ibv_reg_mr_iova2_lib || !ibv_modify_qp_lib || !ibv_destroy_qp_lib || !ibv_query_port_lib || !ibv_wc_status_str_lib) {
+       throw mscclpp::IbError("Failed to load one or more function in the ibibverbs library: " + std::string(dlerror()),
+                              errno);
+       dlclose(handle);
+@@ -214,6 +215,15 @@ struct IBVerbs {
+     return nullptr;
+   }
+ 
++  static const char* ibv_wc_status_str(enum ibv_wc_status status) {
++    if (!initialized) initialize();
++    if (ibv_wc_status_str_lib) {
++      return ibv_wc_status_str_lib(status);
++    }
++    return nullptr;
++  }
++
++
+   // Static method to clean up
+   static void cleanup() {
+     if (handle) {
+@@ -245,6 +255,7 @@ struct IBVerbs {
+   typedef int (*ibv_query_port_t)(struct ibv_context*, uint8_t, struct ibv_port_attr*);
+   typedef struct ibv_mr* (*ibv_reg_mr_iova2_t)(struct ibv_pd* pd, void* addr, size_t length, uint64_t iova,
+                                                unsigned int access);
++  typedef const char* (*ibv_wc_status_str_t)(enum ibv_wc_status);
+ 
+   static inline ibv_get_device_list_t ibv_get_device_list_lib;
+   static inline ibv_free_device_list_t ibv_free_device_list_lib = nullptr;
+@@ -263,6 +274,7 @@ struct IBVerbs {
+   static inline ibv_destroy_qp_t ibv_destroy_qp_lib = nullptr;
+   static inline ibv_query_port_t ibv_query_port_lib = nullptr;
+   static inline ibv_reg_mr_iova2_t ibv_reg_mr_iova2_lib = nullptr;
++  static inline ibv_wc_status_str_t ibv_wc_status_str_lib = nullptr;
+ 
+   static inline bool initialized = false;
+ };

--- a/ext-src/roce-support.patch
+++ b/ext-src/roce-support.patch
@@ -1,12 +1,13 @@
 diff --git a/include/mscclpp/env.hpp b/include/mscclpp/env.hpp
-index 6708628..3f96b31 100644
+index 6708628..3131b9f 100644
 --- a/include/mscclpp/env.hpp
 +++ b/include/mscclpp/env.hpp
-@@ -30,6 +30,7 @@ class Env {
+@@ -30,6 +30,8 @@ class Env {
    const std::string executionPlanDir;
    const std::string npkitDumpDir;
    const bool cudaIpcUseDefaultStream;
 +  const int ibGidIndex;
++  const int ibTrafficClass;
  
   private:
    Env();
@@ -24,7 +25,7 @@ index 8c012c2..5dc43b6 100644
      if (nIfs == 0) nIfs = findInterfaces("^docker,lo", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs);
      // Finally look for docker, then lo.
 diff --git a/src/env.cpp b/src/env.cpp
-index 625de0a..bcb847e 100644
+index 625de0a..d42de37 100644
 --- a/src/env.cpp
 +++ b/src/env.cpp
 @@ -19,8 +19,9 @@ T readEnv(const std::string &envName, const T &defaultValue) {
@@ -38,26 +39,28 @@ index 625de0a..bcb847e 100644
  }
  
  template <typename T>
-@@ -61,7 +62,8 @@ Env::Env()
+@@ -61,7 +62,9 @@ Env::Env()
        commId(readEnv<std::string>("MSCCLPP_COMM_ID", "")),
        executionPlanDir(readEnv<std::string>("MSCCLPP_EXECUTION_PLAN_DIR", "")),
        npkitDumpDir(readEnv<std::string>("MSCCLPP_NPKIT_DUMP_DIR", "")),
 -      cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)) {}
 +      cudaIpcUseDefaultStream(readEnv<bool>("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", false)),
-+      ibGidIndex(readEnv<int>("MSCCLPP_IB_GID_INDEX", -1))  {}
++      ibGidIndex(readEnv<int>("MSCCLPP_IB_GID_INDEX", -1)),
++      ibTrafficClass(readEnv<int>("MSCCLPP_IB_TC", 0)) {}
  
  std::shared_ptr<Env> env() {
    static std::shared_ptr<Env> globalEnv = std::shared_ptr<Env>(new Env());
-@@ -80,6 +82,7 @@ std::shared_ptr<Env> env() {
+@@ -80,6 +83,8 @@ std::shared_ptr<Env> env() {
      logEnv("MSCCLPP_EXECUTION_PLAN_DIR", globalEnv->executionPlanDir);
      logEnv("MSCCLPP_NPKIT_DUMP_DIR", globalEnv->npkitDumpDir);
      logEnv("MSCCLPP_CUDAIPC_USE_DEFAULT_STREAM", globalEnv->cudaIpcUseDefaultStream);
 +    logEnv("MSCCLPP_IB_GID_INDEX", globalEnv->ibGidIndex);
++    logEnv("MSCCLPP_IB_TC", globalEnv->ibTrafficClass);
    }
    return globalEnv;
  }
 diff --git a/src/ib.cc b/src/ib.cc
-index 542527e..7c939df 100644
+index 542527e..7ebfa3f 100644
 --- a/src/ib.cc
 +++ b/src/ib.cc
 @@ -20,26 +20,200 @@
@@ -301,15 +304,18 @@ index 542527e..7c939df 100644
        std::stringstream err;
        err << "ibv_query_gid failed (errno " << errno << ")";
        throw mscclpp::IbError(err.str(), errno);
-@@ -164,7 +333,7 @@ void IbQp::rtr(const IbQpInfo& info) {
+@@ -164,9 +333,9 @@ void IbQp::rtr(const IbQpInfo& info) {
      qp_attr.ah_attr.grh.dgid.global.subnet_prefix = info.spn;
      qp_attr.ah_attr.grh.dgid.global.interface_id = info.iid;
      qp_attr.ah_attr.grh.flow_label = 0;
 -    qp_attr.ah_attr.grh.sgid_index = 0;
 +    qp_attr.ah_attr.grh.sgid_index = this->info.gidIndex;
      qp_attr.ah_attr.grh.hop_limit = 255;
-     qp_attr.ah_attr.grh.traffic_class = 0;
+-    qp_attr.ah_attr.grh.traffic_class = 0;
++    qp_attr.ah_attr.grh.traffic_class = env()->ibTrafficClass;
    } else {
+     qp_attr.ah_attr.is_global = 0;
+   }
 @@ -290,7 +459,19 @@ void IbQp::postSend() {
  int IbQp::pollCq() {
    int wcNum = IBVerbs::ibv_poll_cq(this->cq, this->maxCqPollNum, this->wcs->data());


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal"_

**What were the changes?**  
_Support RoCE for MSCCLPP and fix several issues_

**Why were the changes made?**  
_MSCCLPP did not work with RoCE NICs. Additionally, accidental issues that broke both IB and RoCE were fixed_

**How was the outcome achieved?**  

- Auto-detection algorithm for GID index
- `MSCCLPP_IB_GID_INDEX` for user-level entry of GID index 
- Avoid considering NICs that have no active ports (observed issue on local clusters at least)
- Support bootstrapping for Ethernet interfaces with the prefix "en". Without this change, bootstrapping will fail on systems with no IB front NICs (observed issue on local clusters at least)
- Check the successful completion status of WCs. Otherwise, data errors can occur despite receiving a positive number of work completions 
- Add hooks for ibv_wc_status_str through the established dynamic loader
- Added AMD peer mem check
- Fix readEnv function which broke gcc 11.4.0 preprocessing when integer specialization is used 
- Avoid repeated logic for validating ibv_port
- Accept user-specified TC for RoCE
- Optionally allow using link-local GID (useful for INTRANET)

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
