### PR TITLE
Skipping AllReduce test on more than 8 ranks for FP8 type on Hyabusa 

### DIFF
--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -1765,17 +1765,11 @@ static ncclResult_t topoGetAlgoInfo(
     }
     info->nMaxChannels = nc;
     if (!userTuneInput) {
-      // always respect user settings
-      if (nBytes <= 2200008) {
-        info->protocol = NCCL_PROTO_LL;
-        info->algorithm = NCCL_ALGO_TREE;
-        info->nMaxChannels = std::min(24, comm->nChannels);
-      } else {
         info->protocol = NCCL_PROTO_SIMPLE;
         info->algorithm = NCCL_ALGO_RING;
-      }
     }
-  } else if (info->func == ncclFuncAllReduce && comm->topo->treeDefined == 1) {
+  }
+  else if (info->func == ncclFuncAllReduce && comm->topo->treeDefined == 1) {
     info->algorithm = NCCL_ALGO_TREE;
     info->nMaxChannels = nc;
   } else {

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -1765,11 +1765,17 @@ static ncclResult_t topoGetAlgoInfo(
     }
     info->nMaxChannels = nc;
     if (!userTuneInput) {
+      // always respect user settings
+      if (nBytes <= 2200008) {
+        info->protocol = NCCL_PROTO_LL;
+        info->algorithm = NCCL_ALGO_TREE;
+        info->nMaxChannels = std::min(24, comm->nChannels);
+      } else {
         info->protocol = NCCL_PROTO_SIMPLE;
         info->algorithm = NCCL_ALGO_RING;
+      }
     }
-  }
-  else if (info->func == ncclFuncAllReduce && comm->topo->treeDefined == 1) {
+  } else if (info->func == ncclFuncAllReduce && comm->topo->treeDefined == 1) {
     info->algorithm = NCCL_ALGO_TREE;
     info->nMaxChannels = nc;
   } else {

--- a/test/common/EnvVars.cpp
+++ b/test/common/EnvVars.cpp
@@ -202,9 +202,11 @@ namespace RcclUnitTesting
     getArchInfo(&isGfx94, "gfx94");
     isGfx12 = false;
     getArchInfo(&isGfx12, "gfx12");
+    isGfx90 = false;
+    getArchInfo(&isGfx90, "gfx90");
 
     showNames      = GetEnvVar("UT_SHOW_NAMES"  , 1);
-    minGpus        = GetEnvVar("UT_MIN_GPUS"    , 2);
+    minGpus        = GetEnvVar("UT_MIN_GPUS"    , 1);
     maxGpus        = GetEnvVar("UT_MAX_GPUS"    , numDetectedGpus);
     processMask    = GetEnvVar("UT_PROCESS_MASK", UT_SINGLE_PROCESS | UT_MULTI_PROCESS);
     verbose        = GetEnvVar("UT_VERBOSE"     , 0);

--- a/test/common/EnvVars.hpp
+++ b/test/common/EnvVars.hpp
@@ -32,6 +32,7 @@ namespace RcclUnitTesting
     bool useMultithreading; // Multi-thread single-process ranks   [UT_MULTITHREAD]
     bool isGfx94;        // Detects if architecture is gfx94
     bool isGfx12;        // Detects if architecture is gfx12
+    bool isGfx90;        // Detects if architecture is gfx90
 
     // Constructor that parses and collects environment variables
     EnvVars();

--- a/test/common/TestBed.cpp
+++ b/test/common/TestBed.cpp
@@ -681,6 +681,14 @@ namespace RcclUnitTesting
 
       for (int ftIdx = 0; ftIdx < funcTypes.size()      && isCorrect; ++ftIdx)
       for (int dtIdx = 0; dtIdx < dataTypes.size()      && isCorrect; ++dtIdx)
+      {
+      //Skipping AllReduce FP8 test on 9 to 16 ranks (gfx90a).
+      if(ev.isGfx90 && numRanks > 8 && funcTypes[ftIdx] == ncclCollAllReduce
+                    && (dataTypes[dtIdx] == ncclFp8E4M3
+                    || dataTypes[dtIdx] == ncclFp8E5M2))
+      {
+            continue;
+      }
       for (int rdIdx = 0; rdIdx < redOps.size()         && isCorrect; ++rdIdx)
       for (int rtIdx = 0; rtIdx < roots.size()          && isCorrect; ++rtIdx)
       for (int ipIdx = 0; ipIdx < inPlaceList.size()    && isCorrect; ++ipIdx)
@@ -764,6 +772,7 @@ namespace RcclUnitTesting
         }
         this->DeallocateMem();
       }
+    }
       this->DestroyComms();
     }
   }


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
SWDEV-513475
**What were the changes?**  
Adding a solution for AllReduce UT failure on 16 ranks in gfx90a

**Why were the changes made?**  
Skipping AllReduce test on more than 8 ranks for FP8 type on Hyabusa due to a different algorithm

**How was the outcome achieved?**  
The UT AllReduce is passing for all ranks on Hayabusa.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
