### PR TITLE
Enable `-Wdeprecated-copy-with-user-provided-copy`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -818,6 +818,7 @@ endif()
 target_compile_options(rccl PRIVATE -Werror=uninitialized)
 target_compile_options(rccl PRIVATE -Werror=sometimes-uninitialized)
 target_compile_options(rccl PRIVATE -Wall)
+target_compile_options(rccl PRIVATE -Werror=deprecated-copy-with-user-provided-copy)
 target_compile_options(rccl PRIVATE -Wno-format-nonliteral)
 target_compile_options(rccl PRIVATE -fgpu-rdc)               # Generate relocatable device code (required for extern __shared__)
 target_compile_options(rccl PRIVATE -fvisibility=hidden)     # Set symbol visibility to hidden by default

--- a/src/device/op128.h
+++ b/src/device/op128.h
@@ -125,7 +125,11 @@ union alignas(16) BytePack<16> {
   uint64_t u64[2];
   ulong2 ul2, native;
 #if !defined(USE_INDIRECT_FUNCTION_CALL) || defined(__gfx942__) || defined(__gfx950__)
-  inline __device__ BytePack<16>& operator=(BytePack<16> other) {
+  inline __device__ BytePack<16>() = default;
+  inline __device__ BytePack<16>(const BytePack<16>& other) {
+    *this = other;
+  }
+  inline __device__ BytePack<16>& operator=(const BytePack<16>& other) {
     u64[0] = other.u64[0];
     u64[1] = other.u64[1];
     return *this;

--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -344,6 +344,8 @@ struct rccl_float8
     // default constructor
     HIP_HOST_DEVICE rccl_float8() = default;
 
+    constexpr inline HIP_HOST_DEVICE rccl_float8(const rccl_float8& a) : data(a.data) {}
+
 #if defined(__gfx942__) || defined(__gfx950__)
     // device specific optimized F8 down-conversion code
 
@@ -492,7 +494,7 @@ struct rccl_float8
     }
 
     // assignment overloading only from the same F8 types
-    inline __host__ __device__ rccl_float8& operator=(const rccl_float8& a)
+    inline HIP_HOST_DEVICE rccl_float8& operator=(const rccl_float8& a)
     {
         data = a.data;
         return *this;
@@ -510,6 +512,8 @@ struct rccl_bfloat8
 
     // default constructor
     HIP_HOST_DEVICE rccl_bfloat8() = default;
+
+    constexpr inline HIP_HOST_DEVICE rccl_bfloat8(const rccl_bfloat8& a) : data(a.data) {}
 
 #if defined(__gfx942__) || defined(__gfx950__)
     // device specific optimized F8 down-conversion code
@@ -659,7 +663,7 @@ struct rccl_bfloat8
     }
 
     // assignment overloading only from the same F8 types
-    inline __host__ __device__ rccl_bfloat8& operator=(const rccl_bfloat8& a)
+    inline HIP_HOST_DEVICE rccl_bfloat8& operator=(const rccl_bfloat8& a)
     {
         data = a.data;
         return *this;
@@ -684,11 +688,11 @@ namespace std
     {
         return rccl_bfloat8(cosf(float(a)));
     }
-    __device__ __host__ constexpr rccl_float8 real(const rccl_float8& a)
+    HIP_HOST_DEVICE constexpr rccl_float8 real(const rccl_float8& a)
     {
         return a;
     }
-    __device__ __host__ constexpr rccl_bfloat8 real(const rccl_bfloat8& a)
+    HIP_HOST_DEVICE constexpr rccl_bfloat8 real(const rccl_bfloat8& a)
     {
         return a;
     }


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Added copy constructors. Enabled a new warning flag.

**Why were the changes made?**  
Having `operator=` without a copy constructor, or a copy constructor without `operator=` is deprecated in C++ and will cause code to fail to compile with newer standards. I've made appropriate fixes and enabled `-Wdeprecated-copy-with-user-provided-copy` to prevent regressions.

**How was the outcome achieved?**  
N/A

**Additional Documentation:**  
N/A

## Approval Checklist
___Do not approve until these items are satisfied.___
- [X] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
