### PR TITLE
Detect if HSA_NO_SCRATCH_RECLAIM is set after initEnv()

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -140,15 +140,6 @@ static pthread_once_t initOnceControl = PTHREAD_ONCE_INIT;
 static void initOnceFunc() {
   initEnv();
   initGdrCopy();
-  char* hsaScratchEnv = getenv("HSA_NO_SCRATCH_RECLAIM");
-  int hipRuntimeVersion = 0;
-  // hipVer is an integer e.g., "6.2.41133" -> 60241133
-  CUDACHECKGOTO(hipRuntimeGetVersion(&hipRuntimeVersion), initResult, exit);
-  if ((hsaScratchEnv && hsaScratchEnv== "1") || hipRuntimeVersion >= 64000000){
-    INFO(NCCL_INIT, "HSA_NO_SCRATCH_RECLAIM : %s, hipVer:%d", hsaScratchEnv, hipRuntimeVersion);
-  }else{
-    WARN("HSA_NO_SCRATCH_RECLAIM is not set with rocm older than 6.4, this has perf impact!");
-  }
   // Always initialize bootstrap network
   NCCLCHECKGOTO(bootstrapNetInit(), initResult, exit);
 
@@ -191,6 +182,15 @@ static ncclResult_t ncclInit() {
         WARN("Missing \"HSA_FORCE_FINE_GRAIN_PCIE=1\" from environment which can lead to low RCCL performance, system instablity or hang!");
 #endif
     }
+  const char* hsaScratchEnv = getenv("HSA_NO_SCRATCH_RECLAIM");
+  int hipRuntimeVersion = 0;
+  // hipVer is an integer e.g., 6.2.41133 -> 60241134
+  CUDACHECK(hipRuntimeGetVersion(&hipRuntimeVersion));
+  if ((hsaScratchEnv && strcmp(hsaScratchEnv,"1") == 0) || hipRuntimeVersion >= 64000000){
+    INFO(NCCL_INIT, "HSA_NO_SCRATCH_RECLAIM : %s, hipVer:%d", hsaScratchEnv, hipRuntimeVersion);
+  }else{
+    WARN("HSA_NO_SCRATCH_RECLAIM is not set with rocm older than 6.4,, rocm ver:%d", hipRuntimeVersion);
+  }
   pthread_once(&initOnceControl, initOnceFunc);
   return initResult;
 }

--- a/src/init.cc
+++ b/src/init.cc
@@ -184,9 +184,9 @@ static ncclResult_t ncclInit() {
     }
   const char* hsaScratchEnv = getenv("HSA_NO_SCRATCH_RECLAIM");
   int hipRuntimeVersion = 0;
-  // hipVer is an integer e.g., 6.2.41133 -> 60241134
+  // hipVer is an integer e.g., 6.2.41133 -> 60241133
   CUDACHECK(hipRuntimeGetVersion(&hipRuntimeVersion));
-  if ((hsaScratchEnv && strcmp(hsaScratchEnv,"1") == 0) || hipRuntimeVersion >= 64000000){
+  if ((hsaScratchEnv && strcmp(hsaScratchEnv,"1") == 0) || hipRuntimeVersion >= 60400000){
     INFO(NCCL_INIT, "HSA_NO_SCRATCH_RECLAIM : %s, hipVer:%d", hsaScratchEnv, hipRuntimeVersion);
   }else{
     WARN("HSA_NO_SCRATCH_RECLAIM is not set with rocm older than 6.4,, rocm ver:%d", hipRuntimeVersion);

--- a/src/init.cc
+++ b/src/init.cc
@@ -140,6 +140,12 @@ static pthread_once_t initOnceControl = PTHREAD_ONCE_INIT;
 static void initOnceFunc() {
   initEnv();
   initGdrCopy();
+  char* hsaScratchEnv = getenv("HSA_NO_SCRATCH_RECLAIM");
+  if (hsaScratchEnv){
+    INFO(NCCL_INIT, "HSA_NO_SCRATCH_RECLAIM : %s", hsaScratchEnv);
+  }else{
+    WARN("HSA_NO_SCRATCH_RECLAIM is not set. HSA scratch reclaim will be enabled with perf overhead with rocm<6.4!");
+  }
   // Always initialize bootstrap network
   NCCLCHECKGOTO(bootstrapNetInit(), initResult, exit);
 

--- a/src/init.cc
+++ b/src/init.cc
@@ -186,9 +186,7 @@ static ncclResult_t ncclInit() {
   int hipRuntimeVersion = 0;
   // hipVer is an integer e.g., 6.2.41133 -> 60241133
   CUDACHECK(hipRuntimeGetVersion(&hipRuntimeVersion));
-  if ((hsaScratchEnv && strcmp(hsaScratchEnv,"1") == 0) || hipRuntimeVersion >= 60400000){
-    INFO(NCCL_INIT, "HSA_NO_SCRATCH_RECLAIM : %s, hipVer:%d", hsaScratchEnv, hipRuntimeVersion);
-  }else{
+  if ((!hsaScratchEnv || strcmp(hsaScratchEnv,"1") != 0) && hipRuntimeVersion < 60400000){
     WARN("HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid RCCL perf hit for rocm older than 6.4,, rocm ver:%d", hipRuntimeVersion);
   }
   pthread_once(&initOnceControl, initOnceFunc);

--- a/src/init.cc
+++ b/src/init.cc
@@ -189,7 +189,7 @@ static ncclResult_t ncclInit() {
   if ((hsaScratchEnv && strcmp(hsaScratchEnv,"1") == 0) || hipRuntimeVersion >= 60400000){
     INFO(NCCL_INIT, "HSA_NO_SCRATCH_RECLAIM : %s, hipVer:%d", hsaScratchEnv, hipRuntimeVersion);
   }else{
-    WARN("HSA_NO_SCRATCH_RECLAIM is not set with rocm older than 6.4,, rocm ver:%d", hipRuntimeVersion);
+    WARN("HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid RCCL perf hit for rocm older than 6.4,, rocm ver:%d", hipRuntimeVersion);
   }
   pthread_once(&initOnceControl, initOnceFunc);
   return initResult;

--- a/src/init.cc
+++ b/src/init.cc
@@ -141,10 +141,13 @@ static void initOnceFunc() {
   initEnv();
   initGdrCopy();
   char* hsaScratchEnv = getenv("HSA_NO_SCRATCH_RECLAIM");
-  if (hsaScratchEnv){
-    INFO(NCCL_INIT, "HSA_NO_SCRATCH_RECLAIM : %s", hsaScratchEnv);
+  int hipRuntimeVersion = 0;
+  // hipVer is an integer e.g., "6.2.41133" -> 60241133
+  CUDACHECKGOTO(hipRuntimeGetVersion(&hipRuntimeVersion), initResult, exit);
+  if ((hsaScratchEnv && hsaScratchEnv== "1") || hipRuntimeVersion >= 64000000){
+    INFO(NCCL_INIT, "HSA_NO_SCRATCH_RECLAIM : %s, hipVer:%d", hsaScratchEnv, hipRuntimeVersion);
   }else{
-    WARN("HSA_NO_SCRATCH_RECLAIM is not set. HSA scratch reclaim will be enabled with perf overhead with rocm<6.4!");
+    WARN("HSA_NO_SCRATCH_RECLAIM is not set with rocm older than 6.4, this has perf impact!");
   }
   // Always initialize bootstrap network
   NCCLCHECKGOTO(bootstrapNetInit(), initResult, exit);


### PR DESCRIPTION
For rocm older than 6.4, we need to set HSA_NO_SCRATCH_RECLAIM=1 to use the LL128 protocol.
Since Env is set outside of RCCL, adding the logging inside rccl lib to detect whether its set during runtime.

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
