### PR TITLE
[NPKit] Use default output directory when env var is not set

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -2558,10 +2558,17 @@ static ncclResult_t commCleanup(ncclComm_t comm) {
   // Dump NPKit events and shutdown
   const char* npkitDumpDir = getenv("NPKIT_DUMP_DIR");
   if (npkitDumpDir == nullptr) {
-    WARN("NPKIT_DUMP_DIR is empty");
-  } else {
-    NCCLCHECK(NpKit::Dump(npkitDumpDir));
+    npkitDumpDir = "./npkit_dump";
+    INFO(NCCL_INIT, "NPKIT_DUMP_DIR is not set, using default directory: %s", npkitDumpDir);
+
+    struct stat st;
+    if (stat(npkitDumpDir, &st) != 0) {
+      if (mkdir(npkitDumpDir, 0755) != 0) {
+        WARN("Failed to create NPKIT_DUMP_DIR directory: %s", npkitDumpDir);
+      }
+    }
   }
+  NCCLCHECK(NpKit::Dump(npkitDumpDir));
   NCCLCHECK(NpKit::Shutdown());
 #endif
 


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
SWDEV-536349

**What were the changes?**  
Create a default NPKit dump directory when it's not set via env variable.

**Why were the changes made?**  
External ask.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
