### PR TITLE
Revert "[GRAPH] Increase default nChannels to 112 for gfx950 (#1596)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 ### Added
 
 * Added new GPU target `gfx950`
-* Added support for unroll=1
+* Added support for `unroll=1` in device-code generation to improve performance
 
 ### Known issue
 
-* Using more than 64 channels can segfault when multiple different collectives are used in the same ncclGroup() call
+* Using more than 64 channels can cause a segmentation fault when multiple different collectives are used in the same `ncclGroup()` call
 
 ## Unreleased - RCCL 2.22.3 for ROCm 6.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Full documentation for RCCL is available at [https://rccl.readthedocs.io](https://rccl.readthedocs.io)
 
+## Unreleased - RCCL 2.22.3 for ROCm 6.5.0
+
+### Added
+
+* Added new GPU target `gfx950`
+* Added support for unroll=1
+
+### Known issue
+
+* Using more than 64 channels can segfault when multiple different collectives are used in the same ncclGroup() call
+
 ## Unreleased - RCCL 2.22.3 for ROCm 6.4.0
 
 ### Added

--- a/src/init.cc
+++ b/src/init.cc
@@ -1351,7 +1351,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     allGather3Data[rank].nc = std::max(allGather3Data[rank].nc, 4/ringGraph->nChannels);
   if (ringGraph->nChannels > MAXCHANNELS/2)
     allGather3Data[rank].nc = 1;
-  if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942")) {
+  if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942") || IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")) {
     // Multi-node MI300A
     int managed = 0;
     CUDACHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeDirectManagedMemAccessFromHost, 0));
@@ -1367,9 +1367,6 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
         // NCCL_MIN_NCHANNELS=24
         allGather3Data[rank].nc = 4;
     }
-  }
-  if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")) {
-    allGather3Data[rank].nc = 4;
   }
 
   allGather3Data[rank].pivotA2AEnabled = comm->topo->pivotA2AEnabled && rcclParamPivotAlltoallEnable();


### PR DESCRIPTION
## Details

**Work item:** Internal

**What were the changes?**  
Reverted [commit 1df73e2](https://github.com/ROCm/rccl/commit/1df73e209e536397b53e0a1c57560119dcd2abe1).

**Why were the changes made?**  
Using more than 64 channels can segfault when multiple different collectives are used in the same `ncclGroup()` call

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
