### PR TITLE
[UT] Increase stack size for StandaloneTests to 480

### DIFF
--- a/test/common/StandaloneUtils.hpp
+++ b/test/common/StandaloneUtils.hpp
@@ -26,7 +26,7 @@
 } while(0)
 
 // should be 112, temp fix to make CI pass
-#define MAX_STACK_SIZE 448
+#define MAX_STACK_SIZE 480
 
 #ifdef ENABLE_LL128
 #define MAX_STACK_SIZE_gfx90a 320


### PR DESCRIPTION
## Details

**Work item:** Internal

**What were the changes?**  
Increased stack size to 480 in RCCL UT Standalone Tests

**Why were the changes made?**  
UT reported `actual: 480 vs 448`

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
