### PR TITLE
fix the size of the recv buffer in AllGather UBR test

### DIFF
--- a/test/AllGatherTests.cpp
+++ b/test/AllGatherTests.cpp
@@ -127,7 +127,7 @@ namespace RcclUnitTesting
     const int nranks = 8;
     size_t count = 2048;
     std::vector<int> sendBuff(count, 0);
-    std::vector<int> recvBuff(count, 0);
+    std::vector<int> recvBuff(nranks*count, 0);
     std::vector<int> expected(nranks*count, 0);
 
     for (int i = 0; i < count; ++i){
@@ -146,7 +146,7 @@ namespace RcclUnitTesting
     const int nranks = 8;
     size_t count = 2048;
     std::vector<int> sendBuff(count, 0);
-    std::vector<int> recvBuff(count, 0);
+    std::vector<int> recvBuff(nranks*count, 0);
     std::vector<int> expected(nranks*count, 0);
     const bool use_managed_mem = true;
     for (int i = 0; i < count; ++i){


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Fixed AllGather.UserBufferRegistration and AllGather.ManagedMemUserBufferRegistration tests

**Why were the changes made?**  
Error in unit test

**How was the outcome achieved?**  
Fixed the receive buffer size

**Additional Documentation:**  

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
