### PR TITLE
moving the thread_fence to apply before atomic fetch

### DIFF
--- a/src/device/primitives.h
+++ b/src/device/primitives.h
@@ -27,12 +27,12 @@
   } else { \
     const int w = threadIdx.x/WARP_SIZE; \
     const int wid = threadIdx.x%WARP_SIZE; \
+    __THREAD_FENCE; \
     if (wid == 0) { \
       barrier_next += nthreads/WARP_SIZE; \
       __hip_atomic_fetch_add(barriers, 1, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
       int spins = 0; \
       int rate_limit = 50; \
-      __THREAD_FENCE; \
       while (__hip_atomic_load(barriers, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP) < barrier_next) { \
         spins++; \
         if (spins == NCCL_SPINS_BEFORE_CHECK_ABORT) { \

--- a/src/device/primitives.h
+++ b/src/device/primitives.h
@@ -27,9 +27,9 @@
   } else { \
     const int w = threadIdx.x/WARP_SIZE; \
     const int wid = threadIdx.x%WARP_SIZE; \
-    __THREAD_FENCE; \
     if (wid == 0) { \
       barrier_next += nthreads/WARP_SIZE; \
+      __THREAD_FENCE; \
       __hip_atomic_fetch_add(barriers, 1, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
       int spins = 0; \
       int rate_limit = 50; \


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal (SWDEV-522349)

**What were the changes?**  
Apply thread_fence across all warps to fix AllToAllV failure

**Why were the changes made?**  
alltoallv is failing on Hayabusa on 16 ranks

**How was the outcome achieved?**  
This change will help the alltoallv passed.

**Additional Documentation:**  


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
