### PR TITLE
Patched incompatible primitives constructor but from upstream NCCL.

### DIFF
--- a/src/device/all_gather.h
+++ b/src/device/all_gather.h
@@ -10,7 +10,43 @@
 #include "primitives.h"
 
 namespace {
-  template<typename T, typename RedOp, typename Proto, bool isNetOffload = false>
+    //------Temporary work around to fix incompatible primitive constructors------
+    //------Delete when upstream fix in NCCL becomes available -----------------------
+    template<typename T, typename RedOp, typename Proto, bool isNetOffload>
+    struct PrimsCaller {
+      __host__ __device__ static Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, isNetOffload>
+      call(int tid, int nthreads, int const *recvPeers, int const *sendPeers,
+      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group=0,
+      uint8_t connIndexRecv = 0, uint8_t connIndexSend = 0, struct ncclDevWorkColl* collWork = nullptr) {
+          return Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, isNetOffload>(
+            tid, nthreads, recvPeers, sendPeers, inputBuf, outputBuf, redOpArg, group, connIndexRecv, connIndexSend, collWork, nullptr, isNetOffload ? NCCL_MAX_NET_SIZE : 0);
+      }
+    };
+    // Specialization for ProtoLL
+    template<typename T, typename RedOp, int COLL_UNROLL, bool isNetOffload>
+    struct PrimsCaller<T, RedOp, ProtoLL, COLL_UNROLL, isNetOffload> {
+        __host__ __device__ static Primitives<T, RedOp, FanSymmetric<1>, 0, ProtoLL, 0, isNetOffload>
+        call(int tid, int nthreads, int const *recvPeers, int const *sendPeers,
+      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group=0,
+      uint8_t connIndexRecv = 0, uint8_t connIndexSend = 0, struct ncclDevWorkColl* collWork = nullptr) {
+            return Primitives<T, RedOp, FanSymmetric<1>, 0, ProtoLL, 0, isNetOffload>(
+                tid, nthreads, recvPeers, sendPeers, inputBuf, outputBuf, redOpArg, group, connIndexRecv, connIndexSend, collWork, false, false, isNetOffload ? NCCL_MAX_NET_SIZE : 0);
+        }
+    };
+
+    // Specialization for ProtoLL128
+    template<typename T, typename RedOp, int COLL_UNROLL, bool isNetOffload>
+    struct PrimsCaller<T, RedOp, ProtoLL128, COLL_UNROLL, isNetOffload> {
+        __host__ __device__ static Primitives<T, RedOp, FanSymmetric<1>, 0, ProtoLL128, 0, isNetOffload>
+        call(int tid, int nthreads, int const *recvPeers, int const *sendPeers,
+      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group=0,
+      uint8_t connIndexRecv = 0, uint8_t connIndexSend = 0, struct ncclDevWorkColl* collWork = nullptr) {
+            return Primitives<T, RedOp, FanSymmetric<1>, 0, ProtoLL128, 0, isNetOffload>(
+                tid, nthreads, recvPeers, sendPeers, inputBuf, outputBuf, redOpArg, group, connIndexRecv, connIndexSend, collWork, false, false, isNetOffload ? NCCL_MAX_NET_SIZE : 0);
+        }
+    };
+    // ----------------------------------------------------------------------------
+    template<typename T, typename RedOp, typename Proto, bool isNetOffload = false>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
@@ -66,12 +102,19 @@ namespace {
     }
 
     if (tid < workNthreads) {
-      // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
-      // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
-      // coverity[callee_ptr_arith:FALSE]
-      Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, isNetOffload> prims
-        (tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex, work->connIndex, work, NULL, isNetOffload ? NCCL_MAX_NET_SIZE : 0);
+      //--- Work around for incompatible primitive constructor ---
 
+      // // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
+      // // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
+      // // coverity[callee_ptr_arith:FALSE]
+      // Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, isNetOffload> prims
+      //   (tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex, work->connIndex, work, NULL, isNetOffload ? NCCL_MAX_NET_SIZE : 0);
+
+      auto prims = PrimsCaller<T, RedOp, Proto, COLL_UNROLL, isNetOffload>::call(
+          tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf,
+          work->redOpArg, 0, work->connIndex, work->connIndex, work
+      );
+    //---------------------------------------------------------
 #if defined(ENABLE_NPKIT)
       if (tid == 0) {
         prims.npKitCtxIdx = npKitCtxIdx;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

Adding template specialization for resolving incompatible calling of the Primitive Constructor from all_gather.h.

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

Ticket: https://amd-hub.atlassian.net/browse/AFLDSUP-47. A bug introduced from upstream NCCL (https://github.com/ROCm/rccl/commit/a6bf9bfc9ed9e3790dbc369a33b54d8087c3f378) naively tried to add a stepSize_  value to the Primitive template constructor, unaware that stepSize_ is indexed differently in different specializations of the template (i.e. 12th in Simple, 13th in LL and LL128), and the preceding arguments are of different types. This leads to issue described in https://github.com/ROCm/rccl/issues/1762. 

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

As a workaround, templated wrappers around the primitive constructors are introduced. The wrappers specializes for Simple, LL, and LL128 and formulates the correct arguments for each constructor respectively. 

**Additional Documentation:**  
_What else should the reviewer know?_

This is intended to be a temporary workaround. The ideal solution would be to have compatible constructors between LL, LL128, and Simple (e.g. having stepSize_ moved up the index 11 would address this nicely). However, this would result in a major refactor that likely would cause divergence from upstream. It would be the best to report this issue to upstream and wait until they fix it, and use this workaround for now. 

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
