### PR TITLE
Cherry-pick (Add device synchronization before destroying proxy thread. (#1631))

### DIFF
--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -1566,6 +1566,7 @@ void* ncclProxyService(void* _args) {
   }
 
   // Wait for all operations to complete and stop progress thread before freeing any resource
+  hipDeviceSynchronize();
   if (ncclProxyProgressDestroy(proxyState) != ncclSuccess) {
     WARN("[Proxy Service] proxyDestroy failed");
   }


### PR DESCRIPTION
Cherry-pick of #1631 into ROCm 6.4.1