### PR TITLE
msccl: use special send for LL on gfx950

### DIFF
--- a/src/device/msccl_kernel_impl.h
+++ b/src/device/msccl_kernel_impl.h
@@ -278,7 +278,7 @@ __device__ __forceinline__ void mscclRunInterpreter(
             }
 
 #endif
-          prims.send(srcOffset, thisNelem); // LL.send is the only situation where there is no barrier at the end.
+          prims.mscclSend(srcOffset, thisNelem); // LL.send is the only situation where there is no barrier at the end.
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_SEND_EXIT)
             if (tid == 0) {

--- a/src/device/prims_ll128.h
+++ b/src/device/prims_ll128.h
@@ -587,4 +587,7 @@ public:
   __device__ void localCopy(T* srcs, T* dsts, int eltN) {
     return mscclGenericOp<0,1,0,0>(&srcs, 1, &dsts, 1, eltN);
   }
+  __device__ void mscclSend(intptr_t inpIx, int eltN) {
+    return GenericOp<0, 1, Input, -1>(inpIx, -1, eltN, false);
+  }
 };

--- a/src/device/prims_simple.h
+++ b/src/device/prims_simple.h
@@ -1310,4 +1310,7 @@ public:
   __device__ __forceinline__ void localCopy(T* srcs, T* dsts, int eltN) {
     return mscclGenericOp<0,1,0,0>(&srcs, 1, &dsts, 1, eltN);
   }
+  __device__ __forceinline__ void mscclSend(intptr_t inpIx, int eltN) {
+    genericOp<0, 0, 0, 1, Input, -1>(inpIx, -1, eltN, false);
+  }
 };


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal

**What were the changes?**  
[_One sentence describing the work done._]
msccl: use special send for LL on gfx950

**Why were the changes made?**  
Workaround MSCCL data corruption on gfx950 after https://github.com/ROCm/rccl/pull/1770

**How was the outcome achieved?**  
Revert to nontemporal store for LL on gfx950 for msccl only

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
