### PR TITLE
RCCL deadlock discussion (was: increase NCCL_STEPS to match WARPSIZE/4)

### DIFF
--- a/src/device/prims_simple.h
+++ b/src/device/prims_simple.h
@@ -679,9 +679,10 @@ private:
     this->fan = Fan(nrecv, nsend);
 
     constexpr int ThreadPerSync =
-      MaxSend >= 16 || MaxRecv >= 16 ? 32 : // NVLS may have an arity > 8. In that case increase the size of the groups
-      MaxSend >= 8 || MaxRecv >= 8 ? 16 :
-      8; // Allows for all roles (WaitRecv/WaitSend/PostRecv/PostSend) within a single warp
+      MaxSend >= 16 || MaxRecv >= 16 ? 64 : // NVLS may have an arity > 8. In that case increase the size of the groups
+      MaxSend >= 8 || MaxRecv >= 8 ? 32 :
+      16; // Allows for all roles (WaitRecv/WaitSend/PostRecv/PostSend) within a single warp
+
     static_assert(MaxSend <= ThreadPerSync && MaxRecv <= ThreadPerSync, "Not enough threads to cover all peers");
 
     index = -1;

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -30,7 +30,7 @@ extern const char* ncclProtoStr[NCCL_NUM_PROTOCOLS];
 extern const char* funcNames[FUNC_INDEX_TOTAL];
 
 #define NCCL_MAX_OPS 2048
-#define NCCL_STEPS 8
+#define NCCL_STEPS 16
 
 #ifdef __CUDA_ARCH__
   #define NCCL_CUDA_ARCH __CUDA_ARCH__
@@ -82,7 +82,7 @@ union ncclLLFifoLine {
 #define NCCL_LL_FLAG_MAX   0x100
 #define NCCL_LL_FLAG(a) ((uint32_t)((a) % NCCL_LL_FLAG_MAX))
 #else
-#define NCCL_LL_CLEAN_MASK 0x7ffffff8
+#define NCCL_LL_CLEAN_MASK 0x7ffffff0
 #define NCCL_LL_FLAG(a) ((uint32_t)(a))
 #endif
 // Make sure the clean mask will last for at least NCCL_NSTEPS


### PR DESCRIPTION
## Details

**Work item:** GH issue pending

**What were the changes?**  
Increase the pipeline size (NCCL_STEPS) from 8 to 16 to maintain correct synchronization behavior

**Why were the changes made?**  
On Frontier at OLCF with 8 x MI250X nodes, RCCL sporadically stalls, especially when executed on many (>~ 128) nodes, or when using the libfabrics plugin (aws-ofi-rccl). The proposed change adjusts the pipeline width in the 'simple' communication protocol to be compatible with the larger warp (wavefront) size on AMD, which is 64, compared to 32 on NVIDIA hardware.

**How was the outcome achieved?**  
A debug trace with roc-gdb demonstrated that under stall conditions and during a NCCL broadcast, some threads on the first rank in the ring (GPU0) are hanging inside a busy wait loop  (`waitPeer`) https://github.com/ROCm/rccl/blob/4237caad6934872f441212a346007cc063981d0e/src/device/prims_simple.h#L118-L127

A closer inspection revealed that GPU 0 was eight steps (`NCCL_STEPS=8`) ahead of GPU1 and waiting for it to be ready for itself to send, while GPU 1 was waiting on GPU 0 to receive, i.e. the two GPUs were found in a circular deadlock inside `waitPeer`, which should not be allowed by design. However, to ensure asynchronous progress (i.e., GPU 1 sending and receiving at the same time), the original NCCL design uses warp level synchronization and a FIFO pipeline width that matches the maximum number (8) of progress groups of four threads each (`waitRecv`, `waitSend`, `postRecv`, and `postSend`) that fit into a warp. If more than this number of groups fits into a warp, the warp-level synchronization will stall asynchronous progress made by another pipeline. By increasing `NCCL_STEPS` to 16, this guarantees that one wave front will exactly fit one pipeline.

**Additional Documentation:**  
It may be necessary to assess the performance implications of this patch and re-tune collective parameters.

Regarding reproducer:
On Frontier, the stalling behavior is also modulated by the libfabrics version. I had the most "luck" with libfabric 1.20.1 w/ CXI provider, rocm 6.2.4, and aws-ofi-rccl commit 17d41cbf5618536c4b1076d29748416ab307040f
I have a local reproducer code I shared with AMD developers, and which uses jax, but it is not yet minimal.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
