### PR TITLE
Adding #include <dlfcn.h> in nccl_net.h to pass build

### DIFF
--- a/src/include/plugin/nccl_net.h
+++ b/src/include/plugin/nccl_net.h
@@ -11,6 +11,7 @@
 #include "nccl_common.h"
 #include "net_device.h"
 #include <stdint.h>
+#include <dlfcn.h>
 
 #define NCCL_NET_HANDLE_MAXSIZE 128
 //Maximum value NCCL can accept for maxP2pBytes and maxCollBytes net properties


### PR DESCRIPTION
## Details

Build fails as follows:

/home/users/hankinsr/rccl/build/hipify/src/plugin/net/net_v6.cc:137:31: error: use of undeclared identifier 'dlsym'
  137 |   ncclNet_v6 = (ncclNet_v6_t*)dlsym(lib, "ncclNetPlugin_v6");
...

**What were the changes?**  

Add include of dlfcn.h into nccl_net.h

**Why were the changes made?**  

This change fixes the build because dlsym is now used in the nccl_net API files.