### PR TITLE
Fix LL128 proto selection to respect user setting

### DIFF
--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -736,7 +736,7 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   for (int c=0; c<NCCL_NUM_FUNCTIONS; c++) for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
     // Disable LL protocol on gfx12xx
     int pEnable = (p == NCCL_PROTO_LL && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx12")) ? 0 : protoEnable[c*NCCL_NUM_PROTOCOLS+p];
-    if (p == NCCL_PROTO_LL128) {
+    if (pEnable != 0 && p == NCCL_PROTO_LL128) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #if defined(ENABLE_LL128)
       // Enable LL128 by default only on gfx90a with available tuning table


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** Internal

**What were the changes?**  
Modified the LL128 protocol validation condition in `tuning.cc` to ensure that we don't always select LL128 when `NCCL_PROTO` is set to a different protocol.

**Why were the changes made?**  
The existing logic was also unconditionally selecting LL128 along with the user-specified `NCCL_PROTO` settings. This caused LL128 to be enabled even when users explicitly set `NCCL_PROTO=simple` or other protocols, effectively ignoring the user setting. Thus, setting NCCL_PROTO=simple would still result in LL128 being selected for small message sizes instead of the requested Simple protocol.

**How was the outcome achieved?**  
Changed the validation condition from checking protocol type only to also verifying that `pEnable != 0`. The `parseList` function has been updated after the 2.24 sync, which properly sets `protoEnable `values to 0 (disabled) for non-selected protocols and 1 (enabled) for user-specified protocols.

**Additional Documentation:**  

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
