### PR TITLE
[BUILD] Fix RHEL-10 packaging for rcclras and rccl-UnitTests executables

### DIFF
--- a/cmake/rcclRAS.cmake
+++ b/cmake/rcclRAS.cmake
@@ -14,13 +14,11 @@ target_link_libraries(rcclras PRIVATE hip::host)
 target_link_libraries(rcclras PRIVATE dl)
 
 if(BUILD_SHARED_LIBS)
-  target_link_libraries(rcclras PRIVATE rccl)
-  set_property(TARGET rcclras PROPERTY INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_BINARY_DIR};${ROCM_PATH}/lib")
+  target_link_libraries(rcclras PRIVATE rccl hip::device)
 else()
   add_dependencies(rcclras rccl)
   target_link_libraries(rcclras PRIVATE dl rt -lrccl -L${CMAKE_BINARY_DIR} -lamdhip64 -L${ROCM_PATH}/lib)
 endif()
 
-set_target_properties(rcclras PROPERTIES BUILD_RPATH "${CMAKE_BINARY_DIR};${ROCM_PATH}/lib")
 
 rocm_install(TARGETS rcclras)

--- a/install.sh
+++ b/install.sh
@@ -313,6 +313,9 @@ if [[ "${build_tests}" == true ]] || ([[ "${run_tests}" == true ]] && [[ ! -x ./
     cmake_common_options="${cmake_common_options} -DBUILD_TESTS=ON"
 fi
 
+# Add build directory to RPATH for packaging dependency resolution
+cmake_common_options="${cmake_common_options} -DCMAKE_EXE_LINKER_FLAGS=\"-Wl,-rpath,${PWD}\""
+
 # Initiate RCCL CMake
 # Passing ONLY_FUNCS separately (not as part of ${cmake_common_options}) as
 # ${ONLY_FUNCS} is a debug-only feature

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -156,13 +156,11 @@ if(BUILD_TESTS)
     target_link_libraries(${test_executable} PRIVATE ${RCCL_COMMON_LINK_LIBS})
     if(BUILD_SHARED_LIBS)
       target_link_libraries(${test_executable} PRIVATE rccl)
-      set_property(TARGET ${test_executable} PROPERTY INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${ROCM_PATH}/lib;${CMAKE_BINARY_DIR}")
     else()
       add_dependencies(${test_executable} rccl)
       target_link_libraries(${test_executable} PRIVATE dl rt numa -lrccl -L${CMAKE_BINARY_DIR} -lrocm_smi64 -L${ROCM_PATH}/lib -L${ROCM_PATH}/rocm_smi/lib)
     endif()
 
-    set_property(TARGET ${test_executable} PROPERTY BUILD_RPATH "${CMAKE_BINARY_DIR};${ROCM_PATH}/lib")
     rocm_install(TARGETS ${test_executable} COMPONENT tests)
   endforeach()
 


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** SWDEV-545851

**What were the changes?**  
Removed explicit RPATH settings from `cmake/rcclRAS.cmake` and `test/CMakeLists.txt`. Added `hip::device` target to `target_link_libraries` for linking hip dependencies.

**Why were the changes made?**  
RCCL packages were missing from ROCM mainline builds on RHEL-10. This is because RHEL-10 rejects binaries containing absolute paths in RPATH/RUNPATH sections.

**How was the outcome achieved?**  
Replaced manual library linking with `hip::device` imported target.

**Additional Documentation:**  


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
