### PR TITLE
Code coverage improvements for alloc.h 

### DIFF
--- a/test/AllocTests.cpp
+++ b/test/AllocTests.cpp
@@ -118,5 +118,32 @@ namespace RcclUnitTesting
         hipFree(d_dst);
     
     }
-    
+
+    TEST(Alloc, ZeroElementMemcpy) {
+        float *d_src = nullptr, *d_dst = nullptr;
+        ASSERT_EQ(hipMalloc(&d_src, sizeof(float)), hipSuccess);
+        ASSERT_EQ(hipMalloc(&d_dst, sizeof(float)), hipSuccess);
+
+        ncclResult_t result = ncclCudaMemcpy<float>(d_dst, d_src, 0);
+        EXPECT_EQ(result, ncclSuccess) << "Zero-element copy should succeed (no-op)";
+
+        hipFree(d_src);
+        hipFree(d_dst);
+    }
+
+    TEST(Alloc, MemcpyNullSrcOrDstPointer) {
+        constexpr size_t N = 16;
+        float* d_valid = nullptr;
+        ASSERT_EQ(hipMalloc(&d_valid, N * sizeof(float)), hipSuccess);
+
+        // Case 1: src is nullptr
+        ncclResult_t result = ncclCudaMemcpy<float>(d_valid, nullptr, N);
+        EXPECT_EQ(result, ncclUnhandledCudaError) << "Expected ncclUnhandledCudaError when src is nullptr";
+
+        // Case 2: dst is nullptr
+        result = ncclCudaMemcpy<float>(nullptr, d_valid, N);
+        EXPECT_EQ(result, ncclUnhandledCudaError) << "Expected ncclUnhandledCudaError when dst is nullptr";
+
+        hipFree(d_valid);
+    }
 } //namespace rccl

--- a/test/AllocTests.cpp
+++ b/test/AllocTests.cpp
@@ -1,0 +1,122 @@
+/*************************************************************************
+ * Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include <gtest/gtest.h>
+#include <rccl/rccl.h>
+#include <alloc.h>
+ 
+#include "TestBed.hpp"
+
+template ncclResult_t ncclCudaMemcpy<float>(float*, float*, size_t);
+namespace RcclUnitTesting
+{
+    TEST(Alloc, ncclIbMallocDebugNonZero) {
+        void* ptr = nullptr;
+        size_t size = 4096;
+      
+        ncclResult_t result = ncclIbMalloc(&ptr, size);
+      
+        EXPECT_EQ(result, ncclSuccess);
+        ASSERT_NE(ptr, nullptr);
+      
+        char* char_ptr = static_cast<char*>(ptr);
+        for (size_t i = 0; i < size; ++i) {
+          ASSERT_EQ(char_ptr[i], 0);
+        }
+      
+        free(ptr);
+    }
+      
+    TEST(Alloc, ncclIbMallocDebugZeroSize) {
+        void* ptr = (void*)0xdeadbeef;
+        ncclResult_t result = ncclIbMalloc(&ptr, 0);
+      
+        EXPECT_EQ(result, ncclSuccess);
+        EXPECT_EQ(ptr, nullptr);
+    }
+      
+      
+    TEST(Alloc, ncclCuMemHostAlloc) {
+        void* ptr = NULL;
+        void* handle = NULL;
+        size_t size = 1024;
+        ncclResult_t result = ncclCuMemHostAlloc(&ptr, handle, size);     
+        ASSERT_EQ(result, ncclInternalError);
+    }
+
+    TEST(Alloc, ncclCuMemHostFree)
+    {
+        void* dummyPtr = reinterpret_cast<void*>(0x1234); // any dummy address
+        ncclResult_t result = ncclCuMemHostFree(dummyPtr);    
+        ASSERT_EQ(result, ncclInternalError);
+    }
+      
+    TEST(Alloc, ncclCuMemAlloc)
+    {
+        void* ptr = reinterpret_cast<void*>(0x1234);     // dummy non-null input
+        void* handle = reinterpret_cast<void*>(0x5678);  // dummy non-null input
+        size_t size = 1024;
+        hipMemAllocationHandleType type = hipMemHandleTypeNone;
+        ncclResult_t result = ncclCuMemAlloc(&ptr, &handle, type, size);
+        EXPECT_EQ(result, ncclInternalError);       
+    }
+
+    TEST(Alloc, ncclCuMemFree)
+    {
+        void* dummyPtr = reinterpret_cast<void*>(0xdeadbeef); // arbitrary non-null
+        ncclResult_t result = ncclCuMemFree(dummyPtr);
+        EXPECT_EQ(result, ncclInternalError);  
+    }
+
+    TEST(Alloc, ncclCuMemAllocAddr)
+    {
+        void* ptr = reinterpret_cast<void*>(0x1111);  // Dummy non-null input
+        hipMemGenericAllocationHandle_t handle = reinterpret_cast<hipMemGenericAllocationHandle_t>(0x1234);
+        size_t size = 4096;
+        ncclResult_t result = ncclCuMemAllocAddr(&ptr, &handle, size);     
+        ASSERT_EQ(result, ncclInternalError);
+    }
+       
+    TEST(Alloc, ncclCuMemFreeAddr)
+    {
+        void* testPtr = reinterpret_cast<void*>(0xbeefcafe); // Arbitrary non-null pointer
+        ncclResult_t result = ncclCuMemFreeAddr(testPtr);
+        ASSERT_EQ(result, ncclInternalError);   
+    }
+    
+    TEST(Alloc, NcclCudaMemcpy) {
+        constexpr size_t N = 128;
+        float *d_src = nullptr, *d_dst = nullptr;
+        float h_src[N], h_dst[N];
+    
+        for (size_t i = 0; i < N; ++i) h_src[i] = static_cast<float>(i + 1);
+        // Allocate device memory
+    
+        ASSERT_EQ(hipMalloc(&d_src, N * sizeof(float)), hipSuccess);
+        ASSERT_EQ(hipMalloc(&d_dst, N * sizeof(float)), hipSuccess);
+    
+        // Copy from host to device (source buffer)
+        ASSERT_EQ(hipMemcpy(d_src, h_src, N * sizeof(float), hipMemcpyHostToDevice), hipSuccess);
+        
+        // Perform the tested function
+        ncclResult_t result = ncclCudaMemcpy<float>(d_dst, d_src, N);
+        
+        ASSERT_EQ(result, ncclSuccess);  // Fixed typo: was ncclSsuccess
+        
+        // Copy result back to host
+        ASSERT_EQ(hipMemcpy(h_dst, d_dst, N * sizeof(float), hipMemcpyDeviceToHost), hipSuccess);
+    
+        // Check correctness
+        for (size_t i = 0; i < N; ++i) {
+            EXPECT_EQ(h_src[i], h_dst[i]) << "Mismatch at index " << i;
+        }
+        // Free memory
+        hipFree(d_src);
+        hipFree(d_dst);
+    
+    }
+    
+} //namespace rccl

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,7 @@ if(BUILD_TESTS)
 
     set(TEST_FIXTURE_SOURCE_FILES
       AltRsmiTests.cpp
+      AllocTests.cpp
       ArgCheckTests.cpp
       common/main_fixtures.cpp
       common/EnvVars.cpp


### PR DESCRIPTION
**Work item:** Internal

**What were the changes?**  
Added Unit tests to increase code coverage for alloc.h
This PR adds one file - test/AllocTests.cpp comprising of 9 tests. 

**Why were the changes made?**  
The test improved code coverage for alloc.h 
|| Function Coverage  | Line Coverage | Region coverage | Branch Coverage |
|-------------| ------------- | ------------- | ------------- | ------------- |
| Default Coverage  |  57.89% (11/19)  |   67.19% (129/192)  |   56.78% (201/354) |   43.48% (60/138)  |
| Updated Coverage |  100.00% (19/19) |   94.79% (182/192) |   72.91% (261/358) |   52.90% (73/138)  |

**How was the outcome achieved?**  
The outcome was achieved by adding a AllocTests.cpp file comprising of the tests. 
The visibility set to default instead of hidden achieved by   https://github.com/ROCm/rccl/pull/1664
Also the code coverage was run on the Unit test binary and not librccl.so

	`/opt/rocm/lib/llvm/bin/llvm-cov show ./rccl-UnitTests --instr-profile=merged.profdata --format=html --output-dir=$WORKDIR/output/rccl_cov_report-lib --project-title=RCCL_Lib_Coverage_Report --object ../librccl.so`


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
