### PR TITLE
Fix broken link to RCCL Replayer GitHub info (#1655)

### DIFF
--- a/docs/how-to/troubleshooting-rccl.rst
+++ b/docs/how-to/troubleshooting-rccl.rst
@@ -133,7 +133,7 @@ Using the RCCL Replayer
 The RCCL Replayer is a debugging tool designed to analyze and replay the collective logs obtained from RCCL runs. 
 It can be helpful when trying to reproduce problems, because it uses dummy data and doesn't have any dependencies 
 on non-RCCL calls. For more information, 
-see `RCCL Replayer GitHub documentation <https://github.com/ROCm/rccl/tree/develop/tools/rccl_replayer>`_.
+see `RCCL Replayer GitHub documentation <https://github.com/ROCm/rccl/tree/develop/tools/RcclReplayer>`_.
 
 You must build the RCCL Replayer before you can use it. To build it, run these commands. Ensure ``MPI_DIR`` is set to 
 the path where MPI is installed.


### PR DESCRIPTION
(cherry picked from commit df778b4ea12acb608d061a36739ca721980143b6)

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _Internal

**What were the changes?**  
Fix broken link

**Why were the changes made?**  
The RCCL Replayer section of the GitHub was reorganized and a link pointing to the old directory broke

**How was the outcome achieved?**  
Fixed the link in docs

**Additional Documentation:**  
No functional effects. One-line fix.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
