### PR TITLE
[TEST] Switch to googletest release 1.12.0

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -50,7 +50,7 @@ if(NOT GTest_FOUND AND BUILD_TESTS OR INSTALL_DEPENDENCIES)
 
     download_project(PROJ                googletest
                      GIT_REPOSITORY      https://github.com/google/googletest.git
-                     GIT_TAG             release-1.11.0
+                     GIT_TAG             release-1.12.0
                      INSTALL_DIR         ${GTEST_ROOT}
                      CMAKE_ARGS          -DBUILD_GTEST=ON -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> ${COMPILER_OVERRIDE} -DBUILD_SHARED_LIBS=OFF
                      LOG_DOWNLOAD        TRUE


### PR DESCRIPTION
## Details

**Work item:** Internal

**What were the changes?**  
Switched from googletest 1.11.0 to 1.12.0

**Why were the changes made?**  
Newer versions of CMake (4.0+) do not support CMake Minimum version < 3.5.
e.g., error message => `Compatibility with CMake < 3.5 has been removed from CMake`
googletest 1.11.0 uses `cmake_minimum_required(VERSION 2.8.12)`, so build fails.

**How was the outcome achieved?**  
Switch version of googletest from `release-1.11.0` to `release-1.12.0` in the DownloadProject section for GTest.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
