### PR TITLE
Change WARP_SIZE to constant 64.

### DIFF
--- a/src/include/device.h
+++ b/src/include/device.h
@@ -67,7 +67,7 @@ union ncclLLFifoLine {
   int4 i4;
 };
 
-#define WARP_SIZE warpSize
+#define WARP_SIZE 64
 #define MAXCHANNELS 128
 #define CHANNEL_LIMIT 16
 #define NCCL_MAX_LOCAL_RANKS 72


### PR DESCRIPTION
## Details
This is another legitimate approach for #1720. I am opening this PR to do extended CI testing.

**Work item:** Internal

**What were the changes?**  
Change `warpSize` to a constant.

**Why were the changes made?**  
ROCm 7.0 does not define `warpSize`.

**How was the outcome achieved?**  
One line modification.

**Additional Documentation:**  
This is another approach.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
