### PR TITLE
[GRAPH] Pass rank instead of busId due to a change in an internal function signature

### DIFF
--- a/src/graph/search.cc
+++ b/src/graph/search.cc
@@ -696,7 +696,7 @@ ncclResult_t ncclTopoSearchRecNet(struct ncclTopoSystem* system, struct ncclTopo
             if (paths[i].count <= paths[f].count) {
               // prefer GPU direct RDMA
               enum ncclTopoGdrMode useGdr;
-              NCCLCHECK(ncclTopoCheckGdr(system, system->nodes[GPU].nodes[i].id, net->id, 0, &useGdr));
+              NCCLCHECK(ncclTopoCheckGdr(system, system->nodes[GPU].nodes[i].gpu.rank, net->id, 0, &useGdr));
               if (paths[i].count < paths[f].count || (paths[i].count == paths[f].count && !f_gdr && useGdr)) {
                 f = i;
                 f_gdr = useGdr;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
SWDEV-541381

**What were the changes?**  
_One sentence describing the work done._
Use rank id instead of busId in the `ncclTopoCheckGdr` to find closest NIC. 

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._
RCCL can't find a path for pattern and chooses the far NIC, which drops performance in some cases. This is seen after the 2.24 sync.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._
Updated `ncclTopoCheckGdr` function to use rank id.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
