### PR TITLE
Set `GTEST_BOTH_LIBRARIES` appropriately

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -70,6 +70,8 @@ if(NOT GTest_FOUND AND BUILD_TESTS OR INSTALL_DEPENDENCIES)
         message(FATAL_ERROR "Cannot find gtest library installation path.")
     find_package(GTest REQUIRED CONFIG PATHS ${GTEST_ROOT})
     endif()
+elseif(GTest_FOUND AND BUILD_TESTS)
+  set(GTEST_BOTH_LIBRARIES "GTest::gtest;GTest::gtest_main")
 endif()
 
 # Find or download/install rocm-cmake project


### PR DESCRIPTION
## Details

If `find_package()` succeeds to find GTest and `INSTALL_DEPENDENCIES` is set to OFF, `GTEST_BOTH_LIBRARIES` is not set and thus `rccl-UnitTests` fails with trying to link unknown symbols.

**Work item:**

https://github.com/ROCm/TheRock/issues/479

**What were the changes?**  

Set `GTEST_BOTH_LIBRARIES` when `GTest_FOUND` is true.

**Why were the changes made?**  

Building rccl fails as gtest cannot be linked when `GTest_FOUND` is true.

**How was the outcome achieved?**  
N/A

**Additional Documentation:**  
N/A

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
