### PR TITLE
Explicitly define a copy constructor for rccl_float8 and rccl_bfloat8

### DIFF
--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -492,7 +492,7 @@ struct rccl_float8
     }
 
     // Explicitly define a copy constructor because copy assignment is defined
-    constexpr rccl_float8(const rccl_float8& o) : data(o.data) {}
+    constexpr inline __host__ __device__ rccl_float8(const rccl_float8& o) : data(o.data) {}
 
     // assignment overloading only from the same F8 types
     inline __host__ __device__ rccl_float8& operator=(const rccl_float8& a)

--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -491,6 +491,9 @@ struct rccl_float8
         return data == 0x80;
     }
 
+    // Explicitly define a copy constructor because copy assignment is defined
+    constexpr rccl_float8(const rccl_float8& o) : data(o.data) {}
+
     // assignment overloading only from the same F8 types
     inline __host__ __device__ rccl_float8& operator=(const rccl_float8& a)
     {
@@ -657,6 +660,9 @@ struct rccl_bfloat8
     {
         return data == 0x80;
     }
+    
+	// Explicitly define a copy constructor because copy assignment is defined
+    constexpr inline __host__ __device__ rccl_bfloat8(const rccl_bfloat8& a) : data(a.data) {}
 
     // assignment overloading only from the same F8 types
     inline __host__ __device__ rccl_bfloat8& operator=(const rccl_bfloat8& a)

--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -661,7 +661,7 @@ struct rccl_bfloat8
         return data == 0x80;
     }
     
-	// Explicitly define a copy constructor because copy assignment is defined
+    // Explicitly define a copy constructor because copy assignment is defined
     constexpr inline __host__ __device__ rccl_bfloat8(const rccl_bfloat8& a) : data(a.data) {}
 
     // assignment overloading only from the same F8 types


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?** 
 
This is to pass LLVM build with -Wdeprecated-copy-with-user-provided-copy.
w/o the fix, we have following compile error:
`error: definition of implicit copy constructor for 'rccl_float8' is deprecated because it has a user-provided copy assignment operator [-Werror,-Wdeprecated-copy-with-user-provided-copy]
  495 |     inline __host__ __device__ rccl_float8& operator=(const rccl_float8& a)
rccl_float8.h:673:16: note: in implicit copy constructor for 'rccl_float8' first required here
  673 |         return rccl_float8(sinf(float(a)));`


**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
