### PR TITLE
add warning if workFIFO is not available after multiple retries.

### DIFF
--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -1187,6 +1187,8 @@ static ncclResult_t scheduleP2pTasksToPlan(
 // Spin until its safe to increase comm->workFifoProduced to desiredProduced.
 static void waitWorkFifoAvailable(struct ncclComm* comm, uint32_t desiredProduced) {
   bool hasRoom = (desiredProduced - comm->workFifoConsumedLeast) <= comm->workFifoBytes;
+  uint64_t count = 0;
+  int warned = 0;
   if (hasRoom) return;
   while (true) {
     // We have to poll for notifications from device.
@@ -1225,6 +1227,17 @@ static void waitWorkFifoAvailable(struct ncclComm* comm, uint32_t desiredProduce
     hasRoom = (desiredProduced - comm->workFifoConsumedLeast) <= comm->workFifoBytes;
     if (hasRoom) break;
     sched_yield();
+
+    /* Warn if we get stuck waiting for workFifo. */
+    count++;
+    if (warned == 0 && count == 100000 && comm->rank == 0) {
+      warned = 1;
+      WARN("Waiting for work FIFO to become available."
+           "Work fifo exhaustion can happen in large scale/high iteration count of alltoall."
+           "In order to increase work FIFO size, set NCCL_WORK_FIFO_BYTES to higher number"
+           " (current: %ld). \n\nRCCL continues to retry...", comm->workFifoBytes);
+    }
+
   }
 }
 

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -1232,10 +1232,10 @@ static void waitWorkFifoAvailable(struct ncclComm* comm, uint32_t desiredProduce
     count++;
     if (warned == 0 && count == 100000 && comm->rank == 0) {
       warned = 1;
-      WARN("Waiting for work FIFO to become available."
-           "Work fifo exhaustion can happen in large scale/high iteration count of alltoall."
-           "In order to increase work FIFO size, set NCCL_WORK_FIFO_BYTES to higher number"
-           " (current: %ld). \n\nRCCL continues to retry...", comm->workFifoBytes);
+      WARN("Waiting for work FIFO to become available. "
+           "Work fifo exhaustion can happen in large scale/high iteration count of alltoall. "
+           "In order to increase work FIFO size, set NCCL_WORK_FIFO_BYTES to higher number (current: %ld).\n\n"
+           "RCCL continues to retry...", comm->workFifoBytes);
     }
 
   }


### PR DESCRIPTION
## Details
Follow up from #1722. We are still not out of the woods for high iteration alltoall. We should not just hang when work FIFO exhaustion occur. This commit prints out warning when RCCL get stuck waiting. 

![image](https://github.com/user-attachments/assets/ab1559a2-7e7c-4a15-8dda-5fa1cddcb6f4)


**What were the changes?**  
Print out warnings after multiple retries to get workFifo.

**Why were the changes made?**  
Provide user warnings and mitigation.

**How was the outcome achieved?**  
Count and print.

**Additional Documentation:**  


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
