### PR TITLE
[DEVICE] Use noinline for LLGenericOp only on gfx950

### DIFF
--- a/src/device/prims_ll.h
+++ b/src/device/prims_ll.h
@@ -432,7 +432,11 @@ private:
   }
 
   template <int RECV, int SEND, int SrcBuf, int DstBuf>
+#if defined(__gfx950__)
   __device__ __attribute__((noinline)) void LLGenericOp(intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp) {
+#else
+  __device__ void LLGenericOp(intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp) {
+#endif
     constexpr int SRC = SrcBuf != -1 ? 1 : 0;
     constexpr int DST = DstBuf != -1 ? 1 : 0;
     T *srcElts = SrcBuf == -1 ? nullptr : userBufs[SrcBuf] + srcIx;


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Gate `noinline` for `LLGenericOp` to `gfx950` only.

**Why were the changes made?**  
`noinline` is required to enable functionality on gfx950, but impacts performance on other GPU targets.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
