### PR TITLE
Add device synchronization before destroying proxy thread.

### DIFF
--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -1702,6 +1702,7 @@ void* ncclProxyService(void* _args) {
   }
 
   // Wait for all operations to complete and stop progress thread before freeing any resource
+  hipDeviceSynchronize();
   if (ncclProxyProgressDestroy(proxyState) != ncclSuccess) {
     WARN("[Proxy Service] proxyDestroy failed");
   }


### PR DESCRIPTION
This commit ensures that GPU finishes all kernel before destroying communicator thread.

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Make sure kernel finishes executing before destroying proxy thread.

**Why were the changes made?**  
Some application might hang if some rank exited too early.

**How was the outcome achieved?**  
Add a synchronization before calling destroy function.

**Additional Documentation:**  


## Approval Checklist
___Do not approve until these items are satisfied.___
- [x] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
