### PR TITLE
Change WARP_SIZE to a constant to get it to compile with ROCm 7.0.

### DIFF
--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -62,7 +62,10 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
 
   if (maxStackSize) *maxStackSize = 0;
   int carveout = ncclParamL1SharedMemoryCarveout();
-  int ncclMaxSharedMem = ncclShmemDynamicSize(cudaArch);
+
+  int warpsize;
+  CUDACHECK(hipDeviceGetAttribute(&warpsize, hipDeviceAttributeWarpSize, comm->cudaDev));
+  int ncclMaxSharedMem = ncclShmemDynamicSize(cudaArch, warpsize);
 
   for (int k=0; k < KernelCount; k++) {
     void* fn = ncclKerns[k].kernelFn;
@@ -1516,7 +1519,7 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
   void* sym = plan->kernelFn;
   dim3 grid = {(unsigned)nChannels, 1, 1};
   dim3 block = {(unsigned)plan->threadPerBlock, 1, 1};
-  int smem = ncclShmemDynamicSize(comm->cudaArch);
+  int smem = ncclShmemDynamicSize(comm->cudaArch, comm->warpSize);
   cudaStream_t launchStream = planner->streams->stream;
   void* extra[] = {plan->kernelArgs, &plan->kernelArgsSize};
 

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -634,8 +634,8 @@ __host__ __device__ constexpr int ncclShmemScratchWarpSize(int cudaArch = NCCL_C
 }
 
 // The amount of dynamic shmem per block
-__host__ __device__ constexpr int ncclShmemDynamicSize(int cudaArch = NCCL_CUDA_ARCH) {
-  return cudaArch < 700 ? 0 : ncclShmemScratchWarpSize(cudaArch)*(NCCL_MAX_NTHREADS/WARP_SIZE);
+__host__ __device__ constexpr int ncclShmemDynamicSize(int cudaArch = NCCL_CUDA_ARCH, int warpsize = WARP_SIZE) {
+  return cudaArch < 700 ? 0 : ncclShmemScratchWarpSize(cudaArch)*(NCCL_MAX_NTHREADS/warpsize);
 }
 
 // Host-side table of kernel function pointers.

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -67,7 +67,12 @@ union ncclLLFifoLine {
   int4 i4;
 };
 
-#define WARP_SIZE warpSize
+#if defined(__GFX9__)
+#define WARP_SIZE 64
+#else
+#define WARP_SIZE 32
+#endif
+
 #define MAXCHANNELS 128
 #define CHANNEL_LIMIT 16
 #define NCCL_MAX_LOCAL_RANKS 72


### PR DESCRIPTION
## Details

`warpSize` has been deprecated in upcoming ROCm 7.0.
(https://rocm.docs.amd.com/en/latest/about/release-notes.html#amdgpu-wavefront-size-compiler-macro-deprecation). 

We are reverting to use our custom constant instead of HIP `warpSize` constant. This change is consistent with guidance from ROCm.

**What were the changes?**  
Change `WARP_SIZE` constant.

**Why were the changes made?**  
RCCL will not compile with new ROCm without this change.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
