### PR TITLE
[P2P] Switch to linear channel mapping for 2 nodes

### DIFF
--- a/src/include/device.h
+++ b/src/include/device.h
@@ -280,7 +280,7 @@ inline __host__ uint8_t ncclP2pChannelBaseForRound(struct ncclComm* comm, int p2
 // ncclP2pChannelToPart and ncclP2pChannelForPart are inverses. The device code
 // uses ncclP2pChannelToPart to determine which part "this" channel is responsible for.
 inline __host__ int ncclP2pChannelForPart(int nP2pChannels, int base, int part, int nParts, int nNodes) {
-  if (nNodes > 1) {
+  if (nNodes > 2) {
     // Only works because nP2pChannels is pow2
     int nChannelsLog2 = countOneBits(nP2pChannels-1);
     int delta = reverseBits(part, nChannelsLog2);
@@ -290,7 +290,7 @@ inline __host__ int ncclP2pChannelForPart(int nP2pChannels, int base, int part, 
   }
 }
 inline __device__ int ncclP2pChannelToPart(int nP2pChannels, int base, int channel, int nParts, int nNodes) {
-  if (nNodes > 1) {
+  if (nNodes > 2) {
     // Only works because nP2pChannels is pow2
     int nChannelsLog2 = countOneBits(nP2pChannels-1);
     int delta = (channel-base) & (nP2pChannels-1);


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___
Will close #1684 if this goes in.

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._
Use linear channel mapping for 2 nodes as well.

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._
Better performance with AINICs.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_
We might want to add an environment variable to switch between linear and bit-reversal based mapping if necessary,

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
