### PR TITLE
[BUILD] MSCCLPP: Fix OS check for CentOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,7 @@ if (ENABLE_MSCCLPP AND ROCM_VERSION VERSION_LESS "60200")
 endif()
 # cmake_host_system_information(RESULT HOST_OS_ID QUERY DISTRIB_ID) ## Requires cmake 3.22
 execute_process(
-  COMMAND bash -c "grep '^ID=' /etc/os-release | cut -d'=' -f2"
+  COMMAND bash -c "grep '^ID=' /etc/os-release | cut -d'=' -f2 | cut -d'\"' -f2"
   OUTPUT_VARIABLE HOST_OS_ID
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )


### PR DESCRIPTION
## Details

**Work item:** Internal

**What were the changes?**  
Fix OS check for enabling MSCCLPP in RCCL on CentOS

**Why were the changes made?**  
RCCL supports MSCCLPP only on Ubuntu and CentOS. However, due to a difference in `/etc/os-release` format, the OS check for enabling MSCCLPP in RCCL was not working on CentOS

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
