### PR TITLE
Add Unit Test for bitops.h

### DIFF
--- a/test/BitOpsTests.cpp
+++ b/test/BitOpsTests.cpp
@@ -1,0 +1,225 @@
+#include "bitops.h"
+#include "gtest/gtest.h"
+
+class BitOpsTestsFixture : public ::testing::Test {
+public:
+    BitOpsTestsFixture() = default;
+    ~BitOpsTestsFixture() override = default;
+protected:
+    int m_size{0};
+    uint32_t m_u32Val{2};
+    uint8_t m_u8Val{2};
+    std::vector<uint32_t> m_u32Vec{2, 4, 8, 16, 32, 64, 128, 256};
+    std::vector<float> m_floatVec{2.0f};
+};
+
+
+TEST_F(BitOpsTestsFixture, DIVUP_Tests) {
+    EXPECT_EQ(DIVUP(0, 8), 0);
+    EXPECT_EQ(DIVUP(1, 8), 1);
+    EXPECT_EQ(DIVUP(7, 8), 1);
+    EXPECT_EQ(DIVUP(8, 8), 1);
+    EXPECT_EQ(DIVUP(9, 8), 2);
+}
+
+TEST_F(BitOpsTestsFixture, ROUNDUP_Tests) {
+    EXPECT_EQ(ROUNDUP(0, 8), 0);
+    EXPECT_EQ(ROUNDUP(1, 8), 8);
+    EXPECT_EQ(ROUNDUP(7, 8), 8);
+    EXPECT_EQ(ROUNDUP(8, 8), 8);
+    EXPECT_EQ(ROUNDUP(9, 8), 16);
+    EXPECT_EQ(ROUNDUP(15, 8), 16);
+    EXPECT_EQ(ROUNDUP(16, 8), 16);
+    EXPECT_EQ(ROUNDUP(17, 8), 24);
+}
+
+TEST_F(BitOpsTestsFixture, ALIGN_POWER_Tests) {
+    EXPECT_EQ(ALIGN_POWER(7, 8), 8);
+    EXPECT_EQ(ALIGN_POWER(8, 8), 8);
+    EXPECT_EQ(ALIGN_POWER(9, 8), 16);
+}
+
+TEST_F(BitOpsTestsFixture, ALIGN_SIZE_Tests) {
+    m_size = 1;
+    ALIGN_SIZE(m_size, 8);
+    EXPECT_EQ(m_size, 8);
+    m_size = 7;
+    ALIGN_SIZE(m_size, 8);
+    EXPECT_EQ(m_size, 8);
+}
+
+TEST_F(BitOpsTestsFixture, divUp_Tests) {
+    EXPECT_EQ(divUp(0, 8), 0);
+    EXPECT_EQ(divUp(1, 8), 1);
+    EXPECT_EQ(divUp(7, 8), 1);
+    EXPECT_EQ(divUp(8, 8), 1);
+    EXPECT_EQ(divUp(9, 8), 2);
+    EXPECT_EQ(divUp(15, 8), 2);
+    EXPECT_EQ(divUp(16, 8), 2);
+    EXPECT_EQ(divUp(17, 8), 3);
+}
+
+TEST_F(BitOpsTestsFixture, roundUp_Tests) {
+    EXPECT_EQ(roundUp(0, 8), 0);
+    EXPECT_EQ(roundUp(1, 8), 8);
+    EXPECT_EQ(roundUp(7, 8), 8);
+    EXPECT_EQ(roundUp(8, 8), 8);
+    EXPECT_EQ(roundUp(9, 8), 16);
+    EXPECT_EQ(roundUp(15, 8), 16);
+    EXPECT_EQ(roundUp(16, 8), 16);
+    EXPECT_EQ(roundUp(17, 8), 24);
+}
+
+TEST_F(BitOpsTestsFixture, roundDown_Tests) {
+    EXPECT_EQ(roundDown(0, 8), 0);
+    EXPECT_EQ(roundDown(1, 8), 0);
+    EXPECT_EQ(roundDown(7, 8), 0);
+    EXPECT_EQ(roundDown(8, 8), 8);
+    EXPECT_EQ(roundDown(9, 8), 8);
+    EXPECT_EQ(roundDown(15, 8), 8);
+    EXPECT_EQ(roundDown(16, 8), 16);
+    EXPECT_EQ(roundDown(17, 8), 16);
+}
+
+TEST_F(BitOpsTestsFixture, alignUp_Tests) {
+    EXPECT_EQ(alignUp(0, 8), 0);
+    EXPECT_EQ(alignUp(1, 8), 8);
+    EXPECT_EQ(alignUp(7, 8), 8);
+    EXPECT_EQ(alignUp(8, 8), 8);
+    EXPECT_EQ(alignUp(9, 8), 16);
+    EXPECT_EQ(alignUp(15, 8), 16);
+    EXPECT_EQ(alignUp(16, 8), 16);
+    EXPECT_EQ(alignUp(17, 8), 24);
+}
+
+
+TEST_F(BitOpsTestsFixture, u32fp8MaxValue) {
+    EXPECT_EQ(u32fp8MaxValue(), 0xf0000000);
+}
+
+TEST_F(BitOpsTestsFixture, u32fp8Encode) {
+    uint8_t expected = 2;
+    EXPECT_EQ(u32fp8Encode(this->m_u32Val), expected);
+}
+
+TEST_F(BitOpsTestsFixture, u32fp8Decode) {
+    uint32_t expected = 2;
+    EXPECT_EQ(u32fp8Decode(this->m_u8Val), expected);
+}
+
+TEST_F(BitOpsTestsFixture, getHash) {
+    uint64_t expected = 0xa4495d05731e3337;
+    auto ret = getHash(this->m_u32Vec.data(), this->m_u32Vec.size() * sizeof(uint32_t));
+    EXPECT_EQ(ret, expected);
+
+    expected = 0xedbaa57e84d6dbaa;
+    ret = getHash(this->m_floatVec.data());
+    EXPECT_EQ(ret, expected);
+}
+
+template <typename T>
+class BitOpsTemplateAllIntTestsFixture : public testing::Test {
+public:
+    BitOpsTemplateAllIntTestsFixture() = default;
+    ~BitOpsTemplateAllIntTestsFixture() override = default;
+protected:
+    T m_countOneBitVal{3};
+    T m_firstOneBitVal{3};
+    T m_popFirstOneBitVal{3};
+    T m_log2DownVal{0};
+    T m_log2UpVal{0};
+    T m_power2UpVal{0};
+    T m_power2DownVal{1};
+};
+
+using BitOpsAllIntTypes = ::testing::Types<int, unsigned int, long, unsigned long, long long, unsigned long long>;
+
+TYPED_TEST_SUITE(BitOpsTemplateAllIntTestsFixture, BitOpsAllIntTypes);
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, BitOpsCountOneBits) {
+    EXPECT_EQ(countOneBits(this->m_countOneBitVal), 2);
+}
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, BitOpsFirstOneBits) {
+    EXPECT_EQ(firstOneBit(this->m_firstOneBitVal), 0);
+}
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, BitOpsPopFirstOneBits) {
+    EXPECT_EQ(popFirstOneBit(&(this->m_popFirstOneBitVal)), 0);
+}
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, log2Down) {
+    EXPECT_EQ(log2Down(this->m_log2DownVal), -1);
+    this->m_log2DownVal = 1;
+    EXPECT_EQ(log2Down(this->m_log2DownVal), 0);
+    this->m_log2DownVal = 2;
+    EXPECT_EQ(log2Down(this->m_log2DownVal), 1);
+}
+
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, log2Up) {
+    EXPECT_EQ(log2Up(this->m_log2UpVal), 0);
+    this->m_log2UpVal = 1;
+    EXPECT_EQ(log2Up(this->m_log2UpVal), 0);
+    this->m_log2UpVal = 2;
+    EXPECT_EQ(log2Up(this->m_log2UpVal), 1);
+    this->m_log2UpVal = 3;
+    EXPECT_EQ(log2Up(this->m_log2UpVal), 2);
+}
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, pow2Up){
+    EXPECT_EQ(pow2Up(this->m_power2UpVal), 1);
+    this->m_power2UpVal = 1;
+    EXPECT_EQ(pow2Up(this->m_power2UpVal), 1);
+    this->m_power2UpVal = 2;
+    EXPECT_EQ(pow2Up(this->m_power2UpVal), 2);
+    this->m_power2UpVal = 3;
+    EXPECT_EQ(pow2Up(this->m_power2UpVal), 4);
+}
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, pow2Down){
+    EXPECT_EQ(pow2Down(this->m_power2DownVal), 1);
+    this->m_power2DownVal = 2;
+    EXPECT_EQ(pow2Down(this->m_power2DownVal), 2);
+    this->m_power2DownVal = 3;
+    EXPECT_EQ(pow2Down(this->m_power2DownVal), 2);
+}
+
+
+template <typename T>
+class BitOpsTemplateUnsignedTestsFixture : public testing::Test {
+public:
+    BitOpsTemplateUnsignedTestsFixture() = default;
+    ~BitOpsTemplateUnsignedTestsFixture() override = default;
+protected:
+    T m_reverseSubBits{2};
+    T m_reverseBits{2}; // 0b10
+};
+
+using BitOpsUnsignedTypes = ::testing::Types<unsigned int, unsigned long, unsigned long long>;
+
+TYPED_TEST_SUITE(BitOpsTemplateUnsignedTestsFixture, BitOpsUnsignedTypes);
+
+TYPED_TEST(BitOpsTemplateUnsignedTestsFixture, reverseSubBits) {
+    auto ret = reverseSubBits<TypeParam, 1>(this->m_reverseSubBits);
+    EXPECT_EQ(ret, this->m_reverseSubBits);
+    ret = reverseSubBits<TypeParam, 2>(this->m_reverseSubBits);
+    EXPECT_EQ(ret, 1);
+    ret = reverseSubBits<TypeParam, 4>(this->m_reverseSubBits);
+    EXPECT_EQ(ret, 4); 
+    ret = reverseSubBits<TypeParam, 8>(this->m_reverseSubBits);
+    EXPECT_EQ(ret, 64); 
+    ret = reverseSubBits<TypeParam, 16>(this->m_reverseSubBits);
+    EXPECT_EQ(ret, 16384);
+    ret = reverseSubBits<TypeParam, 32>(this->m_reverseSubBits);
+    EXPECT_EQ(ret, 1073741824);
+}
+
+
+TYPED_TEST(BitOpsTemplateUnsignedTestsFixture, reverseBits) {
+    auto ret = reverseBits(this->m_reverseBits, 2);
+    EXPECT_EQ(ret, 1); // 0b01
+    ret = reverseBits(this->m_reverseBits, 16);
+    EXPECT_EQ(ret, 16384); // 0b0100000000000000
+}
+

--- a/test/BitOpsTests.cpp
+++ b/test/BitOpsTests.cpp
@@ -73,7 +73,6 @@ TEST(getHash, getHashSuccess) {
 template <typename T>
 class BitOpsTemplateAllIntTestsFixture : public testing::Test {
 public:
-    BitOpsTemplateAllIntTestsFixture() = default;
     ~BitOpsTemplateAllIntTestsFixture() override = default;
 protected:
     T valX_{};
@@ -195,7 +194,7 @@ TYPED_TEST(BitOpsTemplateAllIntTestsFixture, pow2UpSuccess){
     EXPECT_EQ(pow2Up(this->valX_), 4);
 }
 
-TYPED_TEST(BitOpsTemplateAllIntTestsFixture, pow2Down){
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, pow2DownSuccess){
     this->valX_ = 1;
     EXPECT_EQ(pow2Down(this->valX_), 1);
     this->valX_ = 2;
@@ -207,18 +206,17 @@ TYPED_TEST(BitOpsTemplateAllIntTestsFixture, pow2Down){
 template <typename T>
 class BitOpsTemplateUnsignedTestsFixture : public testing::Test {
 public:
-    BitOpsTemplateUnsignedTestsFixture() = default;
     ~BitOpsTemplateUnsignedTestsFixture() override = default;
 protected:
     T reverseSubBits_{2};
-    T reverseBits_{2}; // 0b10
+    T reverseBits_{2};
 };
 
 using BitOpsUnsignedTypes = ::testing::Types<unsigned int, unsigned long, unsigned long long>;
 
 TYPED_TEST_SUITE(BitOpsTemplateUnsignedTestsFixture, BitOpsUnsignedTypes);
 
-TYPED_TEST(BitOpsTemplateUnsignedTestsFixture, reverseSubBits) {
+TYPED_TEST(BitOpsTemplateUnsignedTestsFixture, reverseSubBitsSuccess) {
     auto ret = reverseSubBits<TypeParam, 1>(this->reverseSubBits_);
     EXPECT_EQ(ret, this->reverseSubBits_);
     ret = reverseSubBits<TypeParam, 2>(this->reverseSubBits_);
@@ -233,11 +231,11 @@ TYPED_TEST(BitOpsTemplateUnsignedTestsFixture, reverseSubBits) {
     EXPECT_EQ(ret, 1073741824);
 }
 
-TYPED_TEST(BitOpsTemplateUnsignedTestsFixture, reverseBits) {
+TYPED_TEST(BitOpsTemplateUnsignedTestsFixture, reverseBitsSuccess) {
     auto ret = reverseBits(this->reverseBits_, 2);
-    EXPECT_EQ(ret, 1); // 0b01
+    EXPECT_EQ(ret, 1);
     ret = reverseBits(this->reverseBits_, 16);
-    EXPECT_EQ(ret, 16384); // 0b0100000000000000
+    EXPECT_EQ(ret, 16384);
 }
 
 }

--- a/test/BitOpsTests.cpp
+++ b/test/BitOpsTests.cpp
@@ -1,20 +1,16 @@
+/*************************************************************************
+ * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
 #include "bitops.h"
 #include "gtest/gtest.h"
 
-class BitOpsTestsFixture : public ::testing::Test {
-public:
-    BitOpsTestsFixture() = default;
-    ~BitOpsTestsFixture() override = default;
-protected:
-    int m_size{0};
-    uint32_t m_u32Val{2};
-    uint8_t m_u8Val{2};
-    std::vector<uint32_t> m_u32Vec{2, 4, 8, 16, 32, 64, 128, 256};
-    std::vector<float> m_floatVec{2.0f};
-};
+namespace RcclUnitTesting
+{
 
-
-TEST_F(BitOpsTestsFixture, DIVUP_Tests) {
+TEST(DIVUP, DIVUPSuccess) {
     EXPECT_EQ(DIVUP(0, 8), 0);
     EXPECT_EQ(DIVUP(1, 8), 1);
     EXPECT_EQ(DIVUP(7, 8), 1);
@@ -22,7 +18,7 @@ TEST_F(BitOpsTestsFixture, DIVUP_Tests) {
     EXPECT_EQ(DIVUP(9, 8), 2);
 }
 
-TEST_F(BitOpsTestsFixture, ROUNDUP_Tests) {
+TEST(ROUNDUP, ROUNDUPSuccess) {
     EXPECT_EQ(ROUNDUP(0, 8), 0);
     EXPECT_EQ(ROUNDUP(1, 8), 8);
     EXPECT_EQ(ROUNDUP(7, 8), 8);
@@ -33,88 +29,45 @@ TEST_F(BitOpsTestsFixture, ROUNDUP_Tests) {
     EXPECT_EQ(ROUNDUP(17, 8), 24);
 }
 
-TEST_F(BitOpsTestsFixture, ALIGN_POWER_Tests) {
+TEST(ALIGN_POWER, ALIGN_POWERSuccess) {
     EXPECT_EQ(ALIGN_POWER(7, 8), 8);
     EXPECT_EQ(ALIGN_POWER(8, 8), 8);
     EXPECT_EQ(ALIGN_POWER(9, 8), 16);
 }
 
-TEST_F(BitOpsTestsFixture, ALIGN_SIZE_Tests) {
-    m_size = 1;
-    ALIGN_SIZE(m_size, 8);
-    EXPECT_EQ(m_size, 8);
-    m_size = 7;
-    ALIGN_SIZE(m_size, 8);
-    EXPECT_EQ(m_size, 8);
+TEST(ALIGN_SIZE, ALIGN_SIZESuccess) {
+    int alignSize = 1;
+    ALIGN_SIZE(alignSize, 8);
+    EXPECT_EQ(alignSize, 8);
+    alignSize = 7;
+    ALIGN_SIZE(alignSize, 8);
+    EXPECT_EQ(alignSize, 8);
 }
 
-TEST_F(BitOpsTestsFixture, divUp_Tests) {
-    EXPECT_EQ(divUp(0, 8), 0);
-    EXPECT_EQ(divUp(1, 8), 1);
-    EXPECT_EQ(divUp(7, 8), 1);
-    EXPECT_EQ(divUp(8, 8), 1);
-    EXPECT_EQ(divUp(9, 8), 2);
-    EXPECT_EQ(divUp(15, 8), 2);
-    EXPECT_EQ(divUp(16, 8), 2);
-    EXPECT_EQ(divUp(17, 8), 3);
-}
-
-TEST_F(BitOpsTestsFixture, roundUp_Tests) {
-    EXPECT_EQ(roundUp(0, 8), 0);
-    EXPECT_EQ(roundUp(1, 8), 8);
-    EXPECT_EQ(roundUp(7, 8), 8);
-    EXPECT_EQ(roundUp(8, 8), 8);
-    EXPECT_EQ(roundUp(9, 8), 16);
-    EXPECT_EQ(roundUp(15, 8), 16);
-    EXPECT_EQ(roundUp(16, 8), 16);
-    EXPECT_EQ(roundUp(17, 8), 24);
-}
-
-TEST_F(BitOpsTestsFixture, roundDown_Tests) {
-    EXPECT_EQ(roundDown(0, 8), 0);
-    EXPECT_EQ(roundDown(1, 8), 0);
-    EXPECT_EQ(roundDown(7, 8), 0);
-    EXPECT_EQ(roundDown(8, 8), 8);
-    EXPECT_EQ(roundDown(9, 8), 8);
-    EXPECT_EQ(roundDown(15, 8), 8);
-    EXPECT_EQ(roundDown(16, 8), 16);
-    EXPECT_EQ(roundDown(17, 8), 16);
-}
-
-TEST_F(BitOpsTestsFixture, alignUp_Tests) {
-    EXPECT_EQ(alignUp(0, 8), 0);
-    EXPECT_EQ(alignUp(1, 8), 8);
-    EXPECT_EQ(alignUp(7, 8), 8);
-    EXPECT_EQ(alignUp(8, 8), 8);
-    EXPECT_EQ(alignUp(9, 8), 16);
-    EXPECT_EQ(alignUp(15, 8), 16);
-    EXPECT_EQ(alignUp(16, 8), 16);
-    EXPECT_EQ(alignUp(17, 8), 24);
-}
-
-
-TEST_F(BitOpsTestsFixture, u32fp8MaxValue) {
+TEST(u32fp8MaxValue, u32fp8MaxValueSuccess) {
     EXPECT_EQ(u32fp8MaxValue(), 0xf0000000);
 }
 
-TEST_F(BitOpsTestsFixture, u32fp8Encode) {
-    uint8_t expected = 2;
-    EXPECT_EQ(u32fp8Encode(this->m_u32Val), expected);
+TEST(u32fp8Decode, u32fp8DecodeSuccess) {
+    uint32_t u32Val{2};
+    EXPECT_EQ(u32fp8Decode(u32Val), static_cast<uint8_t>(2));
 }
 
-TEST_F(BitOpsTestsFixture, u32fp8Decode) {
-    uint32_t expected = 2;
-    EXPECT_EQ(u32fp8Decode(this->m_u8Val), expected);
+TEST(u32fp8Encode, u32fp8EncodeSuccess) {
+    uint8_t u8Val{2};
+    EXPECT_EQ(u32fp8Encode(u8Val), static_cast<uint32_t>(2));
 }
 
-TEST_F(BitOpsTestsFixture, getHash) {
-    uint64_t expected = 0xa4495d05731e3337;
-    auto ret = getHash(this->m_u32Vec.data(), this->m_u32Vec.size() * sizeof(uint32_t));
-    EXPECT_EQ(ret, expected);
+TEST(getHash, getHashSuccess) {
+    std::vector<uint32_t> u32Vec{2, 4, 8, 16, 32, 64, 128, 256};
+    uint64_t expectedHash = 0xa4495d05731e3337;
+    auto ret = getHash(u32Vec.data(), u32Vec.size() * sizeof(uint32_t));
+    EXPECT_EQ(ret, expectedHash);
 
-    expected = 0xedbaa57e84d6dbaa;
-    ret = getHash(this->m_floatVec.data());
-    EXPECT_EQ(ret, expected);
+    std::vector<float> floatVec{2.0f};
+    expectedHash = 0xedbaa57e84d6dbaa;
+    ret = getHash(floatVec.data());
+    EXPECT_EQ(ret, expectedHash);
 }
 
 template <typename T>
@@ -123,68 +76,133 @@ public:
     BitOpsTemplateAllIntTestsFixture() = default;
     ~BitOpsTemplateAllIntTestsFixture() override = default;
 protected:
-    T m_countOneBitVal{3};
-    T m_firstOneBitVal{3};
-    T m_popFirstOneBitVal{3};
-    T m_log2DownVal{0};
-    T m_log2UpVal{0};
-    T m_power2UpVal{0};
-    T m_power2DownVal{1};
+    T valX_{};
+    T valY_{};
+    T valZ_{};
 };
 
 using BitOpsAllIntTypes = ::testing::Types<int, unsigned int, long, unsigned long, long long, unsigned long long>;
 
 TYPED_TEST_SUITE(BitOpsTemplateAllIntTestsFixture, BitOpsAllIntTypes);
 
-TYPED_TEST(BitOpsTemplateAllIntTestsFixture, BitOpsCountOneBits) {
-    EXPECT_EQ(countOneBits(this->m_countOneBitVal), 2);
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, divUpSuccess) {
+    this->valX_ = 0;
+    this->valY_= 8;
+    this->valZ_= 0;
+    EXPECT_EQ(divUp(this->valX_, this->valY_), this->valZ_);
+    this->valX_ = 1;
+    this->valY_= 8;
+    this->valZ_= 1;
+    EXPECT_EQ(divUp(this->valX_, this->valY_), this->valZ_);
+    this->valX_ = 7;
+    this->valY_= 8;
+    this->valZ_= 1;
+    EXPECT_EQ(divUp(this->valX_, this->valY_), this->valZ_);
 }
 
-TYPED_TEST(BitOpsTemplateAllIntTestsFixture, BitOpsFirstOneBits) {
-    EXPECT_EQ(firstOneBit(this->m_firstOneBitVal), 0);
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, roundUpSuccess) {
+    this->valX_ = 0;
+    this->valY_= 8;
+    this->valZ_= 0;
+    EXPECT_EQ(roundUp(this->valX_, this->valY_), this->valZ_);
+    this->valX_ = 1;
+    this->valY_= 8;
+    this->valZ_= 8;
+    EXPECT_EQ(roundUp(this->valX_, this->valY_), this->valZ_);
+    this->valX_ = 7;
+    this->valY_= 8;
+    this->valZ_= 8;
+    EXPECT_EQ(roundUp(this->valX_, this->valY_), this->valZ_);
 }
 
-TYPED_TEST(BitOpsTemplateAllIntTestsFixture, BitOpsPopFirstOneBits) {
-    EXPECT_EQ(popFirstOneBit(&(this->m_popFirstOneBitVal)), 0);
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, roundDownSuccess) {
+    this->valX_ = 0;
+    this->valY_= 8;
+    this->valZ_= 0;
+    EXPECT_EQ(roundDown(this->valX_, this->valY_), this->valZ_);
+    this->valX_ = 1;
+    this->valY_= 8;
+    this->valZ_= 0;
+    EXPECT_EQ(roundDown(this->valX_, this->valY_), this->valZ_);
+    this->valX_ = 7;
+    this->valY_= 8;
+    this->valZ_= 0;
+    EXPECT_EQ(roundDown(this->valX_, this->valY_), this->valZ_);
 }
 
-TYPED_TEST(BitOpsTemplateAllIntTestsFixture, log2Down) {
-    EXPECT_EQ(log2Down(this->m_log2DownVal), -1);
-    this->m_log2DownVal = 1;
-    EXPECT_EQ(log2Down(this->m_log2DownVal), 0);
-    this->m_log2DownVal = 2;
-    EXPECT_EQ(log2Down(this->m_log2DownVal), 1);
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, alignUpSuccess) {
+    this->valX_ = 0;
+    this->valY_= 8;
+    this->valZ_= 0;
+    EXPECT_EQ(alignUp(this->valX_, this->valY_), this->valZ_);
+    this->valX_ = 1;
+    this->valY_= 8;
+    this->valZ_= 8;
+    EXPECT_EQ(alignUp(this->valX_, this->valY_), this->valZ_);
+    this->valX_ = 7;
+    this->valY_= 8;
+    this->valZ_= 8;
+    EXPECT_EQ(alignUp(this->valX_, this->valY_), this->valZ_);
+}
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, BitOpsCountOneBitsSuccess) {
+    this->valX_ = 3; // 0b11
+    int expectedBitCount = 2; 
+    EXPECT_EQ(countOneBits(this->valX_), expectedBitCount);
+}
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, BitOpsFirstOneBitsSuccess) {
+    this->valX_ = 3; // 0b11
+    int expectedFirstOneBitIndex = 0; 
+    EXPECT_EQ(firstOneBit(this->valX_), expectedFirstOneBitIndex);
+}
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, BitOpsPopFirstOneBitsSuccess) {
+    this->valX_ = 3; // 0b11
+    int expectedPopFirstOneBitIndex = 0; // 0b01
+    EXPECT_EQ(popFirstOneBit(&(this->valX_)), expectedPopFirstOneBitIndex);
+}
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, log2DownSuccess) {
+    this->valX_ = 0;
+    EXPECT_EQ(log2Down(this->valX_), -1);
+    this->valX_ = 1;
+    EXPECT_EQ(log2Down(this->valX_), 0);
+    this->valX_ = 2;
+    EXPECT_EQ(log2Down(this->valX_), 1);
 }
 
 
-TYPED_TEST(BitOpsTemplateAllIntTestsFixture, log2Up) {
-    EXPECT_EQ(log2Up(this->m_log2UpVal), 0);
-    this->m_log2UpVal = 1;
-    EXPECT_EQ(log2Up(this->m_log2UpVal), 0);
-    this->m_log2UpVal = 2;
-    EXPECT_EQ(log2Up(this->m_log2UpVal), 1);
-    this->m_log2UpVal = 3;
-    EXPECT_EQ(log2Up(this->m_log2UpVal), 2);
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, log2UpSuccess) {
+    this->valX_ = 0;
+    EXPECT_EQ(log2Up(this->valX_), 0);
+    this->valX_ = 1;
+    EXPECT_EQ(log2Up(this->valX_), 0);
+    this->valX_ = 2;
+    EXPECT_EQ(log2Up(this->valX_), 1);
+    this->valX_ = 3;
+    EXPECT_EQ(log2Up(this->valX_), 2);
 }
 
-TYPED_TEST(BitOpsTemplateAllIntTestsFixture, pow2Up){
-    EXPECT_EQ(pow2Up(this->m_power2UpVal), 1);
-    this->m_power2UpVal = 1;
-    EXPECT_EQ(pow2Up(this->m_power2UpVal), 1);
-    this->m_power2UpVal = 2;
-    EXPECT_EQ(pow2Up(this->m_power2UpVal), 2);
-    this->m_power2UpVal = 3;
-    EXPECT_EQ(pow2Up(this->m_power2UpVal), 4);
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, pow2UpSuccess){
+    this->valX_ = 0;
+    EXPECT_EQ(pow2Up(this->valX_), 1);
+    this->valX_ = 1;
+    EXPECT_EQ(pow2Up(this->valX_), 1);
+    this->valX_ = 2;
+    EXPECT_EQ(pow2Up(this->valX_), 2);
+    this->valX_ = 3;
+    EXPECT_EQ(pow2Up(this->valX_), 4);
 }
 
 TYPED_TEST(BitOpsTemplateAllIntTestsFixture, pow2Down){
-    EXPECT_EQ(pow2Down(this->m_power2DownVal), 1);
-    this->m_power2DownVal = 2;
-    EXPECT_EQ(pow2Down(this->m_power2DownVal), 2);
-    this->m_power2DownVal = 3;
-    EXPECT_EQ(pow2Down(this->m_power2DownVal), 2);
+    this->valX_ = 1;
+    EXPECT_EQ(pow2Down(this->valX_), 1);
+    this->valX_ = 2;
+    EXPECT_EQ(pow2Down(this->valX_), 2);
+    this->valX_ = 3;
+    EXPECT_EQ(pow2Down(this->valX_), 2);
 }
-
 
 template <typename T>
 class BitOpsTemplateUnsignedTestsFixture : public testing::Test {
@@ -192,8 +210,8 @@ public:
     BitOpsTemplateUnsignedTestsFixture() = default;
     ~BitOpsTemplateUnsignedTestsFixture() override = default;
 protected:
-    T m_reverseSubBits{2};
-    T m_reverseBits{2}; // 0b10
+    T reverseSubBits_{2};
+    T reverseBits_{2}; // 0b10
 };
 
 using BitOpsUnsignedTypes = ::testing::Types<unsigned int, unsigned long, unsigned long long>;
@@ -201,25 +219,25 @@ using BitOpsUnsignedTypes = ::testing::Types<unsigned int, unsigned long, unsign
 TYPED_TEST_SUITE(BitOpsTemplateUnsignedTestsFixture, BitOpsUnsignedTypes);
 
 TYPED_TEST(BitOpsTemplateUnsignedTestsFixture, reverseSubBits) {
-    auto ret = reverseSubBits<TypeParam, 1>(this->m_reverseSubBits);
-    EXPECT_EQ(ret, this->m_reverseSubBits);
-    ret = reverseSubBits<TypeParam, 2>(this->m_reverseSubBits);
+    auto ret = reverseSubBits<TypeParam, 1>(this->reverseSubBits_);
+    EXPECT_EQ(ret, this->reverseSubBits_);
+    ret = reverseSubBits<TypeParam, 2>(this->reverseSubBits_);
     EXPECT_EQ(ret, 1);
-    ret = reverseSubBits<TypeParam, 4>(this->m_reverseSubBits);
+    ret = reverseSubBits<TypeParam, 4>(this->reverseSubBits_);
     EXPECT_EQ(ret, 4); 
-    ret = reverseSubBits<TypeParam, 8>(this->m_reverseSubBits);
+    ret = reverseSubBits<TypeParam, 8>(this->reverseSubBits_);
     EXPECT_EQ(ret, 64); 
-    ret = reverseSubBits<TypeParam, 16>(this->m_reverseSubBits);
+    ret = reverseSubBits<TypeParam, 16>(this->reverseSubBits_);
     EXPECT_EQ(ret, 16384);
-    ret = reverseSubBits<TypeParam, 32>(this->m_reverseSubBits);
+    ret = reverseSubBits<TypeParam, 32>(this->reverseSubBits_);
     EXPECT_EQ(ret, 1073741824);
 }
 
-
 TYPED_TEST(BitOpsTemplateUnsignedTestsFixture, reverseBits) {
-    auto ret = reverseBits(this->m_reverseBits, 2);
+    auto ret = reverseBits(this->reverseBits_, 2);
     EXPECT_EQ(ret, 1); // 0b01
-    ret = reverseBits(this->m_reverseBits, 16);
+    ret = reverseBits(this->reverseBits_, 16);
     EXPECT_EQ(ret, 16384); // 0b0100000000000000
 }
 
+}

--- a/test/BitOpsTests.cpp
+++ b/test/BitOpsTests.cpp
@@ -58,6 +58,22 @@ TEST(u32fp8Encode, u32fp8EncodeSuccess) {
     EXPECT_EQ(u32fp8Encode(u8Val), static_cast<uint32_t>(2));
 }
 
+TEST(u32fpEncode, u32fpEncodeSuccess) {
+    // log2x is 1, use bitsPerPow2 = 1
+    uint32_t u32Val{0xFFFFFFFF}; // 32 bits set to 1
+    uint32_t u32ExpectVal = 63;
+    int bitsPerPow2 = 1;
+    EXPECT_EQ(u32fpEncode(u32Val, bitsPerPow2), u32ExpectVal);
+}
+
+TEST(u32fpDecode, u32fpDecodeSuccess) {
+    // log2x is 1, use bitsPerPow2 = 1
+    uint32_t u32Val{0xFFFFFFFF}; // 32 bits set to 1
+    uint32_t u32ExpectVal = 63;
+    int bitsPerPow2 = 1;
+    EXPECT_EQ(u32fpDecode(u32Val, bitsPerPow2), u32ExpectVal);
+}
+
 TEST(getHash, getHashSuccess) {
     std::vector<uint32_t> u32Vec{2, 4, 8, 16, 32, 64, 128, 256};
     uint64_t expectedHash = 0xa4495d05731e3337;
@@ -70,6 +86,15 @@ TEST(getHash, getHashSuccess) {
     EXPECT_EQ(ret, expectedHash);
 }
 
+TEST(eatHash, eatHashSuccess){
+    uint64_t acc[2] = {0, 0};
+    uint64_t expectedAcc[2] = {8617830242246783886ull, 2410367826245614052ull};
+    std::vector<uint32_t> u32Vec{2, 4, 8, 16, 32, 64, 128, 256};
+    eatHash(acc, u32Vec.data());
+    EXPECT_EQ(acc[0], expectedAcc[0]);
+    EXPECT_EQ(acc[1], expectedAcc[1]);
+}
+
 template <typename T>
 class BitOpsTemplateAllIntTestsFixture : public testing::Test {
 public:
@@ -80,7 +105,7 @@ protected:
     T valZ_{};
 };
 
-using BitOpsAllIntTypes = ::testing::Types<int, unsigned int, long, unsigned long, long long, unsigned long long>;
+using BitOpsAllIntTypes = ::testing::Types<short, unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long>;
 
 TYPED_TEST_SUITE(BitOpsTemplateAllIntTestsFixture, BitOpsAllIntTypes);
 
@@ -142,6 +167,21 @@ TYPED_TEST(BitOpsTemplateAllIntTestsFixture, alignUpSuccess) {
     this->valY_= 8;
     this->valZ_= 8;
     EXPECT_EQ(alignUp(this->valX_, this->valY_), this->valZ_);
+}
+
+TYPED_TEST(BitOpsTemplateAllIntTestsFixture, alignDownSuccess) {
+    this->valX_ = 0;
+    this->valY_= 8;
+    this->valZ_= 0;
+    EXPECT_EQ(alignDown(this->valX_, this->valY_), this->valZ_);
+    this->valX_ = 1;
+    this->valY_= 8;
+    this->valZ_= 0;
+    EXPECT_EQ(alignDown(this->valX_, this->valY_), this->valZ_);
+    this->valX_ = 9;
+    this->valY_= 8;
+    this->valZ_= 8;
+    EXPECT_EQ(alignDown(this->valX_, this->valY_), this->valZ_);
 }
 
 TYPED_TEST(BitOpsTemplateAllIntTestsFixture, BitOpsCountOneBitsSuccess) {
@@ -212,7 +252,7 @@ protected:
     T reverseBits_{2};
 };
 
-using BitOpsUnsignedTypes = ::testing::Types<unsigned int, unsigned long, unsigned long long>;
+using BitOpsUnsignedTypes = ::testing::Types<unsigned short, unsigned int, unsigned long, unsigned long long>;
 
 TYPED_TEST_SUITE(BitOpsTemplateUnsignedTestsFixture, BitOpsUnsignedTypes);
 
@@ -227,8 +267,10 @@ TYPED_TEST(BitOpsTemplateUnsignedTestsFixture, reverseSubBitsSuccess) {
     EXPECT_EQ(ret, 64); 
     ret = reverseSubBits<TypeParam, 16>(this->reverseSubBits_);
     EXPECT_EQ(ret, 16384);
-    ret = reverseSubBits<TypeParam, 32>(this->reverseSubBits_);
-    EXPECT_EQ(ret, 1073741824);
+    if(!std::is_same<TypeParam, unsigned short>::value) {
+        ret = reverseSubBits<TypeParam, 32>(this->reverseSubBits_);
+        EXPECT_EQ(ret, 1073741824);
+    }
 }
 
 TYPED_TEST(BitOpsTemplateUnsignedTestsFixture, reverseBitsSuccess) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,11 @@ if(BUILD_TESTS)
 
   message("Building rccl unit tests (Installed in /test/rccl-UnitTests)")
 
+  if (ENABLE_CODE_COVERAGE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+    set(HIPCC_COMPILE_FLAGS "${HIPCC_COMPILE_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+  endif()
+
   find_package(hsa-runtime64 PATHS /opt/rocm )
   if(${hsa-runtime64_FOUND})
     message("hsa-runtime64 found @  ${hsa-runtime64_DIR} ")
@@ -134,6 +139,7 @@ if(BUILD_TESTS)
       ArgCheckTests.cpp
       ShmTests.cpp
       P2pTests.cpp
+      BitOpsTests.cpp
       common/main_fixtures.cpp
       common/EnvVars.cpp
     )


### PR DESCRIPTION
## Details
Add Unit Test For bitopts.h

**What were the changes?**  
1. Changed UnitTest Camke to honor code coverage compiler flags
2. Added UnitTest for bitops.h to improve the coverage to  95.65% (22/23)

**Why were the changes made?**  
The motivation is to improve Unit Test Coverage

**How was the outcome achieved?**  
Change in CMakeLists.txt file.
Added Unit Test

**Additional Documentation:**  
If we don't honor the code coverage flags in the CMakeLists.txt, the code coverage report will not be generated for the bitopts.h

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
