### PR TITLE
[DEVICE] Fix validation errors for multi-node LL with non-coherent host memory on gfx950

### DIFF
--- a/src/device/prims_ll.h
+++ b/src/device/prims_ll.h
@@ -260,7 +260,7 @@ private:
 
   __device__ void storeLL(union ncclLLFifoLine* dst, uint64_t val, uint32_t flag) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-#if defined(__gfx950__)
+#if (defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY))
     using Vec = uint32_t __attribute__((ext_vector_type(4)));
     Vec i4;
     i4[0] = val & 0xffffffff;


### PR DESCRIPTION
## Details

**Work item:**
Internal (SWDEV-539149)

**What were the changes?**  
Limit the use of flat storeLL to gfx950 systems that support extended-scope fine-grained host memory.

**Why were the changes made?**  
Using flat storeLL causes data validation errors for small messages (LL protocol) in multi-node runs if the gfx950 systems do not support extended-scope fine-grained host memory.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
