### PR TITLE
fix improper mscclpp patch reverse order

### DIFF
--- a/cmake/MSCCLPP.cmake
+++ b/cmake/MSCCLPP.cmake
@@ -151,16 +151,15 @@ if(ENABLE_MSCCLPP)
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
         )
 
-    
-	execute_process(
-	    COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/no-cache.patch
-	    WORKING_DIRECTORY ${MSCCLPP_SOURCE}
-	)
-
 	execute_process(
             COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/device-flag.patch
             WORKING_DIRECTORY ${MSCCLPP_SOURCE}
     )
+
+    execute_process(
+	    COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/no-cache.patch
+	    WORKING_DIRECTORY ${MSCCLPP_SOURCE}
+	)
     
 	execute_process(
 	    COMMAND git apply --reverse ${CMAKE_CURRENT_SOURCE_DIR}/ext-src/reg-fix.patch


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Update mscclpp patch revert order for two patches.

**Why were the changes made?**  
During rebase for mscclpp patch, the revert order of two patches was applied incorrectly.

**How was the outcome achieved?**  
updated cmake.MSCCLPP 

**Additional Documentation:**  

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
