### PR TITLE
Multi-node reduce_scatter improved auto-selection for LL and LL128 on gfx942

### DIFF
--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -1712,8 +1712,14 @@ static ncclResult_t topoGetAlgoInfo(
     time = backupTime;
   }
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  if(comm->nNodes >= 2 && info->func == ncclFuncReduceScatter && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942")) {
-    // Keep it SIMPLE unless otherwise required
+  // Honor user input for protocl choice
+  static int userProtocolInput = -2;
+  if (userProtocolInput == -2) {
+    const char *protoStr = getenv("NCCL_PROTO");
+    userProtocolInput = !protoStr ? 0 : 1;
+  }
+  if(!userProtocolInput && comm->nNodes >= 2 && info->func == ncclFuncReduceScatter && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942")) {
+    // Keep it simple unless otherwise required
     info->protocol = NCCL_PROTO_SIMPLE;
     // Normalize the comparison to sizePerRank as this is essentially what matters in determining protocl choice
     size_t sizePerRank = nBytes / comm->nRanks;

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -887,7 +887,7 @@ static ncclResult_t addP2pToPlan(
         connIndex[dir] = NCCL_CONN_IDX_P2P_NET;
     }
   }
-  
+
   if (!selfSend) {
     for (int part=0; part < nChannelsMax; part++) {
       int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, part, nChannelsMax, comm->nNodes);
@@ -1670,6 +1670,14 @@ static ncclResult_t updateCollCostTable(
   return ncclSuccess;
 }
 
+// The following parameters are based on the observation that LL and LL128
+// performance is determined by how much data goes out of a GPU
+// TODO: these numbers can be part of topo detection.
+RCCL_PARAM(RsLLMinSizePerRank,    "REDUCE_SCATTER_LL_MIN_SIZE_PER_RANK", 0);
+RCCL_PARAM(RsLLMaxSizePerRank,    "REDUCE_SCATTER_LL_MAX_SIZE_PER_RANK", 655360);
+RCCL_PARAM(RsLL128MinSizePerRank, "REDUCE_SCATTER_LL128_MIN_SIZE_PER_RANK", 131072);
+RCCL_PARAM(RsLL128MaxSizePerRank, "REDUCE_SCATTER_LL128_MAX_SIZE_PER_RANK", 3211264);
+
 static ncclResult_t topoGetAlgoInfo(
     struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes,
     float** collCostTable, int backupAlgo, int backupProto, float backupTime, ncclSimInfo_t* simInfo
@@ -1703,6 +1711,29 @@ static ncclResult_t topoGetAlgoInfo(
     info->protocol = backupProto;
     time = backupTime;
   }
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  if(comm->nNodes >= 2 && info->func == ncclFuncReduceScatter && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942")) {
+    // Keep it SIMPLE unless otherwise required
+    info->protocol = NCCL_PROTO_SIMPLE;
+    // Normalize the comparison to sizePerRank as this is essentially what matters in determining protocl choice
+    size_t sizePerRank = nBytes / comm->nRanks;
+
+    if(sizePerRank <= rcclParamRsLLMaxSizePerRank() && sizePerRank >= rcclParamRsLLMinSizePerRank()) {
+      info->protocol = NCCL_PROTO_LL;
+    }
+#if defined(ENABLE_LL128)
+    // LL128 RS performance is better than LL when enabled, so the next condition overrides the previous LL choice
+    if(comm->topo->ll128Enabled) {
+      if(sizePerRank <= rcclParamRsLL128MaxSizePerRank() && sizePerRank >= rcclParamRsLL128MinSizePerRank()) {
+        info->protocol = NCCL_PROTO_LL128;
+      }
+    }
+#endif
+    if (comm->rank == 0) {
+      printf("ReduceScatter: sizePerRank = %zu, protocol = %d\n", sizePerRank, info->protocol);
+    }
+  }
+#endif
   if (comm->rank == 0) INFO(NCCL_TUNING, "%ld Bytes -> Algo %d proto %d time %f", nBytes, info->algorithm, info->protocol, time);
   if (simInfo) simInfo->estimatedTime = time;
   TRACE(NCCL_COLL, "%ld Bytes -> Algo %d proto %d time %f", nBytes, info->algorithm, info->protocol, time);

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -1712,7 +1712,7 @@ static ncclResult_t topoGetAlgoInfo(
     time = backupTime;
   }
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  // Honor user input for protocl choice
+  // Honor user input for protocol choice
   static int userProtocolInput = -2;
   if (userProtocolInput == -2) {
     const char *protoStr = getenv("NCCL_PROTO");
@@ -1721,7 +1721,7 @@ static ncclResult_t topoGetAlgoInfo(
   if(!userProtocolInput && comm->nNodes >= 2 && info->func == ncclFuncReduceScatter && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942")) {
     // Keep it simple unless otherwise required
     info->protocol = NCCL_PROTO_SIMPLE;
-    // Normalize the comparison to sizePerRank as this is essentially what matters in determining protocl choice
+    // Normalize the comparison to sizePerRank as this is essentially what matters in determining protocol choice
     size_t sizePerRank = nBytes / comm->nRanks;
 
     if(sizePerRank <= rcclParamRsLLMaxSizePerRank() && sizePerRank >= rcclParamRsLLMinSizePerRank()) {

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -1729,9 +1729,6 @@ static ncclResult_t topoGetAlgoInfo(
       }
     }
 #endif
-    if (comm->rank == 0) {
-      printf("ReduceScatter: sizePerRank = %zu, protocol = %d\n", sizePerRank, info->protocol);
-    }
   }
 #endif
   if (comm->rank == 0) INFO(NCCL_TUNING, "%ld Bytes -> Algo %d proto %d time %f", nBytes, info->algorithm, info->protocol, time);


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_Auto selection of protocols based on the data size per GPU ._

**Why were the changes made?**  
_Achieve the best-known experimental BusBW based for multimode MI300x runs._

**How was the outcome achieved?**  
_Numerical analysis on the 1MB data sizes._

**Additional Documentation:**  
_None_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
