### PR TITLE
RCCL Multinode DMA Buffer crash fix

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <new>
 #include <type_traits>
+
 int ncclCudaCompCap();
 
 // PCI Bus ID <-> int64 conversion functions

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <new>
 #include <type_traits>
-
+#include <unistd.h>
 int ncclCudaCompCap();
 
 // PCI Bus ID <-> int64 conversion functions
@@ -545,4 +545,25 @@ T* ncclIntruQueueMpscAbandon(ncclIntruQueueMpsc<T,next>* me) {
     return head;
   }
 }
+/**
+ * @brief function to get page size of the system
+ */
+size_t get_sc_page_size(void);
+
+/**
+ * @brief function to get system's page size aligned memory address and buffersize 
+ *
+ * Given a pointer `ptr` to a buffer of size `bufsize`, this function computes:
+ *   1. A new pointer `aligned_ptr` which points to the start of the page-aligned memory region that includes `ptr`.
+ *   2. A new size `aligned_size` that is the minimum number of bytes (aligned to page size) needed to cover the original buffer from `aligned_ptr`.
+ *
+ * This is useful, for example, when performing operations such as memory mapping or advising memory usage (e.g., with `mmap`, `madvise`, `mlock`, etc.), which often require page-aligned memory ranges.
+ * This function doesn't dereferece the input pointer
+ *
+ * @param[in]  ptr           Pointer to the start of the original memory buffer.
+ * @param[in]  bufsize       Size (in bytes) of the original buffer starting at `ptr`.
+ * @param[out] aligned_ptr   Pointer to a variable that will be set to the aligned base address.
+ * @param[out] aligned_size  Pointer to a variable that will be set to the aligned size.
+ */
+void get_aligned_ptr_and_size(const void *ptr, const size_t bufsize, void **aligned_ptr, size_t *aligned_size);
 #endif

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -17,7 +17,6 @@
 #include <algorithm>
 #include <new>
 #include <type_traits>
-#include <unistd.h>
 int ncclCudaCompCap();
 
 // PCI Bus ID <-> int64 conversion functions

--- a/src/misc/rocmwrap.cc
+++ b/src/misc/rocmwrap.cc
@@ -100,12 +100,7 @@ static void initOnceFunc() {
     //goto error;
   //}
 
-  /* DMA-BUF support */
-  //ROCm support
-  if (ncclParamDmaBufEnable() == 0 ) {
-    INFO(NCCL_INIT, "Dmabuf feature disabled without NCCL_DMABUF_ENABLE=1");
-    goto error;
-  }
+  
   res = pfn_hsa_system_get_info((hsa_system_info_t) 0x204, &dmaBufSupport);
   if (res != HSA_STATUS_SUCCESS || !dmaBufSupport) {
     INFO(NCCL_INIT, "Current version of ROCm does not support dmabuf feature.");
@@ -155,14 +150,17 @@ static void initOnceFunc() {
       else goto error;
     }
   }
-
   /*
    * Required to initialize the ROCr Driver.
    * Multiple calls of hsa_init() will return immediately
    * without making any relevant change
    */
   pfn_hsa_init();
-
+  /* DMA-BUF support */
+  //ROCm support
+  if (ncclParamDmaBufEnable() == 0 ) {
+    WARN("Dmabuf feature disabled without NCCL_DMABUF_ENABLE=1");
+  }
   initResult = ncclSuccess;
   return;
 

--- a/src/misc/rocmwrap.cc
+++ b/src/misc/rocmwrap.cc
@@ -100,7 +100,12 @@ static void initOnceFunc() {
     //goto error;
   //}
 
-  
+  /* DMA-BUF support */
+  //ROCm support
+  if (ncclParamDmaBufEnable() == 0 ) {
+    INFO(NCCL_INIT, "Dmabuf feature disabled without NCCL_DMABUF_ENABLE=1");
+    goto error;
+  }
   res = pfn_hsa_system_get_info((hsa_system_info_t) 0x204, &dmaBufSupport);
   if (res != HSA_STATUS_SUCCESS || !dmaBufSupport) {
     INFO(NCCL_INIT, "Current version of ROCm does not support dmabuf feature.");
@@ -156,11 +161,7 @@ static void initOnceFunc() {
    * without making any relevant change
    */
   pfn_hsa_init();
-  /* DMA-BUF support */
-  //ROCm support
-  if (ncclParamDmaBufEnable() == 0 ) {
-    WARN("Dmabuf feature disabled without NCCL_DMABUF_ENABLE=1");
-  }
+
   initResult = ncclSuccess;
   return;
 

--- a/src/misc/rocmwrap.cc
+++ b/src/misc/rocmwrap.cc
@@ -155,7 +155,7 @@ static void initOnceFunc() {
       else goto error;
     }
   }
-  
+
   /*
    * Required to initialize the ROCr Driver.
    * Multiple calls of hsa_init() will return immediately

--- a/src/misc/rocmwrap.cc
+++ b/src/misc/rocmwrap.cc
@@ -155,6 +155,7 @@ static void initOnceFunc() {
       else goto error;
     }
   }
+  
   /*
    * Required to initialize the ROCr Driver.
    * Multiple calls of hsa_init() will return immediately

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -8,7 +8,7 @@
 #include "core.h"
 
 #include "nvmlwrap.h"
-
+#include <unistd.h>
 #include <stdlib.h>
 
 // Get current Compute Capability

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -289,3 +289,23 @@ void ncclMemoryStackDestruct(struct ncclMemoryStack* me) {
     h = h1;
   }
 }
+
+size_t get_sc_page_size() {
+  static size_t cached_page_size = 0;
+  size_t ps = __atomic_load_n(&cached_page_size,__ATOMIC_RELAXED);
+  if (ps == 0) {
+      ps = (size_t)sysconf(_SC_PAGESIZE);
+      __atomic_store_n(&cached_page_size, ps,__ATOMIC_RELAXED);
+  }
+  return ps;
+}
+
+void get_aligned_ptr_and_size(const void *ptr, const size_t bufsize, void **aligned_ptr, size_t *aligned_size)
+{
+  if (!aligned_ptr || !aligned_size) return;
+  const size_t page_size = get_sc_page_size();
+  uintptr_t aligned_ptr_local = (uintptr_t)ptr & ~(page_size - 1);
+  size_t local_offset = (size_t)((uintptr_t)ptr - aligned_ptr_local);
+  *aligned_size = (bufsize + local_offset + page_size - 1) & ~(page_size - 1);
+  *aligned_ptr = (void *)aligned_ptr_local;
+}

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -300,8 +300,7 @@ size_t get_sc_page_size() {
   return ps;
 }
 
-void get_aligned_ptr_and_size(const void *ptr, const size_t bufsize, void **aligned_ptr, size_t *aligned_size)
-{
+void get_aligned_ptr_and_size(const void *ptr, const size_t bufsize, void **aligned_ptr, size_t *aligned_size) {
   if (!aligned_ptr || !aligned_size) return;
   const size_t page_size = get_sc_page_size();
   uintptr_t aligned_ptr_local = (uintptr_t)ptr & ~(page_size - 1);

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -1688,9 +1688,9 @@ ib_recv:
     NCCLCHECKGOTO(ncclIbRtsQp(qp->qp), ret, fail);
   }
 
-  rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || ncclIbDmaBufSupport(lComm->dev) == ncclSuccess)
-                            && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;
-  useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);               
+  useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);
+  rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || useDmaBuf)
+                            && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;              
   for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
     rCommDev = rComm->devs + i;
     ibDev = ncclIbDevs + rCommDev->base.ibDevN;

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -1707,7 +1707,6 @@ ib_recv:
 #else
         NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), nullptr, hipDeviceMallocFinegrained), ret, fail);
 #endif
-        //NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
         uint64_t export_offset = 0;
         void *aligned_ptr = NULL;
         size_t aligned_size = 0;

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -1706,7 +1706,14 @@ ib_recv:
 #else
         NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), nullptr, hipDeviceMallocFinegrained), ret, fail);
 #endif
-        NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+        //NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+        int dmabuf_fd = -1;
+        uint64_t export_offset = 0;
+        void *aligned_ptr = NULL;
+        size_t aligned_size = 0;
+        get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int) /*devicebuffersize*/, &aligned_ptr, &aligned_size);
+        hsa_status_t export_status = pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, aligned_size, &dmabuf_fd, &export_offset);
+        NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr,rCommDev->base.pd,export_offset, sizeof(int),(uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/,dmabuf_fd, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
       } else {
         rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
         rCommDev->gpuFlush.gpuMr = nullptr;

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -1621,6 +1621,7 @@ ib_recv:
   struct ncclIbRecvCommDev* rCommDev;
   struct ncclIbDevInfo* remDevInfo;
   struct ncclIbQp* qp;
+  bool useDMABuff; 
 
   mergedDev = ncclIbMergedDevs + lComm->dev;
   rComm->base.nRemDevs = remMeta.ndevs;
@@ -1688,7 +1689,7 @@ ib_recv:
 
   rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || ncclIbDmaBufSupport(lComm->dev) == ncclSuccess)
                             && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;
-
+  useDMABuff  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);               
   for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
     rCommDev = rComm->devs + i;
     ibDev = ncclIbDevs + rCommDev->base.ibDevN;
@@ -1707,16 +1708,25 @@ ib_recv:
 #else
         NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), nullptr, hipDeviceMallocFinegrained), ret, fail);
 #endif
-        uint64_t export_offset = 0;
-        void *aligned_ptr = NULL;
-        size_t aligned_size = 0;
-        get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int) /*devicebuffersize*/, &aligned_ptr, &aligned_size);
-        hsa_status_t export_status = pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, aligned_size, &rCommDev->gpuFlush.dmabuf_fd, &export_offset);
-        if(rCommDev->gpuFlush.dmabuf_fd < 0 || export_status != HSA_STATUS_SUCCESS){
-          WARN("Failed to export DMA BUF");
-          goto fail;
+        if (useDMABuff)
+        {
+          uint64_t export_offset = 0;
+          void *aligned_ptr = NULL;
+          size_t aligned_size = 0;
+          get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int) /*devicebuffersize*/, &aligned_ptr, &aligned_size);
+          hsa_status_t export_status = pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, aligned_size, &rCommDev->gpuFlush.dmabuf_fd, &export_offset);
+          if (rCommDev->gpuFlush.dmabuf_fd < 0 || export_status != HSA_STATUS_SUCCESS)
+          {
+            WARN("Failed to export DMA BUF");
+            goto fail;
+          }
+          NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, export_offset, sizeof(int), (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/, rCommDev->gpuFlush.dmabuf_fd, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);
         }
-        NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr,rCommDev->base.pd,export_offset, sizeof(int),(uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/,rCommDev->gpuFlush.dmabuf_fd, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+        else
+        {
+          rCommDev->gpuFlush.dmabuf_fd = -1;
+          NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);
+        }
       } else {
         rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
         rCommDev->gpuFlush.gpuMr = nullptr;

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -1071,6 +1071,7 @@ struct ncclIbGpuFlush {
   int* gpuFlushGpuMem;
   struct ibv_sge sge;
   struct ncclIbQp qp;
+  int dmabuf_fd;
 };
 
 struct ncclIbRemFifo {
@@ -1707,16 +1708,20 @@ ib_recv:
         NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), nullptr, hipDeviceMallocFinegrained), ret, fail);
 #endif
         //NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
-        int dmabuf_fd = -1;
         uint64_t export_offset = 0;
         void *aligned_ptr = NULL;
         size_t aligned_size = 0;
         get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int) /*devicebuffersize*/, &aligned_ptr, &aligned_size);
-        hsa_status_t export_status = pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, aligned_size, &dmabuf_fd, &export_offset);
-        NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr,rCommDev->base.pd,export_offset, sizeof(int),(uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/,dmabuf_fd, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+        hsa_status_t export_status = pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, aligned_size, &rCommDev->gpuFlush.dmabuf_fd, &export_offset);
+        if(rCommDev->gpuFlush.dmabuf_fd < 0 || export_status != HSA_STATUS_SUCCESS){
+          WARN("Failed to export DMA BUF");
+          goto fail;
+        }
+        NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr,rCommDev->base.pd,export_offset, sizeof(int),(uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/,rCommDev->gpuFlush.dmabuf_fd, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
       } else {
         rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
         rCommDev->gpuFlush.gpuMr = nullptr;
+        rCommDev->gpuFlush.dmabuf_fd = -1;
       }
       NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.hostMr, rCommDev->base.pd, &rComm->gpuFlushHostMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE), ret, fail);
       rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
@@ -2453,6 +2458,7 @@ ncclResult_t ncclIbCloseRecv(void* recvComm) {
           commDev->gpuFlush.gpuFlushGpuMem = nullptr;
           if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
           commDev->gpuFlush.gpuMr = nullptr;
+          if(commDev->gpuFlush.dmabuf_fd > 0) { close(commDev->gpuFlush.dmabuf_fd);}
         }
         if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
         if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -793,7 +793,8 @@ static void ibDmaBufSupportInitOnce(){
   ncclIbDev* ibDev = ncclIbDevs + mergedDev->vProps.devs[0];
   struct ibv_pd* pd;
   struct ibv_context* ctx = ibDev->context;
-  rocmLibraryInit();
+  res = rocmLibraryInit();
+  if (res != ncclSuccess) goto failure;
   NCCLCHECKGOTO(wrap_ibv_alloc_pd(&pd, ctx), res, failure);
   // Test kernel DMA-BUF support with a dummy call (fd=-1)
   (void)wrap_direct_ibv_reg_dmabuf_mr(pd, 0ULL /*offset*/, 0ULL /*len*/, 0ULL /*iova*/, -1 /*fd*/, 0 /*flags*/);
@@ -1621,7 +1622,7 @@ ib_recv:
   struct ncclIbRecvCommDev* rCommDev;
   struct ncclIbDevInfo* remDevInfo;
   struct ncclIbQp* qp;
-  bool useDMABuff; 
+  bool useDmaBuf; 
 
   mergedDev = ncclIbMergedDevs + lComm->dev;
   rComm->base.nRemDevs = remMeta.ndevs;
@@ -1689,7 +1690,7 @@ ib_recv:
 
   rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || ncclIbDmaBufSupport(lComm->dev) == ncclSuccess)
                             && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;
-  useDMABuff  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);               
+  useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);               
   for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
     rCommDev = rComm->devs + i;
     ibDev = ncclIbDevs + rCommDev->base.ibDevN;
@@ -1708,7 +1709,7 @@ ib_recv:
 #else
         NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), nullptr, hipDeviceMallocFinegrained), ret, fail);
 #endif
-        if (useDMABuff)
+        if (useDmaBuf)
         {
           uint64_t export_offset = 0;
           void *aligned_ptr = NULL;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal"

**What were the changes?**  
wrap_ibv_reg_dmabuf_mr is used instead of wrap_ibv_reg_mr when applicable

**Why were the changes made?**  
To address Multi-node RCCL fail when using DMABuf with RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING=1

**How was the outcome achieved?**  


**Additional Documentation:**  
a new field is added in struct ncclIbGpuFlush to handle file descriptor opening / closing . This will have effect on size of ncclIbRecvCommDev

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes NO
  - any changes impact library users, and/or NO
  - any changes impact any other ROCm library. NO
