### PR TITLE
Add datatype validation for MSCCLPP AllGather

### DIFF
--- a/src/misc/msccl/msccl_lifecycle.cc
+++ b/src/misc/msccl/msccl_lifecycle.cc
@@ -562,6 +562,18 @@ static inline bool isMscclppAllReduceSupported(ncclDataType_t dataType, ncclRedO
 
   return (op == ncclSum);
 }
+
+static inline bool isMscclppAllGatherSupported(ncclDataType_t dataType) {
+  switch (dataType) {
+#ifdef RCCL_FLOAT8
+  case ncclFloat8e4m3:
+  case ncclFloat8e5m2:
+    return false;
+#endif
+  default:
+    return true;
+  }
+}
 #endif
 
 ncclResult_t mscclEnqueueCheck(
@@ -606,7 +618,7 @@ ncclResult_t mscclEnqueueCheck(
             threadLocalStatus.savedSchedulerParams.clear();
             break;
           }
-          else if (func == mscclFuncAllGather && nBytes * comm->nRanks <= comm->mscclpp_threshold) {
+          else if (func == mscclFuncAllGather && nBytes * comm->nRanks <= comm->mscclpp_threshold && isMscclppAllGatherSupported(dataType)) {
             INFO(NCCL_COLL,"%s: opCount %lx sendbuff %p recvbuff %p count %zi datatype %d op %d root %d comm %p [nranks=%d] stream %p graphMode %d ubr %d",
               "mscclpp_ncclAllGather", comm->opCount, sendBuff, recvBuff, count, dataType, op, root, comm, comm->nRanks, stream, 
 	      	graphMode, buffsRegistered);
@@ -652,7 +664,7 @@ ncclResult_t mscclEnqueueCheck(
             threadLocalStatus.savedSchedulerParams.clear();
             break;
           }
-          else if (func == mscclFuncAllGather && nBytes * comm->nRanks <= comm->mscclpp_threshold) {
+          else if (func == mscclFuncAllGather && nBytes * comm->nRanks <= comm->mscclpp_threshold && isMscclppAllGatherSupported(dataType)) {
             INFO(NCCL_COLL,"%s: opCount %lx sendbuff %p recvbuff %p count %zi datatype %d op %d root %d comm %p [nranks=%d] stream %p graphMode %d ubr %d" ,
               "mscclpp_ncclAllGather", comm->opCount, sendBuff, recvBuff, count, dataType, op, root, comm, comm->nRanks, stream, 
 	      	graphMode, buffsRegistered);


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** LWPCOMMLIBS-658

**What were the changes?**  
Added datatype validation for AllGather before `mscclpp_ncclAllGather` is invoked.

**Why were the changes made?**  
When MSCCLPP is enabled, AllGather (`mscclpp_ncclAllGather`) is crashing with fp8 datatypes. This validation ensures a proper fallback until the underlying issue is resolved.

**How was the outcome achieved?**  
Implemented a switch-based validation function `isMscclppAllGatherSupported(ncclDataType_t dataType)` that conditionally excludes float8 types while returning true for all other datatypes.

**Additional Documentation:**  

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
