### PR TITLE
Address regression for ReduceScatter medium message size

### DIFF
--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -372,10 +372,14 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
 
         // Various model refinements
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-        if (nNodes <= 2)
-          busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[0][a][p];
-        else
-          busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[1][a][p];
+        if(coll == ncclFuncReduceScatter && p == NCCL_PROTO_LL && nNodes >=2 && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx94"))) {
+          busBw *= 0.28;
+        } else {
+          if (nNodes <= 2)
+            busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[0][a][p];
+          else
+            busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[1][a][p];
+        }
         if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL && (coll == ncclFuncBroadcast || coll == ncclFuncReduce) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx94") || IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) && comm->topo->nodes[GPU].count == comm->topo->nRanks) { busBw = busBw * 1.65; }
 #else
         if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL) { busBw = std::min(llMaxBw, busBw * .5); }

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -372,14 +372,13 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
 
         // Various model refinements
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-        if(coll == ncclFuncReduceScatter && p == NCCL_PROTO_LL && nNodes >=2 && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx94"))) {
-          busBw *= 0.28;
-        } else {
-          if (nNodes <= 2)
-            busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[0][a][p];
-          else
-            busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[1][a][p];
-        }
+        if (nNodes <= 2)
+          busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[0][a][p];
+        else
+          busBw *= rcclTuningModel[comm->topo->tuning].bwRatio[1][a][p];
+
+        if(coll == ncclFuncReduceScatter && p == NCCL_PROTO_LL && nNodes >=2 && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx94")))
+          busBw *= 3.5;
         if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL && (coll == ncclFuncBroadcast || coll == ncclFuncReduce) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx94") || IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) && comm->topo->nodes[GPU].count == comm->topo->nRanks) { busBw = busBw * 1.65; }
 #else
         if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL) { busBw = std::min(llMaxBw, busBw * .5); }


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_Change bw ratio for reduce_scatter LL protocol and gfx94**._

**Why were the changes made?**  
_Regression due to premature selection of Simple protocol_

**How was the outcome achieved?**  
_Tuning the bwRatio and observing the impact on computed latency._

**Additional Documentation:**  
_This is tested up to 32 GPUs _

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
