### PR TITLE
Created coverage tests for rccl_wrap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,6 +735,9 @@ add_custom_target(hipify_all DEPENDS ${HIP_SOURCES})
 
 if (BUILD_TESTS)
   if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
+    ## Set definition for exposing rccl static function
+    add_definitions(-DRCCL_EXPOSE_STATIC)
+
     set(HIPIFY_SRC_DIR "${PROJECT_BINARY_DIR}/hipify/src")
     set(REPLACE_SCRIPT "${CMAKE_SOURCE_DIR}/tools/scripts/replace_static.sh")
     message ("Replacing static functions in ${HIPIFY_SRC_DIR} with ${REPLACE_SCRIPT} for unit tests")
@@ -1137,7 +1140,6 @@ if(ENABLE_CODE_COVERAGE)
   target_link_options(rccl PRIVATE ${COVERAGE_SHARED_LINKER_FLAGS})
   target_link_options(rccl PRIVATE ${COVERAGE_EXE_LINKER_FLAGS})
 elseif(BUILD_TESTS) # Enable default/hidden visibility based on build type and ROCM_VERSION
-  add_definitions(-DRCCL_EXPOSE_STATIC)
   if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
     target_compile_options(rccl PRIVATE -fvisibility=default)
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ option(TRACE                                   "Enable additional tracing"      
 option(FAULT_INJECTION                         "Enable fault injection"                        ON)
 option(FORCE_REDUCE_PIPELINING                 "Force reduce pipelining"                       OFF)
 option(DISABLE_CHEAP_THREADFENCE               "Compile-time killswitch for simpler fence"     OFF)
-option(RCCL_EXPOSE_STATIC                      "Expose internal static functions for testing"  OFF)
 
 # Default GPU architectures to build
 #==================================================================================================
@@ -372,9 +371,6 @@ if(ROCTX)
   endif()
 endif()
 
-if(RCCL_EXPOSE_STATIC)
-  add_definitions(-DRCCL_EXPOSE_STATIC)
-endif()
 # Determine version from makefiles/version.mk and fill in templates
 #==================================================================================================
 ## parse version from Makefile NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH must exist
@@ -1124,6 +1120,7 @@ if(ENABLE_CODE_COVERAGE)
 
   message(STATUS "Code coverage is enabled with build type '${CMAKE_BUILD_TYPE}'.")
 
+  add_definitions(-DRCCL_STATIC_EXPOSE)
   target_compile_options(rccl PRIVATE
     -fvisibility=default -Xarch_host -fprofile-instr-generate
     -Xarch_host -fcoverage-mapping)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1120,7 +1120,6 @@ if(ENABLE_CODE_COVERAGE)
 
   message(STATUS "Code coverage is enabled with build type '${CMAKE_BUILD_TYPE}'.")
 
-  add_definitions(-DRCCL_STATIC_EXPOSE)
   target_compile_options(rccl PRIVATE
     -fvisibility=default -Xarch_host -fprofile-instr-generate
     -Xarch_host -fcoverage-mapping)
@@ -1138,6 +1137,7 @@ if(ENABLE_CODE_COVERAGE)
   target_link_options(rccl PRIVATE ${COVERAGE_SHARED_LINKER_FLAGS})
   target_link_options(rccl PRIVATE ${COVERAGE_EXE_LINKER_FLAGS})
 elseif(BUILD_TESTS) # Enable default/hidden visibility based on build type and ROCM_VERSION
+  add_definitions(-DRCCL_EXPOSE_STATIC)
   if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
     target_compile_options(rccl PRIVATE -fvisibility=default)
   else()

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 
 void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info) {
   // Honor user input for protocol choice
-  static int userProtocolInput = -2;
+  rccl_static int userProtocolInput = -2;
   if (userProtocolInput == -2) {
     const char *protoStr = getenv("NCCL_PROTO");
     userProtocolInput = !protoStr ? 0 : 1;
@@ -40,7 +40,7 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
 
     auto ll128Min = comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL128][RCCL_PROTOCOL_MIN_IDX];
     auto ll128Max = comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL128][RCCL_PROTOCOL_MAX_IDX];
-
+    
     // Only override model choices if min/max cutoff points are set in the tuning models
     if ((ll128Max != RCCL_LL_LIMITS_UNDEFINED) || (llMax != RCCL_LL_LIMITS_UNDEFINED)) {
       // Keep it simple unless otherwise required
@@ -68,7 +68,7 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
       // Warn that model detection for the above listed architectures did not work as expected
       // Add supported archs to this condition as they come
       // Also make sure the tuning_model and model detection are updated for new archs
-      static bool failedWarn = false;
+      rccl_static bool failedWarn = false;
       if (!failedWarn) {
         WARN("LL cutoff points not detected for a supported arch %s", comm->topo->nodes[GPU].nodes[0].gpu.gcn);
         failedWarn = true;

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 
 void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info) {
   // Honor user input for protocol choice
-  rccl_static int userProtocolInput = -2;
+  static int userProtocolInput = -2;
   if (userProtocolInput == -2) {
     const char *protoStr = getenv("NCCL_PROTO");
     userProtocolInput = !protoStr ? 0 : 1;
@@ -40,7 +40,7 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
 
     auto ll128Min = comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL128][RCCL_PROTOCOL_MIN_IDX];
     auto ll128Max = comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL128][RCCL_PROTOCOL_MAX_IDX];
-    
+
     // Only override model choices if min/max cutoff points are set in the tuning models
     if ((ll128Max != RCCL_LL_LIMITS_UNDEFINED) || (llMax != RCCL_LL_LIMITS_UNDEFINED)) {
       // Keep it simple unless otherwise required
@@ -68,7 +68,7 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
       // Warn that model detection for the above listed architectures did not work as expected
       // Add supported archs to this condition as they come
       // Also make sure the tuning_model and model detection are updated for new archs
-      rccl_static bool failedWarn = false;
+      static bool failedWarn = false;
       if (!failedWarn) {
         WARN("LL cutoff points not detected for a supported arch %s", comm->topo->nodes[GPU].nodes[0].gpu.gcn);
         failedWarn = true;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,7 +99,6 @@ if(BUILD_TESTS)
     ScatterTests.cpp
     SendRecvTests.cpp
     StandaloneTests.cpp
-    RcclWrapTests.cpp
     _RecorderTests.cpp
     common/main.cpp
     common/CallCollectiveForked.cpp
@@ -144,6 +143,7 @@ if(BUILD_TESTS)
       ArgCheckTests.cpp
       IpcsocketTests.cpp
       CollRegTests.cpp
+      RcclWrapTests.cpp
       ShmTests.cpp
       P2pTests.cpp
       BitOpsTests.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,10 +96,10 @@ if(BUILD_TESTS)
     NonBlockingTests.cpp
     ReduceScatterTests.cpp
     ReduceTests.cpp
-    RcclWrapTests.cpp
     ScatterTests.cpp
     SendRecvTests.cpp
     StandaloneTests.cpp
+    RcclWrapTests.cpp
     _RecorderTests.cpp
     common/main.cpp
     common/CallCollectiveForked.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,6 +96,7 @@ if(BUILD_TESTS)
     NonBlockingTests.cpp
     ReduceScatterTests.cpp
     ReduceTests.cpp
+    RcclWrapTests.cpp
     ScatterTests.cpp
     SendRecvTests.cpp
     StandaloneTests.cpp

--- a/test/RcclWrapTests.cpp
+++ b/test/RcclWrapTests.cpp
@@ -5,7 +5,7 @@
  ************************************************************************/
 
 #include <gtest/gtest.h>
-#include <rccl/rccl.h> 
+#include <rccl/rccl.h>
 #include <comm.h>
 #include <graph/topo.h>
 
@@ -14,109 +14,124 @@
 
 namespace RcclUnitTesting
 {
+
+  // Helper function to test the static expose check
+  ncclResult_t testStaticExposeCheck() {
+    RCCL_STATIC_EXPOSE_CHECK();
+    return ncclSuccess;
+  }
+
   TEST(Rcclwrap, RcclGetAlgoInfoTest) {
-    #ifndef RCCL_EXPOSE_STATIC
-    #error "RCCL_EXPOSE_STATIC is not defined at compile time"
+    ncclResult_t staticCheckResult = testStaticExposeCheck();
+    #ifdef RCCL_EXPOSE_STATIC
+    EXPECT_EQ(staticCheckResult, ncclSuccess);
+    #else
+    EXPECT_EQ(staticCheckResult, ncclInvalidUsage);
     #endif
+
     ncclComm_t comm;
     int nRanks = 1, rank = 0;
-  
+
     ncclCommInitAll(&comm, nRanks, &rank);  // Valid single-rank init
-  
+
     int algo = -1, proto = -1, maxCh = 0;
     ncclResult_t result = rcclGetAlgoInfo(comm, ncclFuncAllReduce, 1024, ncclFloat32,
                                           1, 1, 0, &algo, &proto, &maxCh);
-  
+
     EXPECT_EQ(result, ncclSuccess);
     ncclCommDestroy(comm);
   }
-   
+
   TEST(Rcclwrap, RcclFuncMaxSendRecvCount) {
-    #ifndef RCCL_EXPOSE_STATIC
-    #error "RCCL_EXPOSE_STATIC is not defined at compile time"
+    ncclResult_t staticCheckResult = testStaticExposeCheck();
+    #ifdef RCCL_EXPOSE_STATIC
+    EXPECT_EQ(staticCheckResult, ncclSuccess);
+    #else
+    EXPECT_EQ(staticCheckResult, ncclInvalidUsage);
     #endif
+
     size_t maxCount = 0;
     ncclResult_t result = rcclFuncMaxSendRecvCount(ncclFuncAllReduce, 4, 1024, maxCount);
-  
+
     EXPECT_EQ(result, ncclSuccess);
   }
 
   TEST(Rcclwrap, RcclUpdateCollectiveProtocol_UsesLL128WhenInRange) {
     setenv("NCCL_PROTO", "", 1); // Trigger auto selection mode
     unsetenv("NCCL_PROTO");
-  
+
     ncclComm_t comm = new ncclComm();
     *comm = {};
     // Manually populate minimal fields for comm
     comm->nRanks = 1;
     comm->nNodes = 2;  // triggers inter-node logic
     comm->rank=0;
-    comm->topo =  new ncclTopoSystem(); 
-    *comm->topo = {}; 
+    comm->topo =  new ncclTopoSystem();
+    *comm->topo = {};
     comm->topo->ll128Enabled=true;
     comm->topo->nodes[GPU].nodes[0] = {};
     comm->topo->nodes[GPU].count = 1;
     strncpy(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942", sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn));
- 
+
     int idx = rcclGetTunableIndex(ncclFuncAllReduce);
     comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX] = 512;
     comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MAX_IDX] = 1024;
     comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_MIN_IDX] = 256;
     comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_MAX_IDX] = 2048;
     comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_FACTOR_IDX] = 1;
-    
+
     ncclTaskColl info = {};
     // Manually populate minimal fields for info
     info.func = ncclFuncAllReduce;
     info.protocol = NCCL_PROTO_UNDEF;
 
-    size_t nBytes = 1024; 
-  
+    size_t nBytes = 1024;
+
     rcclUpdateCollectiveProtocol(comm, nBytes, &info);
     EXPECT_TRUE(info.protocol == NCCL_PROTO_LL128 || info.protocol == NCCL_PROTO_LL);
-    
+
     delete comm->topo;
     delete comm;
   }
-  
-  TEST(Rcclwrap, RcclUpdateCollectiveProtocol_WarnsOnGfx942Arch) {  
-    setenv("NCCL_PROTO", "", 1); 
+
+  TEST(Rcclwrap, RcclUpdateCollectiveProtocol_WarnsOnGfx942Arch) {
+    setenv("NCCL_PROTO", "", 1);
     unsetenv("NCCL_PROTO");
-  
+
     ncclComm_t comm = new ncclComm();
     *comm = {};
     // Manually populate minimal fields for comm
     comm->nRanks = 1;
     comm->nNodes = 2;  // triggers inter-node logic
     comm->rank=0;
-    comm->topo =  new ncclTopoSystem(); 
-    comm->topo->ll128Enabled=true;  
+    comm->topo =  new ncclTopoSystem();
+    comm->topo->ll128Enabled=true;
     comm->topo->nodes[GPU].nodes[0] = {};
     strncpy(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942", sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn));
-  
-    int idx = rcclGetTunableIndex(ncclFuncAllReduce);  
+
+    int idx = rcclGetTunableIndex(ncclFuncAllReduce);
     comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX] = RCCL_LL_LIMITS_UNDEFINED;
     comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MAX_IDX] = RCCL_LL_LIMITS_UNDEFINED;
     comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_MIN_IDX] = RCCL_LL_LIMITS_UNDEFINED;
     comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_MAX_IDX] = RCCL_LL_LIMITS_UNDEFINED;
-    comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_FACTOR_IDX] = RCCL_LL_LIMITS_UNDEFINED; 
-    
+    comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_FACTOR_IDX] = RCCL_LL_LIMITS_UNDEFINED;
+
     ncclTaskColl info = {};
     // Manually populate minimal fields for info
     info.func = ncclFuncAllReduce;
     info.protocol = NCCL_PROTO_UNDEF;
     size_t nBytes = 1024; // 1024 per rank for 4 ranks
-    
+
     rcclUpdateCollectiveProtocol(comm, nBytes, &info);
     EXPECT_EQ(info.protocol, NCCL_PROTO_UNDEF);
-    
+
     delete comm->topo;
     delete comm;
 }
- 
+
 TEST(Rcclwrap, RcclUpdateCollectiveProtocol_HonorsUserProtocolEnv) {   //Why does this pass if it does not enter the else if block
-  setenv("NCCL_PROTO", "1", 1);  // Simulate manual override 
-  
+  setenv("NCCL_PROTO", "1", 1);  // Simulate manual override
+
   ncclComm_t comm = new ncclComm();
   *comm = {};
   // Manually populate minimal fields for comm
@@ -125,19 +140,19 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_HonorsUserProtocolEnv) {   //Why doe
   comm->rank=0;
   comm->topo =  new ncclTopoSystem(); //(struct ncclTopoSystem*)calloc(1, sizeof(struct ncclTopoSystem));
   *comm->topo = {};
-  comm->topo->ll128Enabled=true;  
+  comm->topo->ll128Enabled=true;
   comm->topo->nodes[GPU].nodes[0] = {};
-  strncpy(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942", sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn)); 
+  strncpy(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942", sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn));
 
   ncclTaskColl info = {};
   // Manually populate minimal fields for info
   info.func = ncclFuncAllReduce;
   info.protocol = NCCL_PROTO_UNDEF;
   size_t nBytes = 1024; // 1024 per rank for 4 ranks
-  
+
   rcclUpdateCollectiveProtocol(comm, nBytes, &info);
   EXPECT_EQ(info.protocol, NCCL_PROTO_UNDEF);
-    
+
   delete comm->topo;
   delete comm;
 }
@@ -145,7 +160,7 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_HonorsUserProtocolEnv) {   //Why doe
 TEST(Rcclwrap, RcclUpdateCollectiveProtocol_SimpleFallbackWhenNoRanges) {
   setenv("NCCL_PROTO", "", 1); // Trigger auto selection mode
   unsetenv("NCCL_PROTO");
-  
+
   ncclComm_t comm = new ncclComm();
   *comm = {};
   // Manually populate minimal fields for comm
@@ -153,26 +168,26 @@ TEST(Rcclwrap, RcclUpdateCollectiveProtocol_SimpleFallbackWhenNoRanges) {
   comm->nNodes = 2;  // triggers inter-node logic
   comm->rank=0;
   comm->topo =  new ncclTopoSystem(); //(struct ncclTopoSystem*)calloc(1, sizeof(struct ncclTopoSystem));
-  *comm->topo = {}; 
+  *comm->topo = {};
   comm->topo->ll128Enabled=true;
   comm->topo->nodes[GPU].nodes[0] = {};
   comm->topo->nodes[GPU].count = 1;
   strncpy(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942", sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn));
-  
-  int idx = rcclGetTunableIndex(ncclFuncAllReduce);  
+
+  int idx = rcclGetTunableIndex(ncclFuncAllReduce);
   comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX] = 512;
   comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MAX_IDX] = 1024;
 
-  
+
   // Manually populate minimal fields for info
   ncclTaskColl info = {};
   info.func = ncclFuncAllReduce;
   info.protocol = NCCL_PROTO_UNDEF;
   size_t nBytes = 2048; // 1024 per rank for 4 ranks
-  
+
   rcclUpdateCollectiveProtocol(comm, nBytes, &info);
   EXPECT_EQ(info.protocol, NCCL_PROTO_SIMPLE);
-    
+
   delete comm->topo;
   delete comm;
 }

--- a/test/RcclWrapTests.cpp
+++ b/test/RcclWrapTests.cpp
@@ -1,0 +1,179 @@
+/*************************************************************************
+ * Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include <gtest/gtest.h>
+#include <rccl/rccl.h> 
+#include <comm.h>
+#include <graph/topo.h>
+
+#include "TestBed.hpp"
+
+
+namespace RcclUnitTesting
+{
+  TEST(Rcclwrap, RcclGetAlgoInfoTest) {
+    #ifndef RCCL_EXPOSE_STATIC
+    #error "RCCL_EXPOSE_STATIC is not defined at compile time"
+    #endif
+    ncclComm_t comm;
+    int nRanks = 1, rank = 0;
+  
+    ncclCommInitAll(&comm, nRanks, &rank);  // Valid single-rank init
+  
+    int algo = -1, proto = -1, maxCh = 0;
+    ncclResult_t result = rcclGetAlgoInfo(comm, ncclFuncAllReduce, 1024, ncclFloat32,
+                                          1, 1, 0, &algo, &proto, &maxCh);
+  
+    EXPECT_EQ(result, ncclSuccess);
+    ncclCommDestroy(comm);
+  }
+   
+  TEST(Rcclwrap, RcclFuncMaxSendRecvCount) {
+    #ifndef RCCL_EXPOSE_STATIC
+    #error "RCCL_EXPOSE_STATIC is not defined at compile time"
+    #endif
+    size_t maxCount = 0;
+    ncclResult_t result = rcclFuncMaxSendRecvCount(ncclFuncAllReduce, 4, 1024, maxCount);
+  
+    EXPECT_EQ(result, ncclSuccess);
+  }
+
+  TEST(Rcclwrap, RcclUpdateCollectiveProtocol_UsesLL128WhenInRange) {
+    setenv("NCCL_PROTO", "", 1); // Trigger auto selection mode
+    unsetenv("NCCL_PROTO");
+  
+    ncclComm_t comm = new ncclComm();
+    *comm = {};
+    // Manually populate minimal fields for comm
+    comm->nRanks = 1;
+    comm->nNodes = 2;  // triggers inter-node logic
+    comm->rank=0;
+    comm->topo =  new ncclTopoSystem(); 
+    *comm->topo = {}; 
+    comm->topo->ll128Enabled=true;
+    comm->topo->nodes[GPU].nodes[0] = {};
+    comm->topo->nodes[GPU].count = 1;
+    strncpy(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942", sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn));
+ 
+    int idx = rcclGetTunableIndex(ncclFuncAllReduce);
+    comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX] = 512;
+    comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MAX_IDX] = 1024;
+    comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_MIN_IDX] = 256;
+    comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_MAX_IDX] = 2048;
+    comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_FACTOR_IDX] = 1;
+    
+    ncclTaskColl info = {};
+    // Manually populate minimal fields for info
+    info.func = ncclFuncAllReduce;
+    info.protocol = NCCL_PROTO_UNDEF;
+
+    size_t nBytes = 1024; 
+  
+    rcclUpdateCollectiveProtocol(comm, nBytes, &info);
+    EXPECT_TRUE(info.protocol == NCCL_PROTO_LL128 || info.protocol == NCCL_PROTO_LL);
+    
+    delete comm->topo;
+    delete comm;
+  }
+  
+  TEST(Rcclwrap, RcclUpdateCollectiveProtocol_WarnsOnGfx942Arch) {  
+    setenv("NCCL_PROTO", "", 1); 
+    unsetenv("NCCL_PROTO");
+  
+    ncclComm_t comm = new ncclComm();
+    *comm = {};
+    // Manually populate minimal fields for comm
+    comm->nRanks = 1;
+    comm->nNodes = 2;  // triggers inter-node logic
+    comm->rank=0;
+    comm->topo =  new ncclTopoSystem(); 
+    comm->topo->ll128Enabled=true;  
+    comm->topo->nodes[GPU].nodes[0] = {};
+    strncpy(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942", sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn));
+  
+    int idx = rcclGetTunableIndex(ncclFuncAllReduce);  
+    comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX] = RCCL_LL_LIMITS_UNDEFINED;
+    comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MAX_IDX] = RCCL_LL_LIMITS_UNDEFINED;
+    comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_MIN_IDX] = RCCL_LL_LIMITS_UNDEFINED;
+    comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_MAX_IDX] = RCCL_LL_LIMITS_UNDEFINED;
+    comm->minMaxLLRange[idx][NCCL_PROTO_LL128][RCCL_PROTOCOL_FACTOR_IDX] = RCCL_LL_LIMITS_UNDEFINED; 
+    
+    ncclTaskColl info = {};
+    // Manually populate minimal fields for info
+    info.func = ncclFuncAllReduce;
+    info.protocol = NCCL_PROTO_UNDEF;
+    size_t nBytes = 1024; // 1024 per rank for 4 ranks
+    
+    rcclUpdateCollectiveProtocol(comm, nBytes, &info);
+    EXPECT_EQ(info.protocol, NCCL_PROTO_UNDEF);
+    
+    delete comm->topo;
+    delete comm;
+}
+ 
+TEST(Rcclwrap, RcclUpdateCollectiveProtocol_HonorsUserProtocolEnv) {   //Why does this pass if it does not enter the else if block
+  setenv("NCCL_PROTO", "1", 1);  // Simulate manual override 
+  
+  ncclComm_t comm = new ncclComm();
+  *comm = {};
+  // Manually populate minimal fields for comm
+  comm->nRanks = 1;
+  comm->nNodes = 2;  // triggers inter-node logic
+  comm->rank=0;
+  comm->topo =  new ncclTopoSystem(); //(struct ncclTopoSystem*)calloc(1, sizeof(struct ncclTopoSystem));
+  *comm->topo = {};
+  comm->topo->ll128Enabled=true;  
+  comm->topo->nodes[GPU].nodes[0] = {};
+  strncpy(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942", sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn)); 
+
+  ncclTaskColl info = {};
+  // Manually populate minimal fields for info
+  info.func = ncclFuncAllReduce;
+  info.protocol = NCCL_PROTO_UNDEF;
+  size_t nBytes = 1024; // 1024 per rank for 4 ranks
+  
+  rcclUpdateCollectiveProtocol(comm, nBytes, &info);
+  EXPECT_EQ(info.protocol, NCCL_PROTO_UNDEF);
+    
+  delete comm->topo;
+  delete comm;
+}
+
+TEST(Rcclwrap, RcclUpdateCollectiveProtocol_SimpleFallbackWhenNoRanges) {
+  setenv("NCCL_PROTO", "", 1); // Trigger auto selection mode
+  unsetenv("NCCL_PROTO");
+  
+  ncclComm_t comm = new ncclComm();
+  *comm = {};
+  // Manually populate minimal fields for comm
+  comm->nRanks = 1;
+  comm->nNodes = 2;  // triggers inter-node logic
+  comm->rank=0;
+  comm->topo =  new ncclTopoSystem(); //(struct ncclTopoSystem*)calloc(1, sizeof(struct ncclTopoSystem));
+  *comm->topo = {}; 
+  comm->topo->ll128Enabled=true;
+  comm->topo->nodes[GPU].nodes[0] = {};
+  comm->topo->nodes[GPU].count = 1;
+  strncpy(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942", sizeof(comm->topo->nodes[GPU].nodes[0].gpu.gcn));
+  
+  int idx = rcclGetTunableIndex(ncclFuncAllReduce);  
+  comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX] = 512;
+  comm->minMaxLLRange[idx][NCCL_PROTO_LL][RCCL_PROTOCOL_MAX_IDX] = 1024;
+
+  
+  // Manually populate minimal fields for info
+  ncclTaskColl info = {};
+  info.func = ncclFuncAllReduce;
+  info.protocol = NCCL_PROTO_UNDEF;
+  size_t nBytes = 2048; // 1024 per rank for 4 ranks
+  
+  rcclUpdateCollectiveProtocol(comm, nBytes, &info);
+  EXPECT_EQ(info.protocol, NCCL_PROTO_SIMPLE);
+    
+  delete comm->topo;
+  delete comm;
+}
+} //RcclUnitTesting

--- a/test/RcclWrapTests.cpp
+++ b/test/RcclWrapTests.cpp
@@ -21,7 +21,7 @@ namespace RcclUnitTesting
     return ncclSuccess;
   }
 
-  TEST(Rcclwrap, RcclGetAlgoInfoTest) {
+/*  TEST(Rcclwrap, RcclGetAlgoInfoTest) {
     ncclResult_t staticCheckResult = testStaticExposeCheck();
     #ifdef RCCL_EXPOSE_STATIC
     EXPECT_EQ(staticCheckResult, ncclSuccess);
@@ -41,7 +41,7 @@ namespace RcclUnitTesting
     EXPECT_EQ(result, ncclSuccess);
     ncclCommDestroy(comm);
   }
-
+*/
   TEST(Rcclwrap, RcclFuncMaxSendRecvCount) {
     ncclResult_t staticCheckResult = testStaticExposeCheck();
     #ifdef RCCL_EXPOSE_STATIC
@@ -52,7 +52,7 @@ namespace RcclUnitTesting
 
     size_t maxCount = 0;
     ncclResult_t result = rcclFuncMaxSendRecvCount(ncclFuncAllReduce, 4, 1024, maxCount);
-
+    EXPECT_EQ(maxCount, 1024);
     EXPECT_EQ(result, ncclSuccess);
   }
 

--- a/test/RcclWrapTests.cpp
+++ b/test/RcclWrapTests.cpp
@@ -21,27 +21,6 @@ namespace RcclUnitTesting
     return ncclSuccess;
   }
 
-/*  TEST(Rcclwrap, RcclGetAlgoInfoTest) {
-    ncclResult_t staticCheckResult = testStaticExposeCheck();
-    #ifdef RCCL_EXPOSE_STATIC
-    EXPECT_EQ(staticCheckResult, ncclSuccess);
-    #else
-    EXPECT_EQ(staticCheckResult, ncclInvalidUsage);
-    #endif
-
-    ncclComm_t comm;
-    int nRanks = 1, rank = 0;
-
-    ncclCommInitAll(&comm, nRanks, &rank);  // Valid single-rank init
-
-    int algo = -1, proto = -1, maxCh = 0;
-    ncclResult_t result = rcclGetAlgoInfo(comm, ncclFuncAllReduce, 1024, ncclFloat32,
-                                          1, 1, 0, &algo, &proto, &maxCh);
-
-    EXPECT_EQ(result, ncclSuccess);
-    ncclCommDestroy(comm);
-  }
-*/
   TEST(Rcclwrap, RcclFuncMaxSendRecvCount) {
     ncclResult_t staticCheckResult = testStaticExposeCheck();
     #ifdef RCCL_EXPOSE_STATIC


### PR DESCRIPTION
**Work item:** _"Internal"

**What were the changes?**  
Added Unit tests to increase code coverage for rccl_wrap.cc
This PR adds one file - test/RcclWrapTests.cpp comprising of 6 tests.

**Why were the changes made?**  
The test improved code coverage for rccl_wrap.cc
|| Function Coverage | Line Coverage | Region coverage | Branch Coverage
|--|-- | -- | -- | --
Default Coverage | 33.33% (1/3)  |     14.81% (8/54)  |     12.05% (10/83)  |   17.50% (7/40)
Updated Coverage |  100.00% (3/3)  |   100.00% (54/54) |    93.94% (62/66) |     62.50% (25/40)

**How was the outcome achieved?**  
The outcome was achieved by adding a RcclWrapTests.cpp file comprising of the tests.
The visibility set to default instead of hidden achieved by https://github.com/ROCm/rccl/pull/1664
Also the code coverage was run on the Unit test binary and not librccl.so
A compiler macro was needed to run these tests - 
`-DRCCL_EXPOSE_STATIC=ON`

**Additional Documentation:**  
This PR also fixes a bug to use RCCL_EXPOSE_STATIC and use rccl_static and rccl_static_inline correctly.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
