### PR TITLE
[DEVICE] Tune unroll for send primitive on gfx942 and gfx950

### DIFF
--- a/src/device/sendrecv.h
+++ b/src/device/sendrecv.h
@@ -260,7 +260,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(__gfx90a__)
         runSend<ProtoSimple<1,1,8>>(subtid, subtn, group, work);
 #elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__)
-        runSend<ProtoSimple<1,1,4>>(subtid, subtn, group, work);
+        runSend<ProtoSimple<1,1,2>>(subtid, subtn, group, work);
 #else
         runSend<ProtoSimple<1,1>>(subtid, subtn, group, work);
 #endif


### PR DESCRIPTION
## Details

**Work item:**
Internal (LWPCLPAT-544)

**What were the changes?**  
Reduce unroll factor from 4 to 2 for `send` operations on gfx942 and gfx950.

**Why were the changes made?**  
Unroll=2 for `send` shows better performance on gfx942 and gfx950. `receive` operation continues to use unroll=4.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
