### PR TITLE
reverting change on RcclReplayer

### DIFF
--- a/tools/RcclReplayer/rcclReplayer.cpp
+++ b/tools/RcclReplayer/rcclReplayer.cpp
@@ -180,36 +180,31 @@ void dataToCsv(GroupCall const& gc, std::ofstream &datafile, double runTime)
 
 void ParseCollectives(char const* logFilename, bool isFirstRank, CollectiveCalls& cc)
 {
+  bool verbose = isFirstRank && (getenv("VERBOSE") != NULL);
   cc.globalRankComms.clear();
   cc.globalRankComms.resize(cc.numGlobalRanks);
   cc.groupCalls.clear();
 
-  std::ifstream fp(logFilename, std::ios::binary);
+  FILE* fp = fopen(logFilename, "r");
   if (!fp) {
     printf("[ERROR] Unable to open file %s\n", logFilename);
     exit(-1);
   }
 
-  constexpr size_t size = sizeof(LineItem) + 1;
-  char line[size]; //size of collectivecall struct
+  char line[2048];
+  LineItem li;
   int lineNum = 0;
 
-  while (fp.getline(line, size))
-  {
-    LineItem li = *((LineItem*)line);
+  while (fgets(line, 2048, fp)) {
+    ++lineNum;
 
-    if (li.coll == 10 || li.coll == 11)
-    {
-      continue;
-    }
-    // if need hostname will parse together with num of line in output
-    // Ignore invalid lines and collectives
-    if (li.nRanks != cc.numGlobalRanks) continue;
+    //Ignore invalid lines and collectives
+    if (!ParseLineItem(line, li) || li.nRanks != cc.numGlobalRanks) continue;
 
     // Figure out commIdx for this globalrank
     int commIdx = -1;
     for (auto i = 0; i < cc.globalRankComms[li.globalRank].size(); i++) {
-      if (cc.globalRankComms[li.globalRank][i] != li.comm) {
+      if (!strcmp(cc.globalRankComms[li.globalRank][i].c_str(), li.comm)) {
         commIdx = i;
         break;
       }
@@ -220,8 +215,8 @@ void ParseCollectives(char const* logFilename, bool isFirstRank, CollectiveCalls
     }
 
     TaskInfo taskInfo;
-    taskInfo.funcType = (ncclFunc_t) li.coll;
-    taskInfo.inPlace  = li.sendbuff == li.recvbuff;
+    taskInfo.funcType = GetFuncType(li.opName);
+    taskInfo.inPlace  = !strcmp(li.sendbuff, li.recvbuff);
     taskInfo.count    = li.count;
     taskInfo.datatype = (ncclDataType_t) li.datatype;
     taskInfo.op       = (ncclRedOp_t) li.op;
@@ -234,7 +229,7 @@ void ParseCollectives(char const* logFilename, bool isFirstRank, CollectiveCalls
       if (gc.opCount != li.opCount) continue;
       if (gc.rankData.count(li.globalRank)) {
         RankData& rd = gc.rankData[li.globalRank];
-        if (rd.commIdx != commIdx || rd.tasks.size() != li.nTasks)
+        if (rd.commIdx != commIdx || rd.tasks.size() != li.task)
           continue;
 
         rd.tasks.push_back(taskInfo);
@@ -242,7 +237,7 @@ void ParseCollectives(char const* logFilename, bool isFirstRank, CollectiveCalls
         break;
       }
       // Rank has no tasks - make sure this is task 0
-      else if (li.nTasks == 0) {
+      else if (li.task == 0) {
         gc.rankData[li.globalRank].lineNum = lineNum;
         gc.rankData[li.globalRank].commIdx = commIdx;
         gc.rankData[li.globalRank].tasks.push_back(taskInfo);
@@ -253,7 +248,7 @@ void ParseCollectives(char const* logFilename, bool isFirstRank, CollectiveCalls
 
     // If no collectives were found, create new one
     if (!found) {
-      if (li.nTasks != 0) {
+      if (li.task != 0) {
         if (isFirstRank) printf("[WARN] Was unable to find corresponding collective for line %d\n", lineNum);
       }
 
@@ -265,7 +260,7 @@ void ParseCollectives(char const* logFilename, bool isFirstRank, CollectiveCalls
       cc.groupCalls.push_back(gc);
     }
   }
-  fp.close();
+  fclose(fp);
 
   // Validate group calls
   // - For non Send/Recv, check that all ranks participate with same parameters count
@@ -378,6 +373,18 @@ void ParseCollectives(char const* logFilename, bool isFirstRank, CollectiveCalls
         printf("[INFO] Scatter pattern detected and replaced with scatter collective\n");
     }
   }
+}
+
+bool ParseLineItem(char const* line, LineItem& li)
+{
+  return sscanf(line,
+                "%[^:]:%d:%d [%d] NCCL INFO %[^:]: opCount %x sendbuff %s "
+                "recvbuff %s count %lu datatype %d op %d root %d comm %s "
+                "[nranks=%d] stream %p task %d globalrank %d",
+                li.hostname, &li.pid, &li.tid, &li.cudaDev, li.opName,
+                &li.opCount, li.sendbuff, li.recvbuff,
+                &li.count, &li.datatype, &li.op, &li.root, li.comm,
+                &li.nRanks, &li.stream, &li.task, &li.globalRank) == 17;
 }
 
 double ReplayRccl(CollectiveCalls& cc, int groupIdx, int& numInvalid)
@@ -558,12 +565,6 @@ void ExecuteCollective(TaskInfo& task, ncclComm_t const& comm, hipStream_t strea
     break;
   case ncclCollRecv:
     NCCL_CALL(ncclRecv(task.outputGpu.ptr, task.count, task.datatype, task.root, comm, stream));
-    break;
-  case ncclStartGroup:
-    NCCL_CALL(ncclGroupStart());
-    break;
-  case ncclEndGroup:
-    NCCL_CALL(ncclGroupEnd());
     break;
   default:
     printf("Error: unsupported collective\n");


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal"

**What were the changes?**  
Replayer is broken with structured logging update, reverting replayer to previous state before newer version of replayer is pushed


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
