### PR TITLE
Cherry-pick fix the size of the recv buffer in AllGather UBR test (#1564)

### DIFF
--- a/test/AllGatherTests.cpp
+++ b/test/AllGatherTests.cpp
@@ -127,7 +127,7 @@ namespace RcclUnitTesting
     const int nranks = 8;
     size_t count = 2048;
     std::vector<int> sendBuff(count, 0);
-    std::vector<int> recvBuff(count, 0);
+    std::vector<int> recvBuff(nranks*count, 0);
     std::vector<int> expected(nranks*count, 0);
 
     for (int i = 0; i < count; ++i){
@@ -146,7 +146,7 @@ namespace RcclUnitTesting
     const int nranks = 8;
     size_t count = 2048;
     std::vector<int> sendBuff(count, 0);
-    std::vector<int> recvBuff(count, 0);
+    std::vector<int> recvBuff(nranks*count, 0);
     std::vector<int> expected(nranks*count, 0);
     const bool use_managed_mem = true;
     for (int i = 0; i < count; ++i){


### PR DESCRIPTION
(cherry picked from commit 59c55842f1e934e2857c720098b395eb12aec4f7)

Cherry-pick of PR #1564 to ROCm 6.4.1

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
