### PR TITLE
Compiler Warning Fixes 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -832,6 +832,7 @@ target_compile_options(rccl PRIVATE -Werror=uninitialized)
 target_compile_options(rccl PRIVATE -Werror=sometimes-uninitialized)
 target_compile_options(rccl PRIVATE -Wall)
 target_compile_options(rccl PRIVATE -Wno-format-nonliteral)
+target_compile_options(rccl PRIVATE -Wno-unused-function)
 target_compile_options(rccl PRIVATE -fgpu-rdc)               # Generate relocatable device code (required for extern __shared__)
 target_compile_options(rccl PRIVATE -fvisibility=hidden)     # Set symbol visibility to hidden by default
 if (HAVE_KERNARG_PRELOAD)

--- a/src/channel.cc
+++ b/src/channel.cc
@@ -6,7 +6,6 @@
 
 #include "channel.h"
 #include "param.h"
-#include "gdrwrap.h"
 #include "transport.h"
 
 ncclResult_t initChannel(struct ncclComm* comm, int channelId) {

--- a/src/device/all_gather.h
+++ b/src/device/all_gather.h
@@ -16,7 +16,10 @@ namespace {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #endif
+#if defined(ENABLE_NPKIT)
     const int bid = ncclShmem.channelId - work->channelLo;
+    int npKitCtxIdx = bid;
+#endif
     ncclRing *ring = &ncclShmem.channel.ring;
     const int *ringRanks = ring->userRanks;
     const int nranks = ncclShmem.comm.nRanks;
@@ -27,9 +30,6 @@ namespace {
     int nelem;
     int rankDest;
 
-#if defined(ENABLE_NPKIT)
-    int npKitCtxIdx = bid;
-#endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {

--- a/src/device/all_reduce.h
+++ b/src/device/all_reduce.h
@@ -23,7 +23,10 @@ namespace {
     ncclRing *ring = &ncclShmem.channel.ring;
     int ringIx = ring->index;
     const int nranks = ncclShmem.comm.nRanks;
+#if defined(ENABLE_NPKIT)
     const int bid = ncclShmem.channelId - work->channelLo;
+    int npKitCtxIdx = bid;
+#endif
     ssize_t size;
     ssize_t gridOffset;
     ssize_t channelCount;
@@ -34,9 +37,6 @@ namespace {
     int nelem;
     int chunk;
 
-#if defined(ENABLE_NPKIT)
-    int npKitCtxIdx = bid;
-#endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {
@@ -216,7 +216,10 @@ namespace {
 #else
   __device__ __attribute__((noinline)) void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #endif
+#if defined(ENABLE_NPKIT)
     const int bid = ncclShmem.channelId - work->channelLo;
+    int npKitCtxIdx = bid;
+#endif
     ncclTree *tree = &ncclShmem.channel.tree;
     size_t size;
     size_t gridOffset;
@@ -226,9 +229,6 @@ namespace {
     size_t offset;
     int nelem;
 
-#if defined(ENABLE_NPKIT)
-    int npKitCtxIdx = bid;
-#endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {
@@ -364,7 +364,9 @@ namespace {
 #else
   __device__ __attribute__((noinline)) void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #endif
+#if defined(ENABLE_NPKIT)
     const int bid = ncclShmem.channelId - work->channelLo;
+#endif
     ncclTree *tree = &ncclShmem.channel.tree;
     size_t size;
     size_t gridOffset;

--- a/src/device/broadcast.h
+++ b/src/device/broadcast.h
@@ -15,7 +15,10 @@ namespace {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #endif
+#if defined(ENABLE_NPKIT)
     const int bid = ncclShmem.channelId - work->channelLo;
+    int npKitCtxIdx = bid;
+#endif
     ncclRing *ring = &ncclShmem.channel.ring;
     const int rank = ring->userRanks[0];
     const int nextRank = ring->userRanks[1];
@@ -30,9 +33,6 @@ namespace {
     int workNthreads;
     bool isNetOffload = work->isOneRPN && work->netRegUsed;
 
-#if defined(ENABLE_NPKIT)
-    int npKitCtxIdx = bid;
-#endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {

--- a/src/device/primitives.h
+++ b/src/device/primitives.h
@@ -25,7 +25,7 @@
   if (nthreads == NCCL_MAX_NTHREADS) { \
     __THREAD_FENCE; __builtin_amdgcn_s_barrier(); \
   } else { \
-    const int w = threadIdx.x/WARP_SIZE; \
+    /**const int w = threadIdx.x/WARP_SIZE //unused var**/; \
     const int wid = threadIdx.x%WARP_SIZE; \
     if (wid == 0) { \
       barrier_next += nthreads/WARP_SIZE; \

--- a/src/device/prims_ll.h
+++ b/src/device/prims_ll.h
@@ -141,7 +141,6 @@ private:
   __device__ uint64_t readLL(int offset, int i) {
     union ncclLLFifoLine* src = recvPtr(i) + offset;
     uint32_t flag = recvFlag(i);
-    uint32_t data1, flag1, data2, flag2;
     int spins = 0;
 
 #if defined(ENABLE_NPKIT) && (defined(ENABLE_NPKIT_EVENT_PRIM_LL_DATA_PROCESS_ENTRY) && defined(ENABLE_NPKIT_EVENT_PRIM_LL_DATA_PROCESS_EXIT) || defined(ENABLE_NPKIT_PRIM_COLLECT_DATA_PROCESS_TIME))
@@ -168,6 +167,7 @@ private:
     } while ((i4.flag1 != flag) || (i4.flag2 != flag));
     uint64_t val64 = (uint64_t)(i4.data1) + (((uint64_t)i4.data2) << 32);
 #else
+    uint32_t data1, flag1, data2, flag2;
     do {
       asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(data1), "=r"(flag1), "=r"(data2), "=r"(flag2) : "l"(&src->i4) : "memory");
 #if defined(ENABLE_NPKIT) && (defined(ENABLE_NPKIT_EVENT_PRIM_LL_DATA_PROCESS_ENTRY) && defined(ENABLE_NPKIT_EVENT_PRIM_LL_DATA_PROCESS_EXIT) || defined(ENABLE_NPKIT_PRIM_COLLECT_DATA_PROCESS_TIME))

--- a/src/device/prims_ll128.h
+++ b/src/device/prims_ll128.h
@@ -496,10 +496,9 @@ public:
       bool ipcReg = false, bool netReg = false, int stepSize_ = 0
     ):
     redOp(redOpArg),
-    tid(tid), nthreads(nthreads), wid(tid%WARP_SIZE), warp(tid/WARP_SIZE),
-    warpInBlock(threadIdx.x/WARP_SIZE),
-    flagThread((tid%4)==3), group(group),
-    stepSize(ncclShmem.comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS/sizeof(uint64_t)) {
+    tid(tid), nthreads(nthreads), wid(tid%WARP_SIZE), 
+    stepSize(ncclShmem.comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS/sizeof(uint64_t)), 
+    warp(tid/WARP_SIZE), warpInBlock(threadIdx.x/WARP_SIZE), flagThread((tid%4)==3), group(group) {
     auto *channel = &ncclShmem.channel;
     barriers = &ncclShmem.groups[group].barrier;
     int nrecv=0, nsend=0;

--- a/src/device/prims_simple.h
+++ b/src/device/prims_simple.h
@@ -739,8 +739,8 @@ public:
       uint8_t connIndexRecv = 0, uint8_t connIndexSend = 0, struct ncclDevWorkColl* collWork = nullptr,
       struct ncclDevWorkP2p* p2pWork = nullptr, int stepSize_ = 0, int mode = primsModeDefault
     ):
-    tid(tid), nthreads(nthreads), tidInBlock(threadIdx.x), group(group),
-    stepSize(stepSize_ == 0 ? ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_) {
+    tid(tid), tidInBlock(threadIdx.x), nthreads(nthreads),
+    stepSize(stepSize_ == 0 ? ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_), group(group) {
 
     // For send operations, we need an extra warp to overlap the threadfence and the copy
     barriers = &ncclShmem.groups[group].barrier;

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -8,7 +8,7 @@
 
 #include "enqueue.h"
 #include "argcheck.h"
-#include "coll_net.h"
+// #include "coll_net.h"
 #include "graph/topo.h"
 #include <hip/hip_runtime.h>
 #include <hip/hip_ext.h>

--- a/src/graph/connect.cc
+++ b/src/graph/connect.cc
@@ -119,14 +119,13 @@ bool isRankHere(const char* s, int start, int end, int rank) {
 
 ncclResult_t ncclTreeBasePostset(struct ncclComm* comm,
     struct ncclTopoGraph* treeGraph) {
-  int x=0, y=0;
+  int x=0;
   for (int i=0;  treeGraph->treeBase[i][0]!=0; i++)
   {
     x=i+1;
   }
   if( treeGraph->treeBase[0][0] == 0) return ncclSuccess;
   int nChannels = comm->nChannels;
-  int localRanks = comm->topo->nodes[GPU].count;
   //new tree
   for (int c=0; c<nChannels; c++) { // in here
     int buff = c%x;
@@ -260,10 +259,10 @@ static ncclResult_t connectRings(struct ncclComm* comm, int* ringRecv, int* ring
   return ncclSuccess;
 }
 
-static ncclResult_t getIndexes(int* ranks, int* indexes, int nNodes) {
- for (int n=0; n<nNodes; n++) indexes[n] = ranks[n];
- return ncclSuccess;
-}
+// static ncclResult_t getIndexes(int* ranks, int* indexes, int nNodes) {
+//  for (int n=0; n<nNodes; n++) indexes[n] = ranks[n];
+//  return ncclSuccess;
+// }
 
 static ncclResult_t setTreeUp(struct ncclTree* tree, int* indexes, int u) {
   if (u == -1) return ncclSuccess;
@@ -436,6 +435,7 @@ static ncclResult_t connectCollNet(struct ncclComm* comm, struct ncclTopoGraph* 
   return ncclSuccess;
 }
 
+#if CUDART_VERSION >= 12010
 static ncclResult_t connectNvls(struct ncclComm* comm, int* nvlsHeads, int nHeads) {
   int headRank = -1;
   if (nHeads == 0) {
@@ -515,6 +515,7 @@ static ncclResult_t connectNvls(struct ncclComm* comm, int* nvlsHeads, int nHead
       nvls1->treeDown[0], nvls1->treeDown[1], nvls1->treeDown[2], comm->rank, nvls1->treeUp);
   return ncclSuccess;
 }
+#endif
 
 // Legacy naming
 NCCL_PARAM(MinNrings, "MIN_NRINGS", -2);

--- a/src/graph/paths.cc
+++ b/src/graph/paths.cc
@@ -286,14 +286,17 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
     // GPU not found, we can't use p2p.
     return ncclSuccess;
   }
-
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   int intermediateIndex = -1;
+#endif
   // Set intermediate GPU rank, if routing through an intermediate GPU.
   struct ncclTopoLinkList* path = gpu1->paths[GPU]+g2;
   if (path->count == 2) {
     struct ncclTopoNode* intermediateNode = path->list[0]->remNode;
     if (intermediateNode->type == GPU) {
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)     
       intermediateIndex = intermediateNode - system->nodes[GPU].nodes;
+#endif
       if (intermediateRank) *intermediateRank = intermediateNode->gpu.rank;
     }
   }
@@ -324,8 +327,7 @@ compare:
   // Compute the PCI distance and compare with the p2pLevel.
   if (path->type <= p2pLevel) *p2p = 1;
 
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-#else
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   if (*p2p == 1) {
     // NCCL_IGNORE_DISABLED_P2P=2 is used by unit tests that don't want to
     // validate against NVML at all since they are pretending to be on other hw.
@@ -500,10 +502,10 @@ ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int netDev, int rank, int*
   int g;
   struct ncclTopoSystem* system = comm->topo;
   NCCLCHECK(ncclTopoRankToIndex(system, rank, &g));
-  struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   *flush = 1;
 #else
+  struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
   // Flush is required on Ampere and earlier
   if (gpu->gpu.cudaCompCap >= 90) *flush = 0;
 #endif

--- a/src/graph/rome_models.cc
+++ b/src/graph/rome_models.cc
@@ -1338,7 +1338,6 @@ end:
  */
 ncclResult_t parseGraphLight(const char* str, struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int* gpu_map) {
   int gpus[NCCL_TOPO_MAX_NODES]; //transcribe/change according to gpu_map
-  int nChannels = 0;
   int gpu = 0;
   int offset = 0;
   int start_offset = offset;
@@ -1348,7 +1347,7 @@ ncclResult_t parseGraphLight(const char* str, struct ncclTopoSystem* system, str
   }
   int status = 0; // 0 : between numbers, 1 : inside number
   int ngpus = system->nodes[GPU].count;
-  int x=0, y=0;
+  int x=0;
   do {
     int digit = str[offset] - '0';
     if (digit >= 0 && digit <= 9) {
@@ -1855,7 +1854,7 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   bool isAlltoall = checkAlltoallWidth(&romeTopo);
   if (!isAlltoall) return ncclSuccess;
 
-  int gcnt = 0;
+  // int gcnt = 0;
   int *g8, n[NCCL_TOPO_MAX_NODES];
   int *all_gpu_permutations = (int *)malloc(TOTAL_PERMUTE_COUNT*NUMA_CPUS*NUMA_GPUS*sizeof(int));
   struct timeval tvs, tve;
@@ -1878,7 +1877,7 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
       }
       if (ngpusPerNuma == 0) continue;
       if (ngpusPerNuma != NUMA_GPUS) break;
-      gcnt++;
+      // gcnt++;
       // init GPU mapping
       for (int k = 0; k < ngpus; k++) {
         if (romeTopo.gpuNuma[k] != j) continue;
@@ -1927,7 +1926,7 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
     if (p < TOTAL_PERMUTE_COUNT) break;
   }
   gettimeofday(&tve, NULL);
-  float t = (tve.tv_sec - tvs.tv_sec)*1E3 + (tve.tv_usec - tvs.tv_usec)/1E3;
+  // float t = (tve.tv_sec - tvs.tv_sec)*1E3 + (tve.tv_usec - tvs.tv_usec)/1E3;
   if (i >= sizeof(romeTopoModels)/sizeof(romeTopoModels[0])) {
     //printf("No solution in %.2fms\n", t);
     return ncclSuccess;
@@ -2033,7 +2032,6 @@ ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* 
   int i;
 
   int ngpus = system->nodes[GPU].count;
-  int ncpus = system->nodes[CPU].count;
   int nnets = system->nodes[NET].count;
 
   // Only support ring and tree graphs
@@ -2127,7 +2125,7 @@ ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* 
     }
   }
   gettimeofday(&tve, NULL);
-  float t = (tve.tv_sec - tvs.tv_sec)*1E3 + (tve.tv_usec - tvs.tv_usec)/1E3;
+  // float t = (tve.tv_sec - tvs.tv_sec)*1E3 + (tve.tv_usec - tvs.tv_usec)/1E3;
   if (i >= sizeof(romeTopoModels)/sizeof(romeTopoModels[0])) {
     //printf("No solution in %.2fms (%d iter)\n", t, time);
     return ncclSuccess;
@@ -2237,7 +2235,7 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   // only match for system with 16 GPUs
   if (ngpus != 16 || ncpus != NUMA_CPUS) return ncclSuccess;
 
-  int gcnt = 0;
+  // int gcnt = 0;
   int *g16, n[NCCL_TOPO_MAX_NODES], rdm[NUMA_GPUS*NUMA_CPUS];
   int *all_gpu_permutations = (int *)malloc(TOTAL_PERMUTE_COUNT*NUMA_CPUS*NUMA_GPUS*sizeof(int));
   struct timeval tvs, tve;
@@ -2258,7 +2256,7 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
       }
       if (ngpusPerNuma == 0) continue;
       if (ngpusPerNuma != NUMA_GPUS) break;
-      gcnt++;
+      // gcnt++;
       // init GPU mapping
       for (int k = 0; k < ngpus; k++) {
         if (romeTopo.gpuNuma[k] != j) continue;
@@ -2313,7 +2311,7 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
     if (p < TOTAL_PERMUTE_COUNT) break;
   }
   gettimeofday(&tve, NULL);
-  float t = (tve.tv_sec - tvs.tv_sec)*1E3 + (tve.tv_usec - tvs.tv_usec)/1E3;
+  // float t = (tve.tv_sec - tvs.tv_sec)*1E3 + (tve.tv_usec - tvs.tv_usec)/1E3;
   if (i >= sizeof(romeTopoModels)/sizeof(romeTopoModels[0])) {
     //printf("No solution in %.2fms\n", t);
     return ncclSuccess;

--- a/src/graph/topo.h
+++ b/src/graph/topo.h
@@ -221,7 +221,7 @@ ncclResult_t ncclTopoGetXmlFromGraphs(int ngraphs, struct ncclTopoGraph** graphs
 
 ncclResult_t ncclTopoGetCompCap(struct ncclTopoSystem* system, int* ccMin, int* ccMax);
 
-static ncclResult_t ncclTopoIdToIndex(struct ncclTopoSystem* system, int type, int64_t id, int* index) {
+inline ncclResult_t ncclTopoIdToIndex(struct ncclTopoSystem* system, int type, int64_t id, int* index) {
   *index = -1;
   for (int i=0; i<system->nodes[type].count; i++) {
     if (system->nodes[type].nodes[i].id == id) {
@@ -232,7 +232,7 @@ static ncclResult_t ncclTopoIdToIndex(struct ncclTopoSystem* system, int type, i
   return ncclInternalError;
 }
 
-static ncclResult_t ncclTopoRankToIndex(struct ncclTopoSystem* system, int rank, int* index) {
+inline ncclResult_t ncclTopoRankToIndex(struct ncclTopoSystem* system, int rank, int* index) {
   *index = -1;
   for (int i=0; i<system->nodes[GPU].count; i++) {
     if (system->nodes[GPU].nodes[i].gpu.rank == rank) {
@@ -243,7 +243,7 @@ static ncclResult_t ncclTopoRankToIndex(struct ncclTopoSystem* system, int rank,
   return ncclInternalError;
 }
 
-static ncclResult_t ncclTopoDevToRank(struct ncclTopoSystem* system, int dev, int* rank) {
+inline ncclResult_t ncclTopoDevToRank(struct ncclTopoSystem* system, int dev, int* rank) {
   *rank = -1;
   for (int i=0; i<system->nodes[GPU].count; i++) {
     if (NCCL_TOPO_ID_SYSTEM_ID(system->nodes[GPU].nodes[i].id) != system->systemId) continue; // Only consider GPUs on our node
@@ -255,7 +255,7 @@ static ncclResult_t ncclTopoDevToRank(struct ncclTopoSystem* system, int dev, in
   return ncclInternalError;
 }
 
-static ncclResult_t ncclTopoIdToNetDev(struct ncclTopoSystem* system, int64_t id, int* netDev) {
+inline ncclResult_t ncclTopoIdToNetDev(struct ncclTopoSystem* system, int64_t id, int* netDev) {
   *netDev = -1;
   for (int i=0; i<system->nodes[NET].count; i++) {
     if (system->nodes[NET].nodes[i].id == id) {
@@ -268,7 +268,7 @@ static ncclResult_t ncclTopoIdToNetDev(struct ncclTopoSystem* system, int64_t id
 }
 
 // Returns XGMI speed in GB/s
-static float ncclTopoXGMISpeed(const char* gcn) {
+inline float ncclTopoXGMISpeed(const char* gcn) {
   if (IsArchMatch(gcn, "gfx90a"))
     return MI200_XGMI_WIDTH;
   else if (IsArchMatch(gcn, "gfx942"))
@@ -280,7 +280,7 @@ static float ncclTopoXGMISpeed(const char* gcn) {
 }
 
 // Returns NVLink bw in GB/s
-static float ncclTopoNVLinkBw(int cudaCompCap) {
+inline float ncclTopoNVLinkBw(int cudaCompCap) {
   return
     cudaCompCap >= 100 ? SM100_NVLINK_BW :
     cudaCompCap >= 90 ? SM90_NVLINK_BW :
@@ -292,10 +292,10 @@ static float ncclTopoNVLinkBw(int cudaCompCap) {
 }
 
 // Mirror bits
-static bool isPow2(int val) {
+inline bool isPow2(int val) {
   return (val & (val-1)) == 0;
 }
-static int mirrorBits(int val, int pow2) {
+inline int mirrorBits(int val, int pow2) {
   int mirror = 0;
   for (int b=1, mb=(pow2>>1); b<pow2; b<<=1, mb>>=1) if (val & b) mirror |= mb;
   return mirror;

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -167,7 +167,7 @@ static struct tuningModel tuning_model_0 {
     { 1.0, 0.8, 0.2, 1.0, 1.0, 0.3, 1.0, 0.1, 0.1, 0.2, 0.2, 0.1, 0.5, 1.0, 0.8, 0.8, 1.0, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, },
   },
 
-  .llProtoRanges = {RCCL_LL_LIMITS_UNDEFINED},
+  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
 };
 
 static struct tuningModel tuning_model_1 {
@@ -199,7 +199,7 @@ static struct tuningModel tuning_model_1 {
     { 0.3, 1.0, 0.3, 0.1, 0.1, 0.1, 0.3, 0.7, 1.0, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.3, 0.5, 0.9, 1.0, 1.0, 1.0, 1.0, },
   },
 
-  .llProtoRanges = {RCCL_LL_LIMITS_UNDEFINED},
+  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
 };
 
 static struct tuningModel tuning_model_2 {
@@ -231,7 +231,7 @@ static struct tuningModel tuning_model_2 {
     { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.4, 0.5, 0.6, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, },
   },
 
-  .llProtoRanges = {RCCL_LL_LIMITS_UNDEFINED},
+  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
 };
 
 static struct tuningModel tuning_model_3 {
@@ -263,7 +263,7 @@ static struct tuningModel tuning_model_3 {
     { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.5, 1.0, 0.1, 0.3, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.3, 0.4, 0.7, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, },
   },
 
-  .llProtoRanges = {RCCL_LL_LIMITS_UNDEFINED},
+  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
 };
 
 static struct tuningModel tuning_model_4 {
@@ -295,7 +295,7 @@ static struct tuningModel tuning_model_4 {
     { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 0.8, 0.5, 0.1, 0.7, 0.2, 0.4, 0.4, 0.6, 0.7, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, },
   },
 
-  .llProtoRanges = {RCCL_LL_LIMITS_UNDEFINED},
+  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
 };
 
 static struct tuningModel tuning_model_5 {

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -352,6 +352,7 @@ static struct tuningModel rcclTuningModel[] = {
 #define HOPPER_COMPCAP_IDX 2
 #define BLACKWELL_COMPCAP_IDX 3
 
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
 // LL128 max BW per channel
 static const double llMaxBws[][3] = {
   /* Volta-N1/Intel-N2/Intel-N4) */ {39.0, 39.0, 20.4},
@@ -378,6 +379,7 @@ static const double perChMaxTreeBws[][3] = {
   /* Hopper (N1/N2/N4) */ {38.7, 41.4, 36.0},
   /* Blackwell (N1/N2/N4) */ {2*38.7, 2*41.4, 2*36.0},
 };
+#endif
 
 NCCL_PARAM(PatEnable, "PAT_ENABLE", 2);
 static int ncclPatEnable(struct ncclComm* comm) {
@@ -426,7 +428,7 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   int nNodes = comm->nNodes;
   int nRanks = comm->nRanks;
   if (nRanks <= 1) return ncclSuccess;
-
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   int compCapIndex = minCompCap >= 100 ? BLACKWELL_COMPCAP_IDX : (minCompCap >= 90 ? HOPPER_COMPCAP_IDX : minCompCap >= 80 ? AMPERE_COMPCAP_IDX : VOLTA_COMPCAP_IDX);
   int index2 = nNodes <= 2 ? nNodes-1 : 2;
   // LL: for single node, we look at GPU type; for multi-node, we look at CPU type
@@ -436,6 +438,7 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   double perChMaxTreeBw = perChMaxTreeBws[compCapIndex][index2];
   double perChMaxRingLL128Bw = perChMaxRingLL128Bws[compCapIndex][index2];
   double perChMaxTreeLL128Bw = perChMaxTreeLL128Bws[compCapIndex][index2];
+#endif
   // De-penalize Tree/Simple latency on Power systems to favor Tree than Ring
   //if (comm->cpuArch == NCCL_TOPO_CPU_ARCH_POWER) hwLat[NCCL_HW_PCI][NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] = hwLat[NCCL_HW_PCI][NCCL_ALGO_RING][NCCL_PROTO_SIMPLE];
   float ppn = (float)nRanks / nNodes;
@@ -760,11 +763,13 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
 
 // Trees are not perfectly sticking to the model for medium sizes. Applying a static correction
 // factor is not ideal but works quite well. Powers of two, 64 B to 256MB.
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
 static float treeCorrectionFactor[NCCL_NUM_PROTOCOLS][23] = {
   { 1.0, 1.0, 1.0, 1.0,  .9,  .8,  .7,  .7,  .7,  .7,  .6,  .5,  .4,  .4,  .5,  .6,  .7,  .8,  .9, 1.0, 1.0, 1.0, 1.0 },
   { 1.0, 1.0, 1.0, 1.0, 1.0,  .9,  .8,  .8,  .8,  .7,  .6,  .6,  .6,  .6,  .6,  .6,  .8,  .9,  .9,  .9,  .9, 1.0, 1.0 },
   {  .9,  .9,  .9,  .9,  .9,  .9,  .9,  .8,  .7,  .6,  .6,  .5,  .5,  .5,  .5,  .6,  .7,  .8,  .7,  .7,  .8,  .9,  .9 }
 };
+#endif
 
 ncclResult_t ncclTopoGetAlgoTime(struct ncclComm* comm, int coll, int algorithm, int protocol, size_t nBytes, int numPipeOps, float* time) {
   float bw = comm->bandwidths[coll][algorithm][protocol];

--- a/src/graph/xml.h
+++ b/src/graph/xml.h
@@ -69,10 +69,10 @@ ncclResult_t ncclTopoGetStrFromSys(const char* path, const char* fileName, char*
 /* Functions  */
 /**************/
 
-static size_t xmlMemSize(int maxNodes) {
+inline size_t xmlMemSize(int maxNodes) {
   return offsetof(struct ncclXml, nodes) + sizeof(struct ncclXmlNode)*maxNodes;
 }
-static ncclResult_t xmlAlloc(struct ncclXml** xml, int maxNodes) {
+inline ncclResult_t xmlAlloc(struct ncclXml** xml, int maxNodes) {
   char* mem;
   NCCLCHECK(ncclCalloc(&mem, xmlMemSize(maxNodes)));
   *xml = (struct ncclXml*)mem;
@@ -80,7 +80,7 @@ static ncclResult_t xmlAlloc(struct ncclXml** xml, int maxNodes) {
   return ncclSuccess;
 }
 
-static ncclResult_t xmlGetAttrIndex(struct ncclXmlNode* node, const char* attrName, int* index) {
+inline ncclResult_t xmlGetAttrIndex(struct ncclXmlNode* node, const char* attrName, int* index) {
   *index = -1;
   const int nAttrs = node->nAttrs;
   for (int a=0; a<nAttrs; a++) {
@@ -92,14 +92,14 @@ static ncclResult_t xmlGetAttrIndex(struct ncclXmlNode* node, const char* attrNa
   return ncclSuccess;
 }
 
-static ncclResult_t xmlGetAttr(struct ncclXmlNode* node, const char* attrName, const char** value) {
+inline ncclResult_t xmlGetAttr(struct ncclXmlNode* node, const char* attrName, const char** value) {
   int index;
   NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
   *value = index == -1 ? NULL : node->attrs[index].value;
   return ncclSuccess;
 }
 
-static ncclResult_t xmlGetAttrStr(struct ncclXmlNode* node, const char* attrName, const char** value) {
+inline ncclResult_t xmlGetAttrStr(struct ncclXmlNode* node, const char* attrName, const char** value) {
   NCCLCHECK(xmlGetAttr(node, attrName, value));
   if (*value == NULL) {
     WARN("Attribute %s of node %s not found", attrName, node->name);
@@ -107,21 +107,21 @@ static ncclResult_t xmlGetAttrStr(struct ncclXmlNode* node, const char* attrName
   }
   return ncclSuccess;
 }
-static ncclResult_t xmlGetAttrInt(struct ncclXmlNode* node, const char* attrName, int* value) {
+inline ncclResult_t xmlGetAttrInt(struct ncclXmlNode* node, const char* attrName, int* value) {
   const char* str;
   NCCLCHECK(xmlGetAttrStr(node, attrName, &str));
   *value = strtol(str, NULL, 0);
   return ncclSuccess;
 }
 
-static ncclResult_t xmlGetAttrIntDefault(struct ncclXmlNode* node, const char* attrName, int* value, int defaultValue) {
+inline ncclResult_t xmlGetAttrIntDefault(struct ncclXmlNode* node, const char* attrName, int* value, int defaultValue) {
   const char* str;
   NCCLCHECK(xmlGetAttr(node, attrName, &str));
   *value = str ? strtol(str, NULL, 0) : defaultValue;
   return ncclSuccess;
 }
 
-static ncclResult_t xmlGetAttrLong(struct ncclXmlNode* node, const char* attrName, int64_t* value) {
+inline ncclResult_t xmlGetAttrLong(struct ncclXmlNode* node, const char* attrName, int64_t* value) {
   const char* str;
   NCCLCHECK(xmlGetAttrStr(node, attrName, &str));
   *value = strtol(str, NULL, 0);
@@ -129,21 +129,21 @@ static ncclResult_t xmlGetAttrLong(struct ncclXmlNode* node, const char* attrNam
 }
 
 
-static ncclResult_t xmlGetAttrFloat(struct ncclXmlNode* node, const char* attrName, float* value) {
+inline ncclResult_t xmlGetAttrFloat(struct ncclXmlNode* node, const char* attrName, float* value) {
   const char* str;
   NCCLCHECK(xmlGetAttrStr(node, attrName, &str));
   *value = strtof(str, NULL);
   return ncclSuccess;
 }
 
-static ncclResult_t xmlGetAttrFloatDefault(struct ncclXmlNode* node, const char* attrName, float* value, float defaultValue) {
+inline ncclResult_t xmlGetAttrFloatDefault(struct ncclXmlNode* node, const char* attrName, float* value, float defaultValue) {
   const char* str;
   NCCLCHECK(xmlGetAttr(node, attrName, &str));
   *value = str ? strtof(str, NULL) : defaultValue;
   return ncclSuccess;
 }
 
-static ncclResult_t xmlFindTag(struct ncclXml* xml, const char* tagName, struct ncclXmlNode** node) {
+inline ncclResult_t xmlFindTag(struct ncclXml* xml, const char* tagName, struct ncclXmlNode** node) {
   *node = NULL;
   for (int i=0; i<xml->maxIndex; i++) {
     struct ncclXmlNode* n = xml->nodes+i;
@@ -155,7 +155,7 @@ static ncclResult_t xmlFindTag(struct ncclXml* xml, const char* tagName, struct 
   return ncclSuccess;
 }
 
-static ncclResult_t xmlFindNextTag(struct ncclXml* xml, const char* tagName, struct ncclXmlNode* prev, struct ncclXmlNode** node) {
+inline ncclResult_t xmlFindNextTag(struct ncclXml* xml, const char* tagName, struct ncclXmlNode* prev, struct ncclXmlNode** node) {
   *node = NULL;
   for (int i=prev-xml->nodes+1; i<xml->maxIndex; i++) {
     struct ncclXmlNode* n = xml->nodes+i;
@@ -167,7 +167,7 @@ static ncclResult_t xmlFindNextTag(struct ncclXml* xml, const char* tagName, str
   return ncclSuccess;
 }
 
-static ncclResult_t xmlFindTagKv(struct ncclXml* xml, const char* tagName, struct ncclXmlNode** node, const char* attrName, const char* attrValue) {
+inline ncclResult_t xmlFindTagKv(struct ncclXml* xml, const char* tagName, struct ncclXmlNode** node, const char* attrName, const char* attrValue) {
   *node = NULL;
   for (int i=0; i<xml->maxIndex; i++) {
     struct ncclXmlNode* n = xml->nodes+i;
@@ -183,7 +183,7 @@ static ncclResult_t xmlFindTagKv(struct ncclXml* xml, const char* tagName, struc
   return ncclSuccess;
 }
 
-static ncclResult_t xmlFindNode(struct ncclXmlNode* parentNode, struct ncclXmlNode* searchNode, struct ncclXmlNode** node) {
+inline ncclResult_t xmlFindNode(struct ncclXmlNode* parentNode, struct ncclXmlNode* searchNode, struct ncclXmlNode** node) {
   *node = NULL;
   // Search for the node at the current level only.
   for (int i=0; i<parentNode->nSubs; i++) {
@@ -206,7 +206,7 @@ static ncclResult_t xmlFindNode(struct ncclXmlNode* parentNode, struct ncclXmlNo
   return ncclSuccess;
 }
 
-static ncclResult_t xmlSetAttr(struct ncclXmlNode* node, const char* attrName, const char* value) {
+inline ncclResult_t xmlSetAttr(struct ncclXmlNode* node, const char* attrName, const char* value) {
   int index;
   NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
   if (index == -1) {
@@ -219,7 +219,7 @@ static ncclResult_t xmlSetAttr(struct ncclXmlNode* node, const char* attrName, c
   return ncclSuccess;
 }
 
-static ncclResult_t xmlPrintNodeRecursive(struct ncclXmlNode* node, const char* name) {
+inline ncclResult_t xmlPrintNodeRecursive(struct ncclXmlNode* node, const char* name) {
   while (node) {
     char line[1024*8];
     int cursor = 0;
@@ -237,7 +237,7 @@ static ncclResult_t xmlPrintNodeRecursive(struct ncclXmlNode* node, const char* 
 }
 
 
-static ncclResult_t xmlSetAttrIfUnset(struct ncclXmlNode* node, const char* attrName, const char* value) {
+inline ncclResult_t xmlSetAttrIfUnset(struct ncclXmlNode* node, const char* attrName, const char* value) {
   int index;
   NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
   if (index != -1) return ncclSuccess;
@@ -249,7 +249,7 @@ static ncclResult_t xmlSetAttrIfUnset(struct ncclXmlNode* node, const char* attr
   return ncclSuccess;
 }
 
-static ncclResult_t xmlSetAttrInt(struct ncclXmlNode* node, const char* attrName, const int value) {
+inline ncclResult_t xmlSetAttrInt(struct ncclXmlNode* node, const char* attrName, const int value) {
   int index;
   NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
   if (index == -1) {
@@ -262,7 +262,7 @@ static ncclResult_t xmlSetAttrInt(struct ncclXmlNode* node, const char* attrName
   return ncclSuccess;
 }
 
-static ncclResult_t xmlSetAttrFloat(struct ncclXmlNode* node, const char* attrName, const float value) {
+inline ncclResult_t xmlSetAttrFloat(struct ncclXmlNode* node, const char* attrName, const float value) {
   int index;
   NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
   if (index == -1) {
@@ -275,7 +275,7 @@ static ncclResult_t xmlSetAttrFloat(struct ncclXmlNode* node, const char* attrNa
   return ncclSuccess;
 }
 
-static ncclResult_t xmlSetAttrLong(struct ncclXmlNode* node, const char* attrName, const int64_t value) {
+inline ncclResult_t xmlSetAttrLong(struct ncclXmlNode* node, const char* attrName, const int64_t value) {
   int index;
   NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
   if (index == -1) {
@@ -288,7 +288,7 @@ static ncclResult_t xmlSetAttrLong(struct ncclXmlNode* node, const char* attrNam
   return ncclSuccess;
 }
 
-static ncclResult_t xmlUnsetAttr(struct ncclXmlNode* node, const char* attrName) {
+inline ncclResult_t xmlUnsetAttr(struct ncclXmlNode* node, const char* attrName) {
   int index;
   NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
   if (index == -1) return ncclSuccess;
@@ -300,7 +300,7 @@ static ncclResult_t xmlUnsetAttr(struct ncclXmlNode* node, const char* attrName)
   return ncclSuccess;
 }
 
-static ncclResult_t xmlGetSub(struct ncclXmlNode* node, const char* subName, struct ncclXmlNode** sub) {
+inline ncclResult_t xmlGetSub(struct ncclXmlNode* node, const char* subName, struct ncclXmlNode** sub) {
   *sub = NULL;
   for (int s=0; s<node->nSubs; s++) {
     if (strcmp(node->subs[s]->name, subName) == 0) {
@@ -311,7 +311,7 @@ static ncclResult_t xmlGetSub(struct ncclXmlNode* node, const char* subName, str
   return ncclSuccess;
 }
 
-static ncclResult_t xmlGetSubKv(struct ncclXmlNode* node, const char* subName, struct ncclXmlNode** sub, const char* attrName, const char* attrValue) {
+inline ncclResult_t xmlGetSubKv(struct ncclXmlNode* node, const char* subName, struct ncclXmlNode** sub, const char* attrName, const char* attrValue) {
   *sub = NULL;
   for (int s=0; s<node->nSubs; s++) {
     struct ncclXmlNode* subNode = node->subs[s];
@@ -326,14 +326,14 @@ static ncclResult_t xmlGetSubKv(struct ncclXmlNode* node, const char* subName, s
   }
   return ncclSuccess;
 }
-static ncclResult_t xmlGetSubKvInt(struct ncclXmlNode* node, const char* subName, struct ncclXmlNode** sub, const char* attrName, const int attrValue) {
+inline ncclResult_t xmlGetSubKvInt(struct ncclXmlNode* node, const char* subName, struct ncclXmlNode** sub, const char* attrName, const int attrValue) {
   char strValue[10];
   snprintf(strValue, 10, "%d", attrValue);
   NCCLCHECK(xmlGetSubKv(node, subName, sub, attrName, strValue));
   return ncclSuccess;
 }
 
-static ncclResult_t xmlAddNode(struct ncclXml* xml, struct ncclXmlNode* parent, const char* subName, struct ncclXmlNode** sub) {
+inline ncclResult_t xmlAddNode(struct ncclXml* xml, struct ncclXmlNode* parent, const char* subName, struct ncclXmlNode** sub) {
   if (xml->maxIndex == xml->maxNodes) {
     WARN("Error : too many XML nodes (max %d)", xml->maxNodes);
     return ncclInternalError;
@@ -355,7 +355,7 @@ static ncclResult_t xmlAddNode(struct ncclXml* xml, struct ncclXmlNode* parent, 
   return ncclSuccess;
 }
 
-static ncclResult_t xmlRemoveNode(struct ncclXmlNode* node) {
+inline ncclResult_t xmlRemoveNode(struct ncclXmlNode* node) {
   node->type = NODE_TYPE_NONE;
   struct ncclXmlNode* parent = node->parent;
   if (parent == NULL) return ncclSuccess;
@@ -368,7 +368,7 @@ static ncclResult_t xmlRemoveNode(struct ncclXmlNode* node) {
   return ncclSuccess;
 }
 
-static ncclResult_t xmlAddTree(struct ncclXml* dst, struct ncclXmlNode* parent, struct ncclXmlNode* srcNode) {
+inline ncclResult_t xmlAddTree(struct ncclXml* dst, struct ncclXmlNode* parent, struct ncclXmlNode* srcNode) {
   if (dst->maxIndex == dst->maxNodes) {
     WARN("Error : too many XML nodes (max %d)", dst->maxNodes);
     return ncclInternalError;

--- a/src/include/gdrwrap.h
+++ b/src/include/gdrwrap.h
@@ -180,11 +180,8 @@ static gdr_t ncclGdrInit() {
 
 template <typename T>
 static ncclResult_t ncclGdrCudaCalloc(T** ptr, T** devPtr, size_t nelem, void** gdrHandle, hipStream_t stream) {
-  gdr_info_t info;
   size_t mapSize;
-  gdr_mh_t mh;
   char *devMem;
-  void *gdrMap;
 
   mapSize = ncclSizeOfT<T>()*nelem;
 
@@ -216,7 +213,7 @@ static ncclResult_t ncclGdrCudaCalloc(T** ptr, T** devPtr, size_t nelem, void** 
 
 template <typename T>
 static ncclResult_t ncclGdrCudaCopy(void *gdrHandle, T* dst, T* src, size_t nelem) {
-  gdr_mem_desc_t *md = (gdr_mem_desc_t*)gdrHandle;
+  //gdr_mem_desc_t *md = (gdr_mem_desc_t*)gdrHandle; Unused 
   memcpy(dst, src, nelem*sizeof(T));
   return ncclSuccess;
 }

--- a/src/include/msccl/msccl_parser.h
+++ b/src/include/msccl/msccl_parser.h
@@ -45,59 +45,6 @@ struct mscclXml {
   int maxIndex;
 };
 
-static ncclResult_t mscclXmlGetAttrIndex(struct mscclXmlNode* node, const char* attrName, int* index) {
-  *index = -1;
-  const int nAttrs = node->nAttrs;
-  for (int a=0; a<nAttrs; a++) {
-    if (strncmp(node->attrs[a].key, attrName, MAX_STR_LEN) == 0) {
-      *index = a;
-      return ncclSuccess;
-    }
-  }
-  return ncclSuccess;
-}
-
-static ncclResult_t mscclXmlGetAttr(struct mscclXmlNode* node, const char* attrName, const char** value) {
-  int index;
-  NCCLCHECK(mscclXmlGetAttrIndex(node, attrName, &index));
-  *value = index == -1 ? NULL : node->attrs[index].value;
-  return ncclSuccess;
-}
-
-static ncclResult_t mscclXmlGetAttrStr(struct mscclXmlNode* node, const char* attrName, const char** value) {
-  NCCLCHECK(mscclXmlGetAttr(node, attrName, value));
-  if (*value == NULL) {
-    WARN("Attribute %s of node %s not found", attrName, node->name);
-    return ncclInternalError;
-  }
-  return ncclSuccess;
-}
-static ncclResult_t mscclXmlGetAttrInt(struct mscclXmlNode* node, const char* attrName, int* value) {
-  const char* str;
-  NCCLCHECK(mscclXmlGetAttrStr(node, attrName, &str));
-  *value = strtol(str, NULL, 0);
-  return ncclSuccess;
-}
-
-static ncclResult_t mscclXmlGetAttrInt64(struct mscclXmlNode* node, const char* attrName, int64_t* value) {
-  const char* str;
-  NCCLCHECK(mscclXmlGetAttrStr(node, attrName, &str));
-  *value = strtoll(str, NULL, 0);
-  return ncclSuccess;
-}
-
-static ncclResult_t mscclXmlFindTag(struct mscclXml* xml, const char* tagName, struct mscclXmlNode** node) {
-  *node = NULL;
-  for (int i=0; i<xml->maxIndex; i++) {
-    struct mscclXmlNode* n = xml->nodes+i;
-    if (strcmp(n->name, tagName) == 0) {
-      *node = n;
-      return ncclSuccess;
-    }
-  }
-  return ncclSuccess;
-}
-
 ncclResult_t mscclGetAlgoFromXmlFile(const char* xmlGraphFile, struct mscclAlgo* algo, int rank);
 
 ncclResult_t mscclGetAlgoMetaFromXmlFile(const char* xmlGraphFile, struct mscclAlgoMeta* algoMeta);

--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -122,7 +122,7 @@ namespace rocblas_hip_f8_impl
         else
             x = reinterpret_cast<uint16_t&>(_x);
 
-        uint32_t y, head, mantissa;
+        uint32_t head, mantissa;
         int      exponent, bias;
         uint32_t sign;
 

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -39,7 +39,7 @@ struct netIf {
 int parseStringList(const char* string, struct netIf* ifList, int maxList);
 bool matchIfList(const char* string, int port, struct netIf* ifList, int listSize, bool matchExact);
 
-static long log2i(long n) {
+inline long log2i(long n) {
   return log2Down(n);
 }
 

--- a/src/init.cc
+++ b/src/init.cc
@@ -711,7 +711,9 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
   int nRanks = comm->nRanks;
   struct ncclDevCommAndChannels tmpCommAndChans;
   struct ncclDevCommAndChannels *devCommAndChans = NULL;
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   struct ncclNvmlCCStatus ccStatus;
+#endif
   bool ccEnable = false;
 
   NCCLCHECKGOTO(ncclStrongStreamAcquireUncaptured(&comm->sharedRes->deviceStream), ret, fail);
@@ -1860,9 +1862,6 @@ fail:
 static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   struct ncclCommInitRankAsyncJob* job = (struct ncclCommInitRankAsyncJob*)job_;
   ncclComm_t comm = job->comm;
-#ifdef ENABLE_MSCCLPP
-  ncclUniqueId origUniqueId = *job->commId;
-#endif
   ncclResult_t res = ncclSuccess;
   int archMajor, archMinor;
   size_t maxLocalSizeBytes = 0;
@@ -1873,8 +1872,10 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   double sum_timers = 0;
   uint64_t timers[TIMERS_INIT_COUNT] = {0};
   unsigned long long commIdHash;
+#ifdef USE_INDIRECT_FUNCTION_CALL
   int64_t stackSize;
   hipDeviceProp_t devProp;
+#endif
 
   timers[TIMER_INIT_TOTAL] = clockNano();
   CUDACHECKGOTO(cudaSetDevice(cudaDev), res, fail);

--- a/src/misc/alt_rsmi.cc
+++ b/src/misc/alt_rsmi.cc
@@ -48,7 +48,7 @@ struct ARSMI_systemNode {
     std::string s_card;
 };
 
-static const char *kPathDRMRoot = "/sys/class/drm";
+// static const char *kPathDRMRoot = "/sys/class/drm"; // unused variable
 static const char *kKFDNodesPathRoot = "/sys/class/kfd/kfd/topology/nodes";
 static const uint32_t kAmdGpuId = 0x1002;
 
@@ -66,7 +66,6 @@ static thread_local int ARSMI_num_devices=-1;
 int ARSMI_init(void)
 {
     std::string err_msg;
-    uint32_t count = 0;
     std::multimap<uint64_t, ARSMI_systemNode> ARSMI_allSystemNodes;
 
     if (ARSMI_num_devices > 0) {
@@ -101,7 +100,7 @@ int ARSMI_init(void)
         int ret_loc_id = read_node_properties(node_id, "location_id", &location_id, properties);
         int ret_domain = read_node_properties(node_id, "domain", &domain, properties);
         int ret_vendor = read_node_properties(node_id, "vendor_id", &vendor_id, properties);
-        if (ret_gpu_id == 0 &&  ~(ret_unique_id != 0 || ret_loc_id != 0 || ret_unique_id != 0 || ret_vendor != 0) &&
+        if (ret_gpu_id == 0 &&  !(ret_unique_id != 0 || ret_loc_id != 0 || ret_domain != 0 || ret_vendor != 0) &&
             (gpu_id != 0) && (vendor_id == kAmdGpuId)) {
             // Do not try to build a node if one of these fields
             // do not exist in KFD (0 as values okay)
@@ -229,7 +228,6 @@ int ARSMI_init(void)
                 continue;
             }
 
-            uint64_t hops;
             uint64_t type;
             uint64_t weight;
             uint64_t min_bandwidth;
@@ -555,7 +553,7 @@ static int getPropertyValue(std::string property, uint64_t *value, std::map<std:
     return 0;
 }
 
-static bool fileExists(char const *filename)
+inline bool fileExists(char const *filename)
 {
     struct stat buf;
     return (stat(filename, &buf) == 0);

--- a/src/misc/msccl/msccl_lifecycle.cc
+++ b/src/misc/msccl/msccl_lifecycle.cc
@@ -30,7 +30,6 @@
 RCCL_PARAM(MscclEnabled, "MSCCL_ENABLE", 1);
 RCCL_PARAM(MscclForceEnabled, "MSCCL_FORCE_ENABLE", 0);
 RCCL_PARAM(MscclEnableSingleProcess, "MSCCL_ENABLE_SINGLE_PROCESS", 1);
-static const char* mscclAlgoFilePathEnv = "MSCCL_ALGO_FILE_PATH";
 
 bool mscclEnabled() {
 #ifdef COMPILE_MSCCL_KERNEL

--- a/src/misc/msccl/msccl_parser.cc
+++ b/src/misc/msccl/msccl_parser.cc
@@ -772,7 +772,6 @@ ncclResult_t mscclAlgoMetaXmlLoad(const char* xmlFilePath, struct mscclXmlNode* 
 }
 
 ncclResult_t mscclGetAlgoMetaFromXmlFile(const char* str, struct mscclAlgoMeta* algoMeta) {
-  ncclResult_t ret = ncclSuccess;
   struct mscclXmlNode* node;
   node = (struct mscclXmlNode *)malloc(sizeof(struct mscclXmlNode));
   NCCLCHECK(mscclAlgoMetaXmlLoad(str, node));

--- a/src/misc/msccl/msccl_parser.cc
+++ b/src/misc/msccl/msccl_parser.cc
@@ -15,6 +15,59 @@
 #include "collectives.h"
 #include "msccl/msccl_parser.h"
 
+static ncclResult_t mscclXmlGetAttrIndex(struct mscclXmlNode* node, const char* attrName, int* index) {
+  *index = -1;
+  const int nAttrs = node->nAttrs;
+  for (int a=0; a<nAttrs; a++) {
+    if (strncmp(node->attrs[a].key, attrName, MAX_STR_LEN) == 0) {
+      *index = a;
+      return ncclSuccess;
+    }
+  }
+  return ncclSuccess;
+}
+
+static ncclResult_t mscclXmlGetAttr(struct mscclXmlNode* node, const char* attrName, const char** value) {
+  int index;
+  NCCLCHECK(mscclXmlGetAttrIndex(node, attrName, &index));
+  *value = index == -1 ? NULL : node->attrs[index].value;
+  return ncclSuccess;
+}
+
+static ncclResult_t mscclXmlGetAttrStr(struct mscclXmlNode* node, const char* attrName, const char** value) {
+  NCCLCHECK(mscclXmlGetAttr(node, attrName, value));
+  if (*value == NULL) {
+    WARN("Attribute %s of node %s not found", attrName, node->name);
+    return ncclInternalError;
+  }
+  return ncclSuccess;
+}
+static ncclResult_t mscclXmlGetAttrInt(struct mscclXmlNode* node, const char* attrName, int* value) {
+  const char* str;
+  NCCLCHECK(mscclXmlGetAttrStr(node, attrName, &str));
+  *value = strtol(str, NULL, 0);
+  return ncclSuccess;
+}
+
+static ncclResult_t mscclXmlGetAttrInt64(struct mscclXmlNode* node, const char* attrName, int64_t* value) {
+  const char* str;
+  NCCLCHECK(mscclXmlGetAttrStr(node, attrName, &str));
+  *value = strtoll(str, NULL, 0);
+  return ncclSuccess;
+}
+
+static ncclResult_t mscclXmlFindTag(struct mscclXml* xml, const char* tagName, struct mscclXmlNode** node) {
+  *node = NULL;
+  for (int i=0; i<xml->maxIndex; i++) {
+    struct mscclXmlNode* n = xml->nodes+i;
+    if (strcmp(n->name, tagName) == 0) {
+      *node = n;
+      return ncclSuccess;
+    }
+  }
+  return ncclSuccess;
+}
+
 ncclResult_t mscclXmlGetChar(FILE* file, char* c) {
   if (fread(c, 1, 1, file) == 0) {
     WARN("XML Parse : Unexpected EOF");
@@ -708,7 +761,6 @@ ncclResult_t mscclXmlLoadSingleNode(FILE* file, struct mscclXmlNode* node) {
 }
 
 ncclResult_t mscclAlgoMetaXmlLoad(const char* xmlFilePath, struct mscclXmlNode* node) {
-  ncclResult_t ret = ncclSuccess;
   FILE* file = fopen(xmlFilePath, "r");
   if (file == NULL) {
     fprintf(stderr, "Could not open MSCCL XML algorithm file %s : %s", xmlFilePath, strerror(errno));

--- a/src/misc/msccl/msccl_setup.cc
+++ b/src/misc/msccl/msccl_setup.cc
@@ -123,7 +123,6 @@ ncclResult_t mscclSetupConnections(struct mscclAlgo* hostAlgo, ncclComm_t comm) 
 
 static ncclResult_t mscclSetupProxyImpl(struct mscclAlgo* hostAlgo, ncclComm_t comm) {
   mscclStatus& status = mscclGetStatus(comm);
-  mscclThreadLocalStatus& threadLocalStatus = mscclGetThreadLocalStatus();
   struct ncclProxyOp proxyOp = {};
   proxyOp.connIndex = 0;
   proxyOp.sliceSteps = status.sliceSteps;

--- a/src/misc/recorder.cc
+++ b/src/misc/recorder.cc
@@ -37,8 +37,8 @@ rcclApiCall::rcclApiCall(rcclCall_t type, const ncclInfo& info)://name(rcclCallS
                                                                 datatype(info.datatype),
                                                                 op(info.op),
                                                                 root(info.root),
-                                                                comm(info.comm),
                                                                 nRanks(info.comm->nRanks),
+                                                                comm(info.comm),
                                                                 stream(info.stream),
                                                                 nTasks(info.comm->planner.nTasksP2p + info.comm->planner.nTasksColl),
                                                                 globalRank(info.comm->localRankToRank[info.comm->localRank]){}

--- a/src/misc/recorder.cc
+++ b/src/misc/recorder.cc
@@ -312,7 +312,6 @@ ncclResult_t Recorder::record(rcclApiCall& call)
   #if ROCM_VERSION >= 60100
     hipStreamCaptureStatus status;
     hipGraph_t graphCaptured;
-    unsigned long long graphID = 0;
     CUDACHECK(hipStreamGetCaptureInfo_v2(call.stream, &status, &(call.graphID), &graphCaptured)); // shouldnt we need dependency?
 
     if (status == hipStreamCaptureStatusActive) // when graph launched this should be disabled

--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -662,7 +662,9 @@ ncclResult_t ncclSocketReady(struct ncclSocket* sock, int *running) {
 }
 
 ncclResult_t ncclSocketConnect(struct ncclSocket* sock) {
+#ifdef ENABLE_TRACE
   char line[SOCKET_NAME_MAXLEN+1];
+#endif
 
   if (sock == NULL) {
     WARN("ncclSocketConnect: pass NULL socket");

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -293,10 +293,8 @@ ncclResult_t dumpProxyState(struct ncclProxyProgressState* state) {
   struct ncclProxyArgs* op = state->active;
   int poolIndex, opIndex;
   int list_len = 0;
-  int sublist_len = 0;
   fprintf(stderr, "ACTIVE OPS\n");
   while (op) {
-    sublist_len = 0;
     NCCLCHECK(getOpIndex(op, state, &poolIndex, &opIndex));
     if (op->state & OP_SEEN) {
       WARN("List loop at element %d-%d", poolIndex, opIndex);
@@ -305,7 +303,6 @@ ncclResult_t dumpProxyState(struct ncclProxyProgressState* state) {
     op->state |= OP_SEEN;
     struct ncclProxyArgs* nextOp = op->nextPeer;
     while (nextOp) {
-      sublist_len++;
       NCCLCHECK(getOpIndex(nextOp, state, &poolIndex, &opIndex));
       if (nextOp->state & OP_SEEN) {
         WARN("List loop at element %d-%d", poolIndex, opIndex);

--- a/src/register/coll_reg.cc
+++ b/src/register/coll_reg.cc
@@ -2,6 +2,7 @@
 #include "transport.h"
 #include "enqueue.h"
 
+#if CUDART_VERSION >= 11030
 static ncclResult_t registerCheckP2PConnection(struct ncclComm* comm, struct ncclConnector* conn, struct ncclTopoGraph* graph, int peer, bool* needReg) {
   if (conn->connected) {
     if (conn->conn.flags & (NCCL_P2P_READ | NCCL_P2P_WRITE)) {
@@ -23,6 +24,7 @@ static ncclResult_t registerCheckP2PConnection(struct ncclComm* comm, struct ncc
   }
   return ncclSuccess;
 }
+#endif
 
 ncclResult_t ncclRegisterCollNvlsBuffers(
     struct ncclComm* comm, struct ncclTaskColl* info,

--- a/src/transport/coll_net.cc
+++ b/src/transport/coll_net.cc
@@ -1283,8 +1283,8 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
     (void)close(dmabuf_fd);
     needReg = false;
   }
-#endif
 peermem:
+#endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, &handle), ret, fail);
   }
@@ -1316,8 +1316,8 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
     (void)close(dmabuf_fd);
     needReg = false;
   }
-#endif
 peermem:
+#endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, &handle), ret, fail);
   }

--- a/src/transport/p2p.cc
+++ b/src/transport/p2p.cc
@@ -1072,9 +1072,6 @@ static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, str
   struct p2pIpcExpInfo* ipcExpInfo = (struct p2pIpcExpInfo*)reqBuff;
   void* regAddr = NULL;
   ncclResult_t ret = ncclSuccess;
-  bool mapped = false;
-  bool imported = false;
-  CUmemGenericAllocationHandle handle;
 
   assert(sizeof(struct p2pIpcExpInfo) == reqSize);
   assert(sizeof(void*) == respSize);
@@ -1089,6 +1086,9 @@ static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, str
     regAddr = (void*)((uintptr_t)regAddr + ipcExpInfo->offset);
   } else {
 #if CUDART_VERSION >= 11030
+    bool mapped = false;
+    bool imported = false;
+    CUmemGenericAllocationHandle handle;
     // cuMem import
     if (connection->sameProcess) {
       // if proxy is same process as request peer, we just need to map the handle.


### PR DESCRIPTION
## Details

Addressing (most) of the compiler warnings with as minimal changes as possible.

**Work item:** "Internal"
**What were the changes?**  
Removing unused variables
Relocation of #If defined(...) or variable definitions to define variables if necessary
Relocation of some function definitions in msccl ( from .h to .cc)

**Why were the changes made?**  
Too many compiler warning while building rccl

**How was the outcome achieved?**  

**Additional Documentation:**  
- There are few warning from ext-src directory, They will be addressed as per our future plans.
- There is a minor bug fix in alt_rsmi.cc (Based on the implementation context and compiler warning)

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
