### PR TITLE
Add acquire fence equivalent for device scope.

### DIFF
--- a/src/device/gfx9_threadfence.h
+++ b/src/device/gfx9_threadfence.h
@@ -34,8 +34,7 @@ inline __device__ void gfx9ThreadFence();
 
 template<>
 inline __device__ void gfx9ThreadFence<true>() {
-    asm volatile("s_waitcnt lgkmcnt(0) vmcnt(0)");
-    asm volatile("buffer_inv sc0 sc1");
+    __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
 }
 
 template<>


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
internal

**What were the changes?**  
Replace ASM with what should be equivalent builtin.  I checked performance, and it looks the same.

**Why were the changes made?**  
Since there's a builtin that does what I want, namely waits for pending memory and LDS requests to complete and then does a L2 cache invalidation, let's just use that.

**How was the outcome achieved?**  
I discovered this while looking at some old notes that Joe had sent me and cross-referencing what instruction sequence constitutes an acquire fence at the device (agent) scope:
<img width="1352" height="852" alt="image" src="https://github.com/user-attachments/assets/914db364-8bed-455e-a208-37bc55945b20" />
Source: https://llvm.org/docs/AMDGPUUsage.html#memory-model-gfx942

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
