### PR TITLE
Increase default WORK_FIFO size to accommodate larger alltoall.

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -517,7 +517,7 @@ NCCL_PARAM(AggChannelSize, "AGG_CHANNEL_SIZE", -2);
 NCCL_PARAM(DisableGraphHelper, "GRAPH_HELPER_DISABLE", 0);
 // GDRCOPY support: FIFO_ENABLE when enabled locates a workFifo in CUDA memory
 NCCL_PARAM(GdrCopyFifoEnable, "GDRCOPY_FIFO_ENABLE", 1);
-#define NCCL_WORK_FIFO_BYTES_DEFAULT (1<<20)
+#define NCCL_WORK_FIFO_BYTES_DEFAULT (1<<22)
 NCCL_PARAM(WorkFifoBytes, "WORK_FIFO_BYTES", NCCL_WORK_FIFO_BYTES_DEFAULT);
 NCCL_PARAM(WorkArgsBytes, "WORK_ARGS_BYTES", INT64_MAX);
 enum ncclLaunchMode ncclParamLaunchMode;


### PR DESCRIPTION
## Details

**Work item:** SWDEV-535912

**What were the changes?**  
Increase default size of WORK_FIFO to accommodate larger alltoall. 

**Why were the changes made?**  
We have seen multiple cases of rccl-tests alltoall_perf hang with 7 nodes + 8 NICs per node due to RCCL runs out of work FIFO and hang. 

**How was the outcome achieved?**  
Increase the default size.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
