### PR TITLE
Fix segfault when libibverbs returns 0 device.

### DIFF
--- a/src/misc/ibvwrap.cc
+++ b/src/misc/ibvwrap.cc
@@ -107,6 +107,7 @@ ncclResult_t wrap_ibv_get_device_list(struct ibv_device ***ret, int *num_devices
 }
 
 ncclResult_t wrap_ibv_free_device_list(struct ibv_device **list) {
+  if (list == nullptr) return ncclSuccess;
   IBV_PASSTHRU(ibvSymbols, ibv_internal_free_device_list, ibv_internal_free_device_list(list));
 }
 


### PR DESCRIPTION
Fix: SWDEV-543816

## Details

**Work item:** : SWDEV-543816

**What were the changes?**  
Check for NULL pointer before calling free.

**Why were the changes made?**  
In some configuration where libibverbs is available but no device, it returns 0 device count but the device list (NULL) is still passed to free. This PR checks for NULL pointer.

**How was the outcome achieved?**  
One line if-statement.

**Additional Documentation:**  


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
