### PR TITLE
Updated CHANGELOG for LL128 support for gfx942 in 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Fixed unit test failures in tests ending with `ManagedMem` and `ManagedMemGraph` suffixes.
 * Fixed the known issue "When splitting a communicator using `ncclCommSplit` in some GPU configurations, MSCCL initialization can cause a segmentation fault." with a design change to use `comm` instead of `rank` for `mscclStatus`. The Global map for `comm` to `mscclStatus` is still not thread safe but should be explicitly handled by mutexes for read writes. This is tested for correctness, but there is a plan to use a thread-safe map data structure in upcoming changes.
 
-
 ### Added
 
 * Added new GPU target `gfx950`.
@@ -18,12 +17,19 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Set a default of 112 channels for a single node with `8 * gfx950`
 * Added MSCCL support for multinode gfx942/gfx950 (i.e., 16 and 32 GPUs). To enable, set the
   environment variable `RCCL_MSCCL_FORCE_ENABLE=1`. Max message size for MSCCL AllGather usage is `12292 * sizeof(datatype) * nGPUs`.
+* Added support for the LL128 protocol on gfx942.
 
 ### Changed
 
 * Compatibility with NCCL 2.23.4
 * Compatibility with NCCL 2.24.3
 * Compatibility with NCCL 2.25.1
+
+## RCCL 2.22.3 for ROCm 6.4.2
+
+### Added
+
+* Added support for the LL128 protocol on gfx942.
 
 ## RCCL 2.22.3 for ROCm 6.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Set a default of 112 channels for a single node with `8 * gfx950`
 * Added MSCCL support for multinode gfx942/gfx950 (i.e., 16 and 32 GPUs). To enable, set the
   environment variable `RCCL_MSCCL_FORCE_ENABLE=1`. Max message size for MSCCL AllGather usage is `12292 * sizeof(datatype) * nGPUs`.
-* Added support for the LL128 protocol on gfx942.
 
 ### Changed
 


### PR DESCRIPTION
Also ported 6.4.2 section
