### PR TITLE
Enable MSCCL++ enabled UBR test for AllReduce, AllGather with TestBed::RunSimpleSweep

### DIFF
--- a/test/AllGatherTests.cpp
+++ b/test/AllGatherTests.cpp
@@ -159,4 +159,27 @@ namespace RcclUnitTesting
 
     callCollectiveForked(nranks, ncclCollAllGather, sendBuff, recvBuff, expected, use_managed_mem);
   }
+
+  TEST(AllGather, UserBufferRegistration_TestBed)
+  {
+    setenv("UT_PROCESS_MASK", "2", 1);
+    //This test requites env variable UT_PROCESS_MASK=2 because of reliance to msccl++
+    TestBed testBed;
+    testBed.ev.maxRanksPerGpu = 1;
+    // Configuration
+    std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllGather};
+    std::vector<ncclDataType_t> const dataTypes       = {ncclFloat16, ncclFloat32};
+    std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
+    std::vector<int>            const roots           = {0};
+    std::vector<int>            const numElements     = {1048576, 500};
+    std::vector<bool>           const inPlaceList     = {false};
+    std::vector<bool>           const managedMemList  = {false};
+    std::vector<bool>           const useHipGraphList = {false};
+    bool                        const  userRegistered  = true;
+    bool                        const  enableSweep = true;
+    testBed.RunSimpleSweep(funcTypes, dataTypes, redOps, roots, numElements,
+                           inPlaceList, managedMemList, useHipGraphList, enableSweep, userRegistered);
+    testBed.Finalize();
+    unsetenv("UT_PROCESS_MASK");
+  }
 }

--- a/test/AllGatherTests.cpp
+++ b/test/AllGatherTests.cpp
@@ -168,7 +168,7 @@ namespace RcclUnitTesting
     testBed.ev.maxRanksPerGpu = 1;
     // Configuration
     std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllGather};
-    std::vector<ncclDataType_t> const dataTypes       = {ncclFloat16, ncclFloat32};
+    std::vector<ncclDataType_t> const dataTypes       = {ncclBfloat16, ncclFloat16, ncclFloat32};
     std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
     std::vector<int>            const roots           = {0};
     std::vector<int>            const numElements     = {1048576, 500};

--- a/test/AllReduceTests.cpp
+++ b/test/AllReduceTests.cpp
@@ -249,4 +249,51 @@ namespace RcclUnitTesting
     }
     callCollectiveForked(nranks, ncclCollAllReduce, sendBuff, recvBuff, expected, use_managed_mem);
   }
+  
+
+  TEST(AllReduce, UserBufferRegistration_TestBed)
+  {
+    TestBed testBed;
+    //testBed.ev.processMask = (1<<1);//UT_MULTI_PROCESS  //i still have to manually set, or place above testBed
+    testBed.ev.maxRanksPerGpu = 1;
+    testBed.ev.maxGpus = 2;
+    testBed.ev.verbose = false;
+    // Configuration
+    std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllReduce};
+    std::vector<ncclDataType_t> const dataTypes       = {ncclInt32};
+    std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
+    std::vector<int>            const roots           = {0};
+    std::vector<int>            const numElements     = {20971520};
+    std::vector<bool>           const inPlaceList     = {false};
+    std::vector<bool>           const managedMemList  = {false};
+    std::vector<bool>           const useHipGraphList = {false};
+    bool                        const  userRegistered  = true;
+    bool                        const  enableSweep = true;
+    testBed.RunSimpleSweep(funcTypes, dataTypes, redOps, roots, numElements,
+                           inPlaceList, managedMemList, useHipGraphList, enableSweep, userRegistered);
+    testBed.Finalize();
+  }
+
+  TEST(AllReduce, UBR2)
+  {
+    TestBed testBed;
+    //testBed.ev.processMask = (1<<1);//UT_MULTI_PROCESS  //i still have to manually set, or place above testBed
+    testBed.ev.maxRanksPerGpu = 1;
+    testBed.ev.maxGpus = 2;
+    testBed.ev.verbose = false;
+    // Configuration
+    std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllReduce};
+    std::vector<ncclDataType_t> const dataTypes       = {ncclInt32};
+    std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
+    std::vector<int>            const roots           = {0};
+    std::vector<int>            const numElements     = {20971520};
+    std::vector<bool>           const inPlaceList     = {false};
+    std::vector<bool>           const managedMemList  = {false};
+    std::vector<bool>           const useHipGraphList = {false};
+    bool                        const  userRegistered  = false;
+    bool                        const  enableSweep = true;
+    testBed.RunSimpleSweep(funcTypes, dataTypes, redOps, roots, numElements,
+                           inPlaceList, managedMemList, useHipGraphList, enableSweep, userRegistered);
+    testBed.Finalize();
+  }
 }

--- a/test/AllReduceTests.cpp
+++ b/test/AllReduceTests.cpp
@@ -253,10 +253,11 @@ namespace RcclUnitTesting
 
   TEST(AllReduce, UserBufferRegistration_TestBed)
   {
+    //This test requites env variable UT_PROCESS_MASK=2 because of reliance to msccl++
+    //conditionally run if multi-process only
+    setenv("UT_PROCESS_MASK", "2", 1);
     TestBed testBed;
-    //testBed.ev.processMask = (1<<1);//UT_MULTI_PROCESS  //i still have to manually set, or place above testBed
     testBed.ev.maxRanksPerGpu = 1;
-    testBed.ev.maxGpus = 2;
     testBed.ev.verbose = false;
     // Configuration
     std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllReduce};
@@ -269,31 +270,12 @@ namespace RcclUnitTesting
     std::vector<bool>           const useHipGraphList = {false};
     bool                        const  userRegistered  = true;
     bool                        const  enableSweep = true;
-    testBed.RunSimpleSweep(funcTypes, dataTypes, redOps, roots, numElements,
-                           inPlaceList, managedMemList, useHipGraphList, enableSweep, userRegistered);
-    testBed.Finalize();
-  }
 
-  TEST(AllReduce, UBR2)
-  {
-    TestBed testBed;
-    //testBed.ev.processMask = (1<<1);//UT_MULTI_PROCESS  //i still have to manually set, or place above testBed
-    testBed.ev.maxRanksPerGpu = 1;
-    testBed.ev.maxGpus = 2;
-    testBed.ev.verbose = false;
-    // Configuration
-    std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllReduce};
-    std::vector<ncclDataType_t> const dataTypes       = {ncclInt32};
-    std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
-    std::vector<int>            const roots           = {0};
-    std::vector<int>            const numElements     = {20971520};
-    std::vector<bool>           const inPlaceList     = {false};
-    std::vector<bool>           const managedMemList  = {false};
-    std::vector<bool>           const useHipGraphList = {false};
-    bool                        const  userRegistered  = false;
-    bool                        const  enableSweep = true;
     testBed.RunSimpleSweep(funcTypes, dataTypes, redOps, roots, numElements,
-                           inPlaceList, managedMemList, useHipGraphList, enableSweep, userRegistered);
+        inPlaceList, managedMemList, useHipGraphList, enableSweep, userRegistered);
+
+    
     testBed.Finalize();
+    unsetenv("UT_PROCESS_MASK");
   }
 }

--- a/test/AllReduceTests.cpp
+++ b/test/AllReduceTests.cpp
@@ -261,7 +261,7 @@ namespace RcclUnitTesting
     testBed.ev.verbose = false;
     // Configuration
     std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllReduce};
-    std::vector<ncclDataType_t> const dataTypes       = {ncclInt32};
+    std::vector<ncclDataType_t> const dataTypes       = {ncclInt32, ncclBfloat16};
     std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
     std::vector<int>            const roots           = {0};
     std::vector<int>            const numElements     = {20971520};

--- a/test/AllReduceTests.cpp
+++ b/test/AllReduceTests.cpp
@@ -261,7 +261,7 @@ namespace RcclUnitTesting
     testBed.ev.verbose = false;
     // Configuration
     std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAllReduce};
-    std::vector<ncclDataType_t> const dataTypes       = {ncclInt32, ncclBfloat16};
+    std::vector<ncclDataType_t> const dataTypes       = {ncclBfloat16, ncclFloat16, ncclFloat32};
     std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
     std::vector<int>            const roots           = {0};
     std::vector<int>            const numElements     = {20971520};

--- a/test/common/CollectiveArgs.hpp
+++ b/test/common/CollectiveArgs.hpp
@@ -116,7 +116,8 @@ namespace RcclUnitTesting
     bool           inPlace;
     bool           useManagedMem;
     bool           userRegistered;
-    void*          commRegHandle;
+    void*          commRegHandleSend;
+    void*          commRegHandleRecv;
     size_t         numInputBytesAllocated;
     size_t         numOutputBytesAllocated;
     size_t         numInputElementsAllocated;

--- a/test/common/TestBed.cpp
+++ b/test/common/TestBed.cpp
@@ -629,7 +629,6 @@ namespace RcclUnitTesting
                                bool                        const& enableSweep,
                                bool                        const& userRegistered)
   {
-    printf("TestBed::RunSimpleSweep start\n");
     // Sort numElements in descending order to cut down on # of allocations
     std::vector<int> sortedN = numElements;
     std::sort(sortedN.rbegin(), sortedN.rend());
@@ -667,8 +666,7 @@ namespace RcclUnitTesting
     bool isCorrect = true;
 
     // Sweep over the number of ranks
-    int numGpus = 8;
-    //for (int numGpus : ev.GetNumGpusList())
+    for (int numGpus : ev.GetNumGpusList())
     for (int isMultiProcess : ev.GetIsMultiProcessList())
     for (int ranksPerGpu=1; ranksPerGpu <= ev.maxRanksPerGpu && isCorrect; ++ranksPerGpu)
     {

--- a/test/common/TestBed.cpp
+++ b/test/common/TestBed.cpp
@@ -236,6 +236,7 @@ namespace RcclUnitTesting
       PIPE_WRITE(childId, optionalArgs);
       PIPE_CHECK(childId);
     }
+
     InteractiveWait("Finishing SetCollectiveArgs");
   }
 
@@ -247,7 +248,6 @@ namespace RcclUnitTesting
                             bool   const userRegistered)
   {
     InteractiveWait("Starting AllocateMem");
-
     // Build list of ranks this applies to (-1 for rank means to set for all)
     std::vector<int> rankList;
     for (int i = 0; i < this->numActiveRanks; ++i)
@@ -271,6 +271,10 @@ namespace RcclUnitTesting
         PIPE_WRITE(childId, useManagedMem);
         PIPE_WRITE(childId, userRegistered);
         PIPE_WRITE(childId, currGroup);
+      }
+
+      for (auto currRank : rankList){
+        int const childId = rankToChildMap[currRank];
         PIPE_CHECK(childId);
       }
     }
@@ -622,8 +626,10 @@ namespace RcclUnitTesting
                                std::vector<bool>           const& inPlaceList,
                                std::vector<bool>           const& managedMemList,
                                std::vector<bool>           const& useHipGraphList,
-                               bool                        const& enableSweep)
+                               bool                        const& enableSweep,
+                               bool                        const& userRegistered)
   {
+    printf("TestBed::RunSimpleSweep start\n");
     // Sort numElements in descending order to cut down on # of allocations
     std::vector<int> sortedN = numElements;
     std::sort(sortedN.rbegin(), sortedN.rend());
@@ -661,7 +667,8 @@ namespace RcclUnitTesting
     bool isCorrect = true;
 
     // Sweep over the number of ranks
-    for (int numGpus : ev.GetNumGpusList())
+    int numGpus = 8;
+    //for (int numGpus : ev.GetNumGpusList())
     for (int isMultiProcess : ev.GetIsMultiProcessList())
     for (int ranksPerGpu=1; ranksPerGpu <= ev.maxRanksPerGpu && isCorrect; ++ranksPerGpu)
     {
@@ -718,7 +725,7 @@ namespace RcclUnitTesting
           // Only allocate once for largest size
           if (neIdx == 0)
           {
-            this->AllocateMem(inPlaceList[ipIdx], managedMemList[mmIdx]);
+            this->AllocateMem(inPlaceList[ipIdx], managedMemList[mmIdx], -1, -1, -1, userRegistered);
             if (testing::Test::HasFailure())
             {
               isCorrect = false;

--- a/test/common/TestBed.hpp
+++ b/test/common/TestBed.hpp
@@ -165,7 +165,8 @@ namespace RcclUnitTesting
                         std::vector<bool>           const& inPlaceList,
                         std::vector<bool>           const& managedMemList,
                         std::vector<bool>           const& useHipGraphList,
-                        bool                        const& enableSweep = true);
+                        bool                        const& enableSweep = true,
+                        bool                        const& userRegistered = false);
 
     // Wait for user-input if in interactive mode
     void InteractiveWait(std::string message);

--- a/test/common/TestBedChild.cpp
+++ b/test/common/TestBedChild.cpp
@@ -395,8 +395,10 @@ namespace RcclUnitTesting
       {
         CollectiveArgs& collArg = this->collArgs[groupId][localRank][collIdx];
         CHECK_CALL(collArg.AllocateMem(inPlace, useManagedMem, userRegistered));
-        if (collArg.userRegistered && (collArg.funcType == ncclCollSend || collArg.funcType == ncclCollRecv))
-          CHILD_NCCL_CALL(ncclCommRegister(this->comms[localRank], collArg.inputGpu.ptr, collArg.numInputBytesAllocated, &(collArg.commRegHandle)),"ncclCommRegister");
+        if (collArg.userRegistered){
+          CHILD_NCCL_CALL(ncclCommRegister(this->comms[localRank], collArg.inputGpu.ptr, collArg.numInputBytesAllocated, &(collArg.commRegHandleSend)),"ncclCommRegister");
+          CHILD_NCCL_CALL(ncclCommRegister(this->comms[localRank], collArg.outputGpu.ptr, collArg.numOutputBytesAllocated, &(collArg.commRegHandleRecv)),"ncclCommRegister");
+        }
         if (this->verbose) INFO("Rank %d on child %d allocates memory for collective %d in group %d on device %d (%s,%s,%s) Input: %p Output %p\n",
                                 globalRank, this->childId, collIdx, groupId, this->deviceIds[localRank],
                                 inPlace ? "in-place" : "out-of-place",
@@ -896,10 +898,12 @@ namespace RcclUnitTesting
           INFO("Child %d release memory for collective %d in group %d (Input: %p Output %p\n",
                this->childId, collIdx, groupId, collArg.inputGpu.ptr, collArg.outputGpu.ptr);
         }
-        if (collArg.userRegistered && (collArg.funcType == ncclCollSend || collArg.funcType == ncclCollRecv))
+        if (collArg.userRegistered)
         {
-          CHILD_NCCL_CALL(ncclCommDeregister(this->comms[localRank], collArg.commRegHandle), "ncclCommDeregister");
+          CHILD_NCCL_CALL(ncclCommDeregister(this->comms[localRank], collArg.commRegHandleSend), "ncclCommDeregister");
+          CHILD_NCCL_CALL(ncclCommDeregister(this->comms[localRank], collArg.commRegHandleRecv), "ncclCommDeregister");
         }
+        
 
         CHECK_CALL(collArg.DeallocateMem());
       }


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Added unit tests for MSCCL++ AllGather and AllReduce in UBR mode. 

**Why were the changes made?**  
Previously these unit tests were using standalone routines and were not utilizing the TestBed infrastructure. Attempts at using TestBed::RunSimpleSweep caused a hang during MSCCL++ enabled ncclCommRegister

**How was the outcome achieved?**  
Added input/output buffer registration, made AllocateMem non-blocking.

**Additional Documentation:**  
MSCCL++ single-process mode is not supported in MSCCL++ and UT will fail unless UT_PROCESS_MASK is set to 2. This is why I use setenv/unsetenv in the scope of each added test.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
