### PR TITLE
Disable context tracking for the current version.

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -501,7 +501,8 @@ static ncclResult_t commFree(ncclComm_t comm) {
   NCCLCHECK(ncclNetFinalize(comm));
   NCCLCHECK(ncclNetPluginUnload(comm));
 
-  ncclCudaContextDrop(comm->context);
+  // Disable until we validate NCCL_LAUNCH_IMPLICIT_ORDER support.
+  //ncclCudaContextDrop(comm->context);
 
   free(comm);
 
@@ -599,7 +600,8 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   comm->lastStream = nullptr;
   CUDACHECK(cudaGetDevice(&comm->cudaDev));
 
-  NCCLCHECK(ncclCudaContextTrack(&comm->context));
+  // Disable until we validate NCCL_LAUNCH_IMPLICIT_ORDER support.
+  //NCCLCHECK(ncclCudaContextTrack(&comm->context));
 
   NCCLCHECK(getBusId(comm->cudaDev, &comm->busId));
   char busId[]="0000:00:00.0";


### PR DESCRIPTION
## Details
NCCL 2.26 feature NCCL_LAUNCH_IMPLICIT_ORDER has not been enabled in current RCCL version. This ncclContextTrack() function is used to support IMPLICIT_ORDER feature by creating extra stream and causing us around 10% performance drop in some workload. This commit is to temporary disabling this function until we validate NCCL_LAUNCH_IMPLICIT_ORDER in the near future,

**Work item:** SWDEV-545911

**What were the changes?**  
Disabling unused function that caused 10% overhead.

**Why were the changes made?**  
Multiple ML apps reported 10% overhead increases.

**How was the outcome achieved?**  
//

**Additional Documentation:**  
If we are not supporting this function by ROCm release, we need to add documentation.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
