### PR TITLE
Fix topo explorer compatibility and capture WarpSize

### DIFF
--- a/tools/topo_expl/include/device_table.h
+++ b/tools/topo_expl/include/device_table.h
@@ -1,7 +1,13 @@
 #ifndef DEVICE_TABLE_COMPATIBILITY
 #define DEVICE_TABLE_COMPATIBILITY
-__forceinline__ __device__ void NCCL_CALL_FUNCTIONS(unsigned short funcIndex) noexcept {}
-__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_1(unsigned short funcIndex) noexcept {}
-__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_2(unsigned short funcIndex) noexcept {}
-__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_4(unsigned short funcIndex) noexcept {}
+
+struct rcclKernelItem {
+  void* funcPtr;
+  int   unroll;
+};
+static struct rcclKernelItem rcclKernelTable[] = { };
+
+template <int unroll>
+__forceinline__ __device__ void NCCL_CALL_FUNCTIONS(unsigned short funcIndex) noexcept { }
+
 #endif

--- a/tools/topo_expl/topo_expl.cpp
+++ b/tools/topo_expl/topo_expl.cpp
@@ -255,11 +255,13 @@ int main(int argc,char* argv[])
     node_model = network.GetNode(i);
     assert(node_model!=0);
     initTransportsRank_3(&comm[i], allGather3Data, treeGraph[i], ringGraph[i], collNetGraph[i], nvlsGraph[i]);
+    CUDACHECK(hipDeviceGetAttribute(&comm[i].WarpSize, hipDeviceAttributeWarpSize, comm[i].cudaDev));
   }
   for (uint64_t len = 8; len <= 4294967296L; len *= 2) {
     struct ncclInfo info;
     float minTime = 3600000000.0;
     info.comm = &comm[0];
+
     info.coll = ncclFuncAllReduce;
     // Find algorithm / protocol.
     int algorithm = -1;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _Internal_

**What were the changes?**  
_Fix compatibility with latest RCCL changes from codegen and device functions_

**Why were the changes made?**  
_Topo Explorer is a useful productivity tool to explore topology-specific details and tuning without having to run RCCL at the required scale_

**How was the outcome achieved?**  
_Modify device_table.h compatibility file and capture WarpSize using HIP function_

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
