### PR TITLE
Improving build time by removing the gfx11xx and host code from rccl_float8.h

### DIFF
--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -24,7 +24,7 @@
 #define ROCBLAS_FLOAT8_H
 
 #include <stdint.h>
-//#include <hip/hip_version.h>
+#include <hip/hip_version.h>
 
 #if __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
 /*! \brief Struct to represent a 8 bit floating-point number. */

--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -24,6 +24,7 @@
 #define ROCBLAS_FLOAT8_H
 
 #include <stdint.h>
+//#include <hip/hip_version.h>
 
 #if __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
 /*! \brief Struct to represent a 8 bit floating-point number. */
@@ -39,7 +40,7 @@ typedef struct
 } rccl_bfloat8;
 
 // __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
-#elif HIP_VERSION >= 60300000
+#elif HIP_VERSION >= 60300000 && !(defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1030__))
 
 #include <hip/hip_fp8.h>
 
@@ -49,26 +50,6 @@ typedef __hip_fp8_e5m2_fnuz rccl_bfloat8;
 #else
 typedef __hip_fp8_e4m3 rccl_float8;
 typedef __hip_fp8_e5m2 rccl_bfloat8;
-
-inline  __device__ float operator*(rccl_float8 a, rccl_float8 b)
-{
-    return float(a) * float(b);
-}
-
-inline  __device__ float operator*(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return float(a) * float(b);
-}
-
-inline  __device__ float operator*(rccl_float8 a, float b)
-{
-    return float(a) * float(b);
-}
-
-inline __device__ float operator*(rccl_bfloat8 a, float b)
-{
-    return float(a) * float(b);
-}
 #endif
 
 // For older versions of ROCm that do not include hip_fp8.h,

--- a/src/include/rccl_float8.h
+++ b/src/include/rccl_float8.h
@@ -24,7 +24,6 @@
 #define ROCBLAS_FLOAT8_H
 
 #include <stdint.h>
-#include <hip/hip_version.h>
 
 #if __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
 /*! \brief Struct to represent a 8 bit floating-point number. */
@@ -44,46 +43,33 @@ typedef struct
 
 #include <hip/hip_fp8.h>
 
-#if   __HIP_DEVICE_COMPILE__ && (defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) ||  (defined(__gfx1100__) || defined(__gfx1101__)))//HIP_FP8_TYPE_OCP is enabled.
-typedef __hip_fp8_e4m3 rccl_float8;
-typedef __hip_fp8_e5m2 rccl_bfloat8;
-#elif __HIP_DEVICE_COMPILE__ && (defined(__gfx942__))
+#if __HIP_DEVICE_COMPILE__ && (defined(__gfx942__))
 typedef __hip_fp8_e4m3_fnuz rccl_float8;
 typedef __hip_fp8_e5m2_fnuz rccl_bfloat8;
 #else
 typedef __hip_fp8_e4m3 rccl_float8;
 typedef __hip_fp8_e5m2 rccl_bfloat8;
+
+inline  __device__ float operator*(rccl_float8 a, rccl_float8 b)
+{
+    return float(a) * float(b);
+}
+
+inline  __device__ float operator*(rccl_bfloat8 a, rccl_bfloat8 b)
+{
+    return float(a) * float(b);
+}
+
+inline  __device__ float operator*(rccl_float8 a, float b)
+{
+    return float(a) * float(b);
+}
+
+inline __device__ float operator*(rccl_bfloat8 a, float b)
+{
+    return float(a) * float(b);
+}
 #endif
-    
-inline std::ostream& operator<<(std::ostream& os, const rccl_float8& f8)
-{
-    return os << float(f8);
-}
-
-inline std::ostream& operator<<(std::ostream& os, const rccl_bfloat8& bf8)
-{
-    return os << float(bf8);
-}
-
-inline __host__ __device__ float operator*(rccl_float8 a, rccl_float8 b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(rccl_float8 a, float b)
-{
-    return float(a) * float(b);
-}
-
-inline __host__ __device__ float operator*(rccl_bfloat8 a, float b)
-{
-    return float(a) * float(b);
-}
 
 // For older versions of ROCm that do not include hip_fp8.h,
 // we provide a local version of the header file as a fallback.

--- a/test/common/CollectiveArgs.cpp
+++ b/test/common/CollectiveArgs.cpp
@@ -201,10 +201,10 @@ namespace RcclUnitTesting
         case ncclUint32:     ss << scalarsPerRank.U4[this->globalRank]; break;
         case ncclInt64:      ss << scalarsPerRank.I8[this->globalRank]; break;
         case ncclUint64:     ss << scalarsPerRank.U8[this->globalRank]; break;
-        case ncclFloat8e4m3: ss << scalarsPerRank.F1[this->globalRank]; break;
+        case ncclFloat8e4m3: ss << (float)scalarsPerRank.F1[this->globalRank]; break;
         case ncclFloat32:    ss << scalarsPerRank.F4[this->globalRank]; break;
         case ncclFloat64:    ss << scalarsPerRank.F8[this->globalRank]; break;
-        case ncclFloat8e5m2: ss << scalarsPerRank.B1[this->globalRank]; break;
+        case ncclFloat8e5m2: ss << (float)scalarsPerRank.B1[this->globalRank]; break;
         case ncclBfloat16:   ss << scalarsPerRank.B2[this->globalRank]; break;
         default:             ss << "(UNKNOWN)";
         }

--- a/test/common/PtrUnion.cpp
+++ b/test/common/PtrUnion.cpp
@@ -234,11 +234,11 @@ namespace RcclUnitTesting
       case ncclUint32:   U4[idx] *= scalarsPerRank.U4[rank]; break;
       case ncclInt64:    I8[idx] *= scalarsPerRank.I8[rank]; break;
       case ncclUint64:   U8[idx] *= scalarsPerRank.U8[rank]; break;
-      case ncclFloat8e4m3:  F1[idx]  = rccl_float8(F1[idx] * scalarsPerRank.F1[rank]); break;
+      case ncclFloat8e4m3:  F1[idx]  = rccl_float8((float)F1[idx] * (float)scalarsPerRank.F1[rank]); break;
       case ncclFloat16:  F2[idx]  = __float2half(__half2float(F2[idx]) * __half2float(scalarsPerRank.F2[rank])); break;
       case ncclFloat32:  F4[idx] *= scalarsPerRank.F4[rank]; break;
       case ncclFloat64:  F8[idx] *= scalarsPerRank.F8[rank]; break;
-      case ncclFloat8e5m2:  B1[idx]  = rccl_bfloat8(B1[idx] * scalarsPerRank.B1[rank]); break;
+      case ncclFloat8e5m2:  B1[idx]  = rccl_bfloat8((float)B1[idx] * (float)scalarsPerRank.B1[rank]); break;
       case ncclBfloat16: B2[idx] *= scalarsPerRank.B2[rank]; break;
       default:
         ERROR("Unsupported datatype\n");


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
SWDEV-539929
**What were the changes?**  
Removing the host side and gfx11 from OCP type check.

**Why were the changes made?**  
The build time overhead is due to those specific architectures when the build includes all architectures (i.e., without -l).

**How was the outcome achieved?**  
We achieved the build time reduction by excluding certain architectures from the build.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
