### PR TITLE
Enable LL128 and Set Tuning Model for 1PPN Configuration

### DIFF
--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -487,7 +487,12 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   int intraHw[NCCL_NUM_ALGORITHMS], hw[NCCL_NUM_ALGORITHMS];
   for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) intraHw[a] = graphs[a]->typeIntra == LINK_NVL ? NCCL_HW_NVLINK : NCCL_HW_PCI;
   for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) hw[a] = nNodes == 1 ? intraHw[a] : NCCL_HW_NET;
-  if(ppn == 1) comm->topo->tuning = 5;
+ 
+  // we need to set ll128Enabled here since we don't have a rome model match for 1ppn
+  if(ppn == 1) {
+    comm->topo->tuning = 5;
+    comm->topo->ll128Enabled = true;
+  }
   memcpy(comm->minMaxLLRange,
         rcclTuningModel[comm->topo->tuning].llProtoRanges,
         sizeof(rcclTuningModel[comm->topo->tuning].llProtoRanges));

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -487,7 +487,7 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   int intraHw[NCCL_NUM_ALGORITHMS], hw[NCCL_NUM_ALGORITHMS];
   for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) intraHw[a] = graphs[a]->typeIntra == LINK_NVL ? NCCL_HW_NVLINK : NCCL_HW_PCI;
   for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) hw[a] = nNodes == 1 ? intraHw[a] : NCCL_HW_NET;
-
+  if(ppn == 1) comm->topo->tuning = 5;
   memcpy(comm->minMaxLLRange,
         rcclTuningModel[comm->topo->tuning].llProtoRanges,
         sizeof(rcclTuningModel[comm->topo->tuning].llProtoRanges));


### PR DESCRIPTION
Work item: 
Internal

What were the changes?
We enabled LL128 and configured the tuning model for 1PPN.

Why were the changes made?
Currently, there is no Rome model that supports 1PPN, so LL128 won't get enabled even if the user selects it. Additionally, there is no dedicated tuning model for 1PPN. The default tuning model in RCCL is model 5 which we are using here.

How was the outcome achieved?
I ran RCCL with 1PPN across 2 and 4 nodes to validate the changes.

** Additional Documentation: **  
_What else should the reviewer know? 
Currently, tuning model 5 is used; a dedicated tuning model for 1PPN is planned as future work. 

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
