### PR TITLE
msccl: adjust msccl threshold for bf16

### DIFF
--- a/src/collectives.cc
+++ b/src/collectives.cc
@@ -125,12 +125,7 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
   }
 
   if (mscclAvailable(comm) && !mscclIsCaller()) {
-    if (datatype != ncclBfloat16) {	  
-    	return mscclEnqueueCheck(
-      		sendbuff, nullptr, nullptr, recvbuff, nullptr, nullptr,
-      		count, datatype, 0, 0, op, mscclFuncAllReduce, comm, stream);
-    }
-    if (datatype == ncclBfloat16 && (count * ncclTypeSize(datatype) <= 8388608)) {
+    if (datatype != ncclBfloat16 || (count * ncclTypeSize(datatype) <= 8388608)) {
 	return mscclEnqueueCheck(
                 sendbuff, nullptr, nullptr, recvbuff, nullptr, nullptr,
                 count, datatype, 0, 0, op, mscclFuncAllReduce, comm, stream);	

--- a/src/collectives.cc
+++ b/src/collectives.cc
@@ -125,9 +125,16 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
   }
 
   if (mscclAvailable(comm) && !mscclIsCaller()) {
-    return mscclEnqueueCheck(
-      sendbuff, nullptr, nullptr, recvbuff, nullptr, nullptr,
-      count, datatype, 0, 0, op, mscclFuncAllReduce, comm, stream);
+    if (datatype != ncclBfloat16) {	  
+    	return mscclEnqueueCheck(
+      		sendbuff, nullptr, nullptr, recvbuff, nullptr, nullptr,
+      		count, datatype, 0, 0, op, mscclFuncAllReduce, comm, stream);
+    }
+    if (datatype == ncclBfloat16 && (count * ncclTypeSize(datatype) <= 8388608)) {
+	return mscclEnqueueCheck(
+                sendbuff, nullptr, nullptr, recvbuff, nullptr, nullptr,
+                count, datatype, 0, 0, op, mscclFuncAllReduce, comm, stream);	
+    }
   }
 
   return ncclEnqueueCheck(&info);


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___
The MSCCL allreduce threshold for single node is 20MB in the xml files. While this threshold works for fp32 and half datatypes, it is not ideal for bf16. This PR adjusts the MSCCL threshold for bf16 type.
 
**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
