### PR TITLE
Fix when more than 64 channels are used for multi-collective group calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 ## Unreleased - RCCL 2.24.3 for ROCm 6.5.0
 
-### Fixed
-* Resolved issue when using more than 64 channels when multiple collectives are used in the same `ncclGroup()` call.
+### Resolved issues
+* Resolved an issue when using more than 64 channels when multiple collectives are used in the same `ncclGroup()` call.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 ## Unreleased - RCCL 2.24.3 for ROCm 6.5.0
 
+### Fixed
+* Resolved issue when using more than 64 channels when multiple collectives are used in the same `ncclGroup()` call.
+
 ### Added
 
 * Added new GPU target `gfx950`.
@@ -11,10 +14,6 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 ### Changed
 
 * Compatibility with NCCL 2.24.3
-
-### Known issue
-
-* Using more than 64 channels can cause a segmentation fault when multiple collectives are used in the same `ncclGroup()` call.
 
 ## Unreleased - RCCL 2.23.4 for ROCm 6.4.1
 


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal

**What were the changes?**  
Fixing how kernel arguments are arranged when more than 64 channels are used.

**Why were the changes made?**  
The original code would incorrectly assign some batches to the wrong channel, which would result in potential memory faults.

**How was the outcome achieved?**  
The original code iterated over each set of 64 channels at a time, including additional batch items, instead of iterating over all of them first, then dealing with additional batch items.

**Additional Documentation:**  
None

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
