### PR TITLE
ext-src: fix mscclpp accuracy issue for allreduce7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 ## Unreleased - RCCL 2.23.4 for ROCm 6.4.1
 
-### Added
+### Resolved issues
 
 * Fixed the accuracy issue of MSCCLPP `allreduc7` kernel in graph mode
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 ### Resolved issues
 
-* Fixed the accuracy issue of MSCCLPP `allreduc7` kernel in graph mode
+* Fixed the accuracy issue for MSCCLPP `allreduc7` kernel in graph mode.
 
 ## Unreleased - RCCL 2.22.3 for ROCm 6.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for RCCL is available at [https://rccl.readthedocs.io](https://rccl.readthedocs.io)
 
+## Unreleased - RCCL 2.23.4 for ROCm 6.4.1
+
+### Added
+
+* Fixed the accuracy issue of MSCCLPP `allreduc7` kernel in graph mode
+
 ## Unreleased - RCCL 2.22.3 for ROCm 6.4.0
 
 ### Added

--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -85,6 +85,11 @@ if(ENABLE_MSCCLPP)
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
 
+	execute_process(
+            COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/device-flag.patch
+            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+        )
+
         message(STATUS "Building mscclpp only for gfx942.")
         mscclpp_cmake_arg(CMAKE_PREFIX_PATH)
         mscclpp_cmake_arg(CMAKE_INSTALL_RPATH_USE_LINK_PATH)
@@ -110,24 +115,31 @@ if(ENABLE_MSCCLPP)
 
      
         find_package(mscclpp_nccl REQUIRED)
-        execute_process(
-           COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/cpx.patch
-           WORKING_DIRECTORY ${MSCCLPP_SOURCE}
-        )
+	
+	execute_process(
+	   COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/device-flag.patch
+	   WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+	)
+	
+	execute_process(
+	    COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mem-reg.patch
+	    WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+	)
+
+	execute_process(
+	    COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mscclpp_ibv_access_relaxed_ordering.patch
+	    WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+	)
+ 
+	execute_process(
+	    COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/read-allred.patch
+	    WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+	)
         
-        execute_process(
-            COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/read-allred.patch
-            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
-        )
-        
-        execute_process(
-            COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mscclpp_ibv_access_relaxed_ordering.patch
-            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
-        )
-        execute_process(
-            COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/mem-reg.patch
-            WORKING_DIRECTORY ${MSCCLPP_SOURCE}
-        )
+	execute_process(
+	   COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/cpx.patch
+	   WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+	)
 
     #endif()
 

--- a/ext-src/device-flag.patch
+++ b/ext-src/device-flag.patch
@@ -1,0 +1,200 @@
+diff --git a/apps/nccl/src/allreduce.hpp b/apps/nccl/src/allreduce.hpp
+index 76674ba..f4ca403 100644
+--- a/apps/nccl/src/allreduce.hpp
++++ b/apps/nccl/src/allreduce.hpp
+@@ -198,11 +198,17 @@ template <typename T>
+ __global__ void __launch_bounds__(32, 1)
+     allreduceAllToAll(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<mscclpp::SmChannel>* smChannels,
+                       size_t channelDataOffset, size_t channelScratchOffset, int rank, int nRanksPerNode, int worldSize,
+-                      size_t nelems, uint32_t flag) {
++                      size_t nelems, uint32_t *deviceFlag, mscclpp::DeviceSyncer* deviceSyncer) {
+   // This version of allreduce only works for single nodes
+   if (worldSize != nRanksPerNode) return;
+   if (sizeof(T) == 2) nelems = (nelems * sizeof(T) + sizeof(T)) / sizeof(int);
+   const int nPeers = nRanksPerNode - 1;
++
++  uint32_t flag = *deviceFlag;
++
++  size_t scratchBaseOffset = (flag % 2) ? SCRATCH_SIZE/2 : 0;
++  channelScratchOffset = scratchBaseOffset;
++
+   const int nBlocksPerPeer = gridDim.x / nPeers;
+   const int localBlockIdx = blockIdx.x % nBlocksPerPeer;
+   const int tid = threadIdx.x + localBlockIdx * blockDim.x;
+@@ -236,13 +242,20 @@ __global__ void __launch_bounds__(32, 1)
+     data = add_vectors<T>(data, src[idx]);
+     dst[idx] = data;
+   }
++  __syncthreads();
++
++  deviceSyncer->sync(gridDim.x);
++
++  if (blockIdx.x == 0 && threadIdx.x == 0) {
++         *deviceFlag = *deviceFlag + 1;
++  }
+ }
+ 
+ template <typename T>
+ __global__ void __launch_bounds__(1024, 1)
+     allreduce7(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<mscclpp::SmChannel>* smChannels,
+                size_t channelDataOffset, size_t channelScratchOffset, int rank, int nRanksPerNode, int worldSize,
+-               size_t nelems, uint32_t flag
++               size_t nelems, uint32_t* deviceFlag, mscclpp::DeviceSyncer* deviceSyncer
+ #if defined(ENABLE_NPKIT)
+                ,
+                NpKitEventCollectContext* npKitEventCollectContexts, uint64_t* cpuTimestamp) {
+@@ -289,6 +302,12 @@ __global__ void __launch_bounds__(1024, 1)
+   if ((nelemsPerRank % 2)) nelemsPerRank = (nelemsPerRank * sizeof(T) + sizeof(T)) / sizeof(T);
+ 
+   const int nPktsPerRank = nelemsPerRank / 2;
++
++  uint32_t flag = *deviceFlag;
++
++  size_t scratchBaseOffset = (flag % 2) ? SCRATCH_SIZE/2 : 0;
++  channelScratchOffset = scratchBaseOffset;
++
+   // thread block & channel info
+   const int nBlocksPerPeer = gridDim.x / nPeers;
+   const int localBlockIdx = blockIdx.x % nBlocksPerPeer;
+@@ -338,6 +357,8 @@ __global__ void __launch_bounds__(1024, 1)
+       channels[index].write(offset, packet);
+     }
+   }
++  __syncthreads();
++
+   // step 3: get data result from scratch buffer
+   mscclpp::LLPacket* dstPkt = (mscclpp::LLPacket*)((char*)scratch + scratchResultOffset);
+   const int dstOffset = remoteRank * nPktsPerRank;
+@@ -347,6 +368,7 @@ __global__ void __launch_bounds__(1024, 1)
+     result[idx].x = data.x;
+     result[idx].y = data.y;
+   }
++  __syncthreads();
+ #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_KERNEL_ALLREDUCE_ENTRY) && \
+     defined(ENABLE_NPKIT_EVENT_KERNEL_ALLREDUCE_EXIT)
+   NpKit::CollectGpuEventShm(NPKIT_EVENT_KERNEL_ALLREDUCE_ENTRY, 0, 0, npkit_timestamp_entry, event_buffer,
+@@ -357,6 +379,11 @@ __global__ void __launch_bounds__(1024, 1)
+ #if defined(ENABLE_NPKIT)
+   NpKit::StoreGpuEventShm(npKitEventCollectContexts, event_buffer, event_buffer_head);
+ #endif
++  deviceSyncer->sync(gridDim.x);
++
++  if (blockIdx.x == 0 && threadIdx.x == 0) {
++         *deviceFlag = *deviceFlag + 1;
++  }
+ }
+ 
+ template <typename T>
+@@ -803,7 +830,7 @@ cudaError_t allreduce(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<
+                       mscclpp::DeviceHandle<mscclpp::SmChannel>* smScrChannels,
+ 		      mscclpp::DeviceHandle<mscclpp::SmChannel>* smOutChannels, size_t channelInOffset,
+                       size_t channelOutOffset, size_t channelScratchOffset, int rank, int nRanksPerNode, int worldSize,
+-                      size_t nelems, cudaStream_t stream) {
++                      size_t nelems, cudaStream_t stream, uint32_t* deviceFlag, mscclpp::DeviceSyncer* syncer) {
+   static uint32_t flag = 1;
+   int readAllred = 0, hieAllred = 0;
+   char* envValue = nullptr;
+@@ -828,8 +855,8 @@ cudaError_t allreduce(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<
+     int nBlocks = nRanksPerNode - 1;
+     int nThreadsPerBlock = 32;
+     allreduceAllToAll<<<nBlocks, nThreadsPerBlock, 0, stream>>>(buff, scratch, resultBuff, smChannels,
+-		    channelInOffset, channelScratchOffset, rank, nRanksPerNode, worldSize, nelems, flag++);
+-  } else if (sizeof(T) * nelems <= (1 << 20)) {
++		    channelInOffset, channelScratchOffset, rank, nRanksPerNode, worldSize, nelems, deviceFlag, syncer);
++  } else if (sizeof(T) * nelems <= (1 << 18)) {
+     int nBlocks = 4*(nRanksPerNode - 1);
+     int nThreadsPerBlock = 1024;
+     if (nelems >= 8192) {
+@@ -840,11 +867,11 @@ cudaError_t allreduce(T* buff, T* scratch, T* resultBuff, mscclpp::DeviceHandle<
+     size_t NpkitSharedMemSize = NPKIT_SHM_NUM_EVENTS * sizeof(NpKitEvent);
+     allreduce7<<<nBlocks, nThreadsPerBlock, NpkitSharedMemSize, stream>>>(
+         buff, scratch, resultBuff, smChannels, channelInOffset, channelScratchOffset, rank, nRanksPerNode, worldSize,
+-        nelems, flag++, NpKit::GetGpuEventCollectContexts(), NpKit::GetCpuTimestamp());
++        nelems, deviceFlag, syncer, NpKit::GetGpuEventCollectContexts(), NpKit::GetCpuTimestamp());
+ #else
+     allreduce7<<<nBlocks, nThreadsPerBlock, 0, stream>>>(buff, scratch, resultBuff, smChannels, channelInOffset,
+                                                          channelScratchOffset, rank, nRanksPerNode, worldSize, nelems,
+-                                                         flag++);
++                                                         deviceFlag, syncer);
+ #endif
+   } else {
+     int nBlocks = 5*(nRanksPerNode - 1);
+diff --git a/apps/nccl/src/nccl.cu b/apps/nccl/src/nccl.cu
+index 5c19dc6..9ac49da 100644
+--- a/apps/nccl/src/nccl.cu
++++ b/apps/nccl/src/nccl.cu
+@@ -91,6 +91,9 @@ struct ncclComm {
+ 
+   uint32_t numScratchBuff;
+   uint32_t buffFlag;
++
++  uint32_t* deviceFlag;
++  mscclpp::DeviceSyncer *syncer;
+ };
+ 
+ struct handleInfo {
+@@ -224,7 +227,7 @@ static ncclResult_t ncclAllReduceFallback(const void* sendbuff, void* recvbuff,
+   mscclpp::DeviceHandle<mscclpp::SmChannel>* smScrChannels = nullptr;
+ 
+   // Creating the channels
+-  if (count * ncclTypeSize(datatype) <= (1 << 20)) {
++  if (count * ncclTypeSize(datatype) <= (1 << 18)) {
+     auto sendIt = comm->channelScratchInfos.find(sendKey);
+     if (sendIt == comm->channelScratchInfos.end()) {
+       std::vector<mscclpp::SmChannel> channels =
+@@ -268,24 +271,28 @@ static ncclResult_t ncclAllReduceFallback(const void* sendbuff, void* recvbuff,
+   switch (datatype) {
+     case ncclFloat16:
+       CUDACHECK(allreduce((half*)sendbuff, (half*)comm->scratchBuff.get(), (half*)recvbuff, smChannels, smScrChannels,
+-	smOutChannels, offsetIn, offsetOut, offsetScratch, rank, NRANKS_PER_NODE, comm->comm->bootstrap()->getNranks(), 	count, stream));
++			smOutChannels, offsetIn, offsetOut, offsetScratch, rank, NRANKS_PER_NODE,
++			comm->comm->bootstrap()->getNranks(), count, stream, comm->deviceFlag, comm->syncer));
+       break;
+     case ncclFloat32:
+       CUDACHECK(allreduce((float*)sendbuff, (float*)comm->scratchBuff.get(), (float*)recvbuff, smChannels,
+                           smScrChannels, smOutChannels, offsetIn, offsetOut, offsetScratch,
+ 			   comm->comm->bootstrap()->getRank(),
+-                          NRANKS_PER_NODE, comm->comm->bootstrap()->getNranks(), count, stream));
++                          NRANKS_PER_NODE, comm->comm->bootstrap()->getNranks(), count, stream, comm->deviceFlag,
++			  comm->syncer));
+       break;
+     case ncclBfloat16:
+       CUDACHECK(allreduce((__bfloat16*)sendbuff, (__bfloat16*)comm->scratchBuff.get(), (__bfloat16*)recvbuff,
+                           smChannels, smScrChannels, smOutChannels, offsetIn, offsetOut, offsetScratch, rank,
+-			   NRANKS_PER_NODE, comm->comm->bootstrap()->getNranks(), count, stream));
++			   NRANKS_PER_NODE, comm->comm->bootstrap()->getNranks(), count, stream, comm->deviceFlag,
++			   comm->syncer));
+       break;
+     case ncclInt32:
+     case ncclUint32:
+       CUDACHECK(allreduce((int*)sendbuff, (int*)comm->scratchBuff.get(), (int*)recvbuff, smChannels, smScrChannels,
+ 			  smOutChannels, offsetIn, offsetOut, offsetScratch, comm->comm->bootstrap()->getRank(),
+-			  NRANKS_PER_NODE, comm->comm->bootstrap()->getNranks(), count, stream));
++			  NRANKS_PER_NODE, comm->comm->bootstrap()->getNranks(), count, stream, comm->deviceFlag,
++			  comm->syncer));
+       break;
+     default:
+       WARN("datatype is invalid");
+@@ -379,6 +386,13 @@ static void ncclCommInitRankFallbackSingleNode(ncclComm* commPtr, std::shared_pt
+   commPtr->scratchBuff = mscclpp::GpuBuffer(SCRATCH_SIZE).memory();
+   commPtr->remoteScratchRegMemories =
+       setupRemoteMemories(commPtr->comm, rank, commPtr->scratchBuff.get(), SCRATCH_SIZE, mscclpp::Transport::CudaIpc);
++
++  cudaMalloc((void**)&(commPtr->syncer), sizeof(mscclpp::DeviceSyncer));
++  cudaMemset((void*)(commPtr->syncer), 0, sizeof(mscclpp::DeviceSyncer));
++
++  uint32_t initFlag = 1;
++  cudaMalloc((void**)&(commPtr->deviceFlag), sizeof(uint32_t));
++  cudaMemcpy((void*)(commPtr->deviceFlag), &initFlag, sizeof(uint32_t), hipMemcpyHostToDevice);
+ }
+ 
+ NCCL_API ncclResult_t ncclGetVersion(int* version) {
+@@ -476,6 +490,8 @@ NCCL_API ncclResult_t ncclCommDestroy(ncclComm_t comm) {
+     NpKit::Shutdown();
+   }
+ #endif
++  cudaFree(comm->deviceFlag);
++  cudaFree(comm->syncer);
+   delete comm;
+   return ncclSuccess;
+ }

--- a/src/init.cc
+++ b/src/init.cc
@@ -1,3 +1,4 @@
+
 /*************************************************************************
  * Copyright (c) 2015-2022, NVIDIA CORPORATION. All rights reserved.
  * Modifications Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
@@ -114,7 +115,7 @@ bool operator ==(const ncclUniqueId& a, const ncclUniqueId& b) {
   return memcmp(a.internal, b.internal, NCCL_UNIQUE_ID_BYTES) == 0;
 }
 
-RCCL_PARAM(MscclppThreshold, "MSCCLPP_THRESHOLD", (size_t)(1024*1024));
+RCCL_PARAM(MscclppThreshold, "MSCCLPP_THRESHOLD", (size_t)(16*1024*1024));
 #endif
 
 static constexpr int64_t defaultEnableMscclpp = 0;


### PR DESCRIPTION
## Details
This PR fixes an issue with allreduce7 kernel in MSCCLPP that gets triggered for graph mode. In allreduce7, the LL protocol flag was getting updated in the host side and not getting captured in graph mode. This PR fixes the issue by incrementing the flag in the kernel.

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
