### PR TITLE
Fix AllReduce regression due to previous max range increase for LL64/LL128 

### DIFF
--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -334,7 +334,7 @@ static struct tuningModel tuning_model_5 {
     /*AllGather*/
     {/*LL (min/max/factor/thread_threshold)*/ {0, 98304,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {98304, 5046272, 1, 64}},
     /*AllReduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 1048576, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {1048576, 9437184, 3145728, 0}},
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 1048576, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {1048576, 9437184, 81205728, 0}},
   },
 };
 

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -334,7 +334,7 @@ static struct tuningModel tuning_model_5 {
     /*AllGather*/
     {/*LL (min/max/factor/thread_threshold)*/ {0, 98304,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {98304, 5046272, 1, 64}},
     /*AllReduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 1048576, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {1048576, 9437184, 81205728, 0}},
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 1048576, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {1048576, 9437184, 3145728, 0}},
   },
 };
 

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -53,9 +53,9 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
       if (comm->topo->ll128Enabled) {
         if (info->func == ncclFuncAllReduce) {
           if(comm->nNodes > 2) {
-            ll128Max *= 15.2; // Scale max message size for n > 2 since Tree has special behavior at 2 nodes
+            ll128Max *= 3.8; // Scale max message size for n > 2 since Tree has special behavior at 2 nodes
           }
-          ll128Max += (log2i(comm->nNodes) - 1) * comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL128][RCCL_PROTOCOL_FACTOR_IDX];
+          // ll128Max += (log2i(comm->nNodes) - 1) * comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL128][RCCL_PROTOCOL_FACTOR_IDX];
         }
         if (sizePerRank <= ll128Max && sizePerRank > ll128Min) {
           info->protocol = NCCL_PROTO_LL128;

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -52,6 +52,9 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
       // When LL128 is performant, the next condition overrides the previous LL choice
       if (comm->topo->ll128Enabled) {
         if (info->func == ncclFuncAllReduce) {
+          if(comm->nNodes > 2) {
+            ll128Max *= 15.2; // Scale max message size for n > 2 since Tree has special behavior at 2 nodes
+          }
           ll128Max += (log2i(comm->nNodes) - 1) * comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL128][RCCL_PROTOCOL_FACTOR_IDX];
         }
         if (sizePerRank <= ll128Max && sizePerRank > ll128Min) {


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _Internal_

**What were the changes?**  
_PR #1771 fixes 2-node regression, but regresses on 4 nodes and above for MI300._

**Why were the changes made?**  
_Regression fix._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
