### PR TITLE
Remove unused variable from rccl_float8.h

### DIFF
--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -73,7 +73,7 @@ namespace rocblas_hip_f8_impl
         else
             x = reinterpret_cast<uint16_t&>(_x);
 
-        uint32_t y, head, mantissa;
+        uint32_t head, mantissa;
         int      exponent, bias;
         uint32_t sign;
 


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** N/A

**What were the changes?**  
Removes an unused variable.

**Why were the changes made?**  
Enabling `-Wunused-variable` internally for our builds. This code violates that warning. (It'd be create if RCCL could enable the flag also.)

**How was the outcome achieved?**  
Deleted the variable :-)

**Additional Documentation:**  
N/A

## Approval Checklist
___Do not approve until these items are satisfied.___
- [X] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
