### PR TITLE
Write JSON file to /tmp directory to avoid incorrect write access in …

### DIFF
--- a/test/_RecorderTests.cpp
+++ b/test/_RecorderTests.cpp
@@ -25,7 +25,7 @@ namespace RcclUnitTesting
    * ******************************************************************************************/
   TEST(Recorder, ParseJson)
   {
-    setenv("RCCL_REPLAY_FILE", "test.json", 1);
+    setenv("RCCL_REPLAY_FILE", "/tmp/test.json", 1);
 
     int pid = getpid();
     hipStream_t stream;
@@ -40,7 +40,7 @@ namespace RcclUnitTesting
     char entry[4096];
     //parse the outfile
     std::string filename = "test" + std::to_string(pid) + ".json";
-    std::ifstream fp("test" + std::to_string(pid) + ".json");
+    std::ifstream fp("/tmp/test" + std::to_string(pid) + ".json");
     fp.getline(entry, 4096);
     fp.getline(entry, 4096);
     fp.getline(entry, 4096);


### PR DESCRIPTION
…recorderTest

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
SWDEV-531185

**What were the changes?**  
Change output JSON file path to /tmp to avoid incorrect access errors.

**Why were the changes made?**  
The test fails when it runs from /opt/rocm/bin directory

**How was the outcome achieved?**  


**Additional Documentation:**  
_What else should the reviewer know?_


