### PR TITLE
changing the HIP-VERSION in rccl_float8.h

### DIFF
--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -40,7 +40,7 @@ typedef struct
 } rccl_bfloat8;
 
 // __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
-#elif HIP_VERSION >= 60200000
+#elif HIP_VERSION >= 60300000
 
 #include <hip/hip_fp8.h>
 


### PR DESCRIPTION

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** [issues/1763](https://github.com/ROCm/rccl/issues/1763)

**What were the changes?**  
changing the HIP-VERSION to 6.3 to avoid using hip_fp8 for older ROCm versions

**Why were the changes made?**  
ROCm versions older than 6.3 do not include definitions for both OCP and FNUZ.

**How was the outcome achieved?**  
RCCL builds and runs fine on ROCm 6.2 and earlier

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
