### PR TITLE
Adding QP tracking information to topo explorer

### DIFF
--- a/tools/topo_expl/Makefile
+++ b/tools/topo_expl/Makefile
@@ -30,6 +30,7 @@ hipify:
 	cp -a ../../src/misc/archinfo.cc hipify_rccl/graph/
 	hipify-perl -inplace -quiet-warnings hipify_rccl/include/*.h
 	hipify-perl -inplace -quiet-warnings hipify_rccl/include/plugin/*.h
+	hipify-perl -inplace -quiet-warnings hipify_rccl/include/latency_profiler/*.h
 	hipify-perl -inplace -quiet-warnings hipify_rccl/device/include/*.h
 	sed -i "s/template<typename T, typename RedOp>/template<typename T, typename RedOp, int COLL_UNROLL>/g" "hipify_rccl/device/include/common.h"
 	sed -i "s/\\(struct RunWorkBatch<ncclFunc[^>]*\\)>*/\\1, COLL_UNROLL>/" "hipify_rccl/device/include/common.h"

--- a/tools/topo_expl/include/device_table.h
+++ b/tools/topo_expl/include/device_table.h
@@ -11,5 +11,8 @@ static struct rcclKernelItem rcclKernelTable[] = { };
 
 template <int unroll>
 __forceinline__ __device__ void NCCL_CALL_FUNCTIONS(unsigned short funcIndex) noexcept { }
+__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_1(unsigned short funcIndex) noexcept { }
+__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_2(unsigned short funcIndex) noexcept { }
+__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_4(unsigned short funcIndex) noexcept { }
 
 #endif

--- a/tools/topo_expl/include/utils.h
+++ b/tools/topo_expl/include/utils.h
@@ -27,6 +27,24 @@ struct allGatherInfo {
   bool mscclEnabled;
 };
 
+struct QPTracker;
+struct NodeQPStats;
+struct RankQPStats;
+struct ChannelQPStats;
+
+QPTracker* getDeviceTracker(int deviceId);
+NodeQPStats* getNodeStats(int nodeId);
+RankQPStats* getRankStats(int rankId, int nodeId);
+ChannelQPStats* getChannelStats(int channelId);
+void printQPStatistics();
+void printChannelMappings();
+void resetQPStatistics();
+int getDeviceQPCount(int deviceId);
+int getNodeQPCount(int nodeId);
+int getRankQPCount(int rankId);
+bool isDeviceQPLimitReached(int deviceId);
+void trackQPWithChannelInfo(int rank, int nodeId, int deviceId, int channelId, int peerRank, bool isSend);
+
 void initCollNet();
 
 ncclResult_t ncclTopoGetSystem(const char* xmlTopoFile, struct ncclTopoSystem** system);

--- a/tools/topo_expl/model.cpp
+++ b/tools/topo_expl/model.cpp
@@ -64,6 +64,40 @@ ncclNet_t ncclNetDummy = {
   0
 };
 
+struct netSendResources {
+  int rank;
+  int nodeId;
+  int deviceId;
+  int channelId;
+  int peerRank;
+  int qpCount;
+};
+
+struct netRecvResources {
+  int rank;
+  int nodeId;
+  int deviceId;
+  int channelId;
+  int peerRank;
+  int qpCount;
+};
+
+struct netSendConnectArgs {
+  int rank;
+  int nodeId;
+  int deviceId;
+  int channelId;
+  int peerRank;
+};
+
+struct netRecvConnectArgs {
+  int rank;
+  int nodeId;
+  int deviceId;
+  int channelId;
+  int peerRank;
+};
+
 ncclNet_t* ncclNet = &ncclNetDummy;
 
 int ncclNetVersion() {
@@ -130,6 +164,22 @@ ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   return ncclSuccess;
 }
 
+static ncclResult_t p2pSendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+  return ncclSuccess;
+}
+
+static ncclResult_t p2pRecvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+  return ncclSuccess;
+}
+
+static ncclResult_t p2pSendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* send) {
+  return ncclSuccess;
+}
+
+static ncclResult_t p2pRecvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* send) {
+  return ncclSuccess;
+}
+
 /* Create and return connect structures for this peer to connect to me */
 ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo,
     struct ncclConnect* connectInfo, struct ncclConnector * recv, int channelId, int connIndex) {
@@ -139,8 +189,8 @@ ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
 struct ncclTransport p2pTransport = {
   "P2P",
   p2pCanConnect,
-  { p2pSendSetup, NULL, NULL, NULL },
-  { p2pRecvSetup, NULL, NULL, NULL }
+  { p2pSendSetup, p2pSendConnect, NULL, NULL, NULL, p2pSendProxyConnect, NULL, NULL, NULL, NULL },
+  { p2pRecvSetup, p2pRecvConnect, NULL, NULL, NULL, p2pRecvProxyConnect, NULL, NULL, NULL, NULL }
 };
 
 NCCL_PARAM(ShmDisable, "SHM_DISABLE", 0);
@@ -198,7 +248,77 @@ struct setupReq {
 
 /* Determine if two peers can communicate with NET */
 ncclResult_t netCanConnect(int* ret,  struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
-  *ret = 1;
+  // Force NET transport for cross-node connections
+  if (info1->hostHash != info2->hostHash) {
+    *ret = 1;  // Use NET transport for cross-node
+    return ncclSuccess;
+  }
+
+  // For same-node, you can choose based on your needs
+  // *ret = 1;  // Always use NET
+  *ret = 0;    // Don't use NET for same-node (will fall back to P2P)
+  return ncclSuccess;
+}
+
+static ncclResult_t netSendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+  struct netSendConnectArgs* args = (struct netSendConnectArgs*)reqBuff;
+
+  int rank = args->rank;
+  int nodeId = args->nodeId;
+  int deviceId = args->deviceId;
+  int channelId = args->channelId;
+  int peerRank = args->peerRank;
+
+  trackQPWithChannelInfo(rank, nodeId, deviceId, channelId, peerRank, true);
+
+  *done = 1;
+  return ncclSuccess;
+}
+
+static ncclResult_t netRecvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+  struct netRecvConnectArgs* args = (struct netRecvConnectArgs*)reqBuff;
+
+  int rank = args->rank;
+  int nodeId = args->nodeId;
+  int deviceId = args->deviceId;
+  int channelId = args->channelId;
+  int peerRank = args->peerRank;
+
+  trackQPWithChannelInfo(rank, nodeId, deviceId, channelId, peerRank, false);
+
+  *done = 1;
+  return ncclSuccess;
+}
+
+static ncclResult_t netSendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* send) {
+  struct netSendResources* resources = (struct netSendResources*)send->transportResources;
+  struct netSendConnectArgs args = {0};
+  args.rank = rank;
+  args.nodeId = comm->node;
+  args.deviceId = comm->cudaDev;
+  args.channelId = resources->channelId;
+  args.peerRank = resources->peerRank;
+
+  args.peerRank = rank;
+  int done = 0;
+  netSendProxyConnect(NULL, NULL, &args, sizeof(args), NULL, 0, &done);
+
+  return ncclSuccess;
+}
+
+static ncclResult_t netRecvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* recv) {
+  struct netRecvResources* resources = (struct netRecvResources*)recv->transportResources;
+  struct netRecvConnectArgs args = {0};
+  args.rank = rank;
+  args.nodeId = comm->node;
+  args.deviceId = comm->cudaDev;
+  args.channelId = resources->channelId;
+  args.peerRank = resources->peerRank;
+
+  args.peerRank = rank;
+  int done = 0;
+  netRecvProxyConnect(NULL, NULL, &args, sizeof(args), NULL, 0, &done);
+
   return ncclSuccess;
 }
 
@@ -210,8 +330,15 @@ ncclResult_t netSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   req.connIndex = connIndex;
   req.netDev = -1;
 
+  struct netSendResources* resources;
   int proxyRank = myInfo->rank;
   int64_t netId;
+
+  NCCLCHECK(ncclCalloc(&resources, 1));
+  resources->channelId = channelId;
+  resources->peerRank = myInfo->rank;
+  send->transportResources = resources;
+
   if (connIndex == NCCL_CONN_IDX_P2P_NET) NCCLCHECK(ncclTopoGetIntraNetDev(comm->topo, myInfo->rank, graph, channelId, 1, &netId, &req.netDev));
   if (req.netDev < 0) NCCLCHECK(ncclTopoGetNetDev(comm, myInfo->rank, graph, channelId, peerInfo->rank, &netId, &req.netDev, &proxyRank));
   NCCLCHECK(ncclTopoCheckGdr(comm->topo, myInfo->rank, netId, 1, &req.useGdr));
@@ -238,8 +365,15 @@ ncclResult_t netRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   req.netDev = -1;
 
   // Use myInfo->rank as the receiver uses its own NIC
+  struct netRecvResources* resources;
   int proxyRank = myInfo->rank;
   int64_t netId;
+
+  NCCLCHECK(ncclCalloc(&resources, 1));
+  resources->channelId = channelId;
+  resources->peerRank = myInfo->rank;
+  recv->transportResources = resources;
+
   if (connIndex == NCCL_CONN_IDX_P2P_NET) NCCLCHECK(ncclTopoGetIntraNetDev(comm->topo, myInfo->rank, graph, channelId, 0, &netId, &req.netDev));
   if (req.netDev < 0) NCCLCHECK(ncclTopoGetNetDev(comm, myInfo->rank, graph, channelId, myInfo->rank, &netId, &req.netDev, &proxyRank));
   NCCLCHECK(ncclTopoCheckGdr(comm->topo, myInfo->rank, netId, 0, &req.useGdr));
@@ -252,8 +386,8 @@ ncclResult_t netRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
 struct ncclTransport netTransport = {
   "NET",
   netCanConnect,
-  { netSendSetup, NULL, NULL, NULL },
-  { netRecvSetup, NULL, NULL, NULL }
+  { netSendSetup, netSendConnect, NULL, NULL, NULL, netSendProxyConnect, NULL, NULL, NULL, NULL },
+  { netRecvSetup, netRecvConnect, NULL, NULL, NULL, netRecvProxyConnect, NULL, NULL, NULL, NULL }
 };
 
 /* Determine if two peers can communicate with NET */

--- a/tools/topo_expl/topo_expl.cpp
+++ b/tools/topo_expl/topo_expl.cpp
@@ -178,6 +178,10 @@ int main(int argc,char* argv[])
     if (numNodesStr)
       numNodes = atol(numNodesStr);
   }
+  bool QPdump = false;
+  if (cmdOptionExists(argv, argv + argc, "-q")) {
+    QPdump = true;
+  }
   for (int i=0; i < numNodes; i++) {
       node = new NodeModel(desc->filename);
       network.AddNode(node);
@@ -312,7 +316,11 @@ int main(int argc,char* argv[])
     }
   }
 
-
+  if (QPdump) {
+    printQPStatistics();
+    printChannelMappings();
+    resetQPStatistics();
+  }
 
   for (int i = 0; i < nranks; i++) {
     free(comm[i].connectSend);

--- a/tools/topo_expl/utils.cpp
+++ b/tools/topo_expl/utils.cpp
@@ -31,6 +31,11 @@
 #include "model.h"
 #include "utils.h"
 #include "rocm_smi/rocm_smi.h"
+#include <map>
+#include <set>
+#include <string>
+#include <iostream>
+#include <algorithm>
 
 const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+2] = { "Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce", "SendRecv", "AllToAllPivot" };
 const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS] = { "Tree", "Ring", "CollNetDirect", "CollNetChain" };
@@ -356,6 +361,7 @@ static ncclResult_t selectTransport(struct ncclComm* comm, struct ncclTopoGraph*
     NCCLCHECK(transport->canConnect(&ret, comm, graph, myInfo, peerInfo));
     if (ret) {
       connector->transportComm = transportComm;
+      INFO(NCCL_INIT, "Selected transport %s for channel %d peer %d", transport->name, channelId, peer);
       NCCLCHECK(transportComm->setup(comm, graph, myInfo, peerInfo, connect, connector, channelId, connIndex));
       if (transportType) *transportType = t;
       if (needsProxy) *needsProxy = (transportComm->proxyProgress != NULL);
@@ -495,7 +501,7 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
               struct ncclConnector* conn = comm->channels[c].peers[sendPeer]->send + connIndex;
               // This connector hasn't completed connection yet
               if (conn->connected == 0) {
-                //NCCLCHECKGOTO(conn->transportComm->connect(comm, sendData[p] + sendDataOffset++, 1, comm->rank, conn), ret, fail);
+                NCCLCHECKGOTO(conn->transportComm->connect(comm, sendData[p] + sendDataOffset++, 1, comm->rank, conn), ret, fail);
                 if (ret == ncclSuccess) {
                   conn->connected = 1;
                   /* comm->channels[c].devPeers[sendPeer]->send[connIndex] is a device memory access. */
@@ -513,7 +519,7 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
               struct ncclConnector* conn = comm->channels[c].peers[recvPeer]->recv + connIndex;
               // This connector hasn't completed connection yet
               if (conn->connected == 0) {
-                //NCCLCHECKGOTO(conn->transportComm->connect(comm, recvData[p] + recvDataOffset++, 1, comm->rank, conn), ret, fail);
+                NCCLCHECKGOTO(conn->transportComm->connect(comm, recvData[p] + recvDataOffset++, 1, comm->rank, conn), ret, fail);
                 if (ret == ncclSuccess) {
                   conn->connected = 1;
                   /* comm->channels[c].devPeers[recvPeer]->recv[connIndex] is a device memory access. */
@@ -1367,3 +1373,227 @@ uint64_t getHostHash(void) {
 ncclResult_t bootstrapIntraNodeAllGather(void* commState, int *ranks, int rank, int nranks, void* allData, int size) {
   return ncclSuccess;
 }
+
+struct QPTracker {
+  int deviceId;
+  int qpCount;
+  int maxQPs;
+};
+
+struct NodeQPStats {
+  int nodeId;
+  int totalQPs;
+  int sendQPs;
+  int recvQPs;
+  int maxQPs;
+  std::map<int, RankQPStats> ranks;
+};
+
+struct RankQPStats {
+  int rankId;
+  int nodeId;
+  int totalQPs;
+  int sendQPs;
+  int recvQPs;
+  int connections;
+  std::map<int, ChannelQPStats> channels;
+};
+
+struct ChannelQPStats {
+  int channelId;
+  int sendQPs;
+  int recvQPs;
+};
+
+static std::map<int, QPTracker> deviceQPTrackers;
+static std::map<int, NodeQPStats> nodeQPStats;
+static std::map<int, RankQPStats> rankQPStats;
+static std::map<int, std::map<int, std::map<int, ChannelQPStats>>> channelQPStats;
+
+QPTracker* getDeviceTracker(int deviceId) {
+  auto it = deviceQPTrackers.find(deviceId);
+  if (it != deviceQPTrackers.end()) {
+    return &it->second;
+  }
+
+  QPTracker newTracker = {0};
+  newTracker.deviceId = deviceId;
+  newTracker.maxQPs = 1000;
+  deviceQPTrackers[deviceId] = newTracker;
+  return &deviceQPTrackers[deviceId];
+}
+
+NodeQPStats* getNodeStats(int nodeId) {
+  auto it = nodeQPStats.find(nodeId);
+  if (it != nodeQPStats.end()) {
+    return &it->second;
+  }
+
+  NodeQPStats newStats = {0};
+  newStats.nodeId = nodeId;
+  newStats.maxQPs = 10000;
+  nodeQPStats[nodeId] = newStats;
+  return &nodeQPStats[nodeId];
+}
+
+RankQPStats* getRankStats(int rankId, int nodeId) {
+  auto it = rankQPStats.find(rankId);
+  if (it != rankQPStats.end()) {
+    return &it->second;
+  }
+
+  RankQPStats newStats = {0};
+  newStats.rankId = rankId;
+  newStats.nodeId = nodeId;
+  rankQPStats[rankId] = newStats;
+  return &rankQPStats[rankId];
+}
+
+void printQPStatistics() {
+  std::cout << "\n=== QP Statistics by Node and Rank ===" << std::endl;
+
+  std::vector<int> nodeIds;
+  for (const auto& pair : nodeQPStats) {
+    nodeIds.push_back(pair.first);
+  }
+  std::sort(nodeIds.begin(), nodeIds.end());
+
+  for (int nodeId : nodeIds) {
+    const NodeQPStats& nodeStats = nodeQPStats[nodeId];
+    std::cout << "Node " << nodeId << ":" << std::endl;
+
+    std::vector<int> rankIds;
+    for (const auto& pair : rankQPStats) {
+      if (pair.second.nodeId == nodeId) {
+        rankIds.push_back(pair.first);
+      }
+    }
+    std::sort(rankIds.begin(), rankIds.end());
+
+    for (int rankId : rankIds) {
+      const RankQPStats& rankStats = rankQPStats[rankId];
+      std::cout << "  rank " << rankId << " - Send QP: " << rankStats.sendQPs
+                << " Recv QP: " << rankStats.recvQPs
+                << " Total QP: " << rankStats.totalQPs << std::endl;
+    }
+    std::cout << std::endl;
+  }
+}
+
+ChannelQPStats* getChannelStats(int nodeId, int rankId, int channelId) {
+  auto& nodeMap = channelQPStats[nodeId];
+  auto& rankMap = nodeMap[rankId];
+  auto it = rankMap.find(channelId);
+  if (it != rankMap.end()) {
+    return &it->second;
+  }
+
+  ChannelQPStats newStats = {0};
+  newStats.channelId = channelId;
+  rankMap[channelId] = newStats;
+  return &rankMap[channelId];
+}
+
+void trackQPWithChannelInfo(int rank, int nodeId, int deviceId, int channelId, int peerRank, bool isSend) {
+  QPTracker* deviceTracker = getDeviceTracker(deviceId);
+  NodeQPStats* nodeTracker = getNodeStats(nodeId);
+  RankQPStats* rankTracker = getRankStats(rank, nodeId);
+  ChannelQPStats* channelTracker = getChannelStats(nodeId, rank, channelId);
+
+  deviceTracker->qpCount++;
+  nodeTracker->totalQPs++;
+  rankTracker->totalQPs++;
+
+  if (isSend) {
+    nodeTracker->sendQPs++;
+    rankTracker->sendQPs++;
+    channelTracker->sendQPs++;
+  } else {
+    nodeTracker->recvQPs++;
+    rankTracker->recvQPs++;
+    channelTracker->recvQPs++;
+  }
+
+  INFO(NCCL_INIT|NCCL_NET, "QP_TRACK: Rank %d -> Peer %d, Channel %d, %s QP, Device %d: %d/%d",
+       rank, peerRank, channelId, isSend ? "SEND" : "RECV",
+       deviceId, deviceTracker->qpCount, deviceTracker->maxQPs);
+}
+
+void printChannelMappings() {
+  std::cout << "\n=== Channel Mappings ===" << std::endl;
+
+  std::vector<int> nodeIds;
+  for (const auto& pair : nodeQPStats) {
+    nodeIds.push_back(pair.first);
+  }
+  std::sort(nodeIds.begin(), nodeIds.end());
+
+  for (int nodeId : nodeIds) {
+    std::cout << "Node " << nodeId << ":" << std::endl;
+
+    std::vector<int> rankIds;
+    for (const auto& pair : rankQPStats) {
+      if (pair.second.nodeId == nodeId) {
+        rankIds.push_back(pair.first);
+      }
+    }
+    std::sort(rankIds.begin(), rankIds.end());
+
+    for (int rankId : rankIds) {
+      const RankQPStats& rankStats = rankQPStats[rankId];
+      std::cout << "  rank " << rankId << std::endl;
+
+      if (channelQPStats.find(nodeId) != channelQPStats.end() &&
+          channelQPStats[nodeId].find(rankId) != channelQPStats[nodeId].end()) {
+
+        std::vector<int> channelIds;
+        for (const auto& pair : channelQPStats[nodeId][rankId]) {
+          channelIds.push_back(pair.first);
+        }
+        std::sort(channelIds.begin(), channelIds.end());
+
+        for (int channelId : channelIds) {
+          const ChannelQPStats& channelStats = channelQPStats[nodeId][rankId][channelId];
+
+          std::cout << "    Channel " << channelId
+                    << ": Send QP: " << channelStats.sendQPs
+                    << " Recv QP: " << channelStats.recvQPs
+                    << " Total QP: " << (channelStats.sendQPs + channelStats.recvQPs)
+                    << std::endl;
+        }
+      }
+    }
+  }
+}
+
+void resetQPStatistics() {
+  deviceQPTrackers.clear();
+  nodeQPStats.clear();
+  rankQPStats.clear();
+  channelQPStats.clear();
+}
+
+int getDeviceQPCount(int deviceId) {
+  auto it = deviceQPTrackers.find(deviceId);
+  if (it != deviceQPTrackers.end()) return it->second.qpCount;
+  return 0;
+}
+
+int getNodeQPCount(int nodeId) {
+  auto it = nodeQPStats.find(nodeId);
+  if (it != nodeQPStats.end()) return it->second.totalQPs;
+  return 0;
+}
+
+int getRankQPCount(int rankId) {
+  auto it = rankQPStats.find(rankId);
+  if (it != rankQPStats.end()) return it->second.totalQPs;
+  return 0;
+}
+
+bool isDeviceQPLimitReached(int deviceId) {
+  auto it = deviceQPTrackers.find(deviceId);
+  if (it != deviceQPTrackers.end()) return it->second.qpCount >= it->second.maxQPs;
+  return false;
+}
+


### PR DESCRIPTION
## Details

**What were the changes?**  
Add Queue-Pair tracking information to topo explorer. If optional arg -q is specified then the QP and channel stats are printed after the tuning table

**Why were the changes made?**  
To get an accurate estimate of the number of send/recv comms and QPs created for different systems and node sizes

**How was the outcome achieved?**  
Extending topo explorer implementation to call the NET transport backend which calls a QP tracker to estimate total number of QPs created per node/per rank and also the send/recv QPs on a per channel basis

```
./topo_expl -m 55 -n 2 -q

....
....
=== QP Statistics by Node and Rank ===
Node 0:
  rank 0 - Send QP: 22 Recv QP: 23 Total QP: 45
  rank 1 - Send QP: 23 Recv QP: 22 Total QP: 45
  rank 2 - Send QP: 23 Recv QP: 23 Total QP: 46
  rank 3 - Send QP: 24 Recv QP: 22 Total QP: 46
  rank 4 - Send QP: 23 Recv QP: 23 Total QP: 46
  rank 5 - Send QP: 23 Recv QP: 22 Total QP: 45
  rank 6 - Send QP: 23 Recv QP: 23 Total QP: 46
  rank 7 - Send QP: 23 Recv QP: 22 Total QP: 45

Node 1:
  rank 8 - Send QP: 23 Recv QP: 22 Total QP: 45
  rank 9 - Send QP: 22 Recv QP: 23 Total QP: 45
  rank 10 - Send QP: 23 Recv QP: 23 Total QP: 46
  rank 11 - Send QP: 22 Recv QP: 24 Total QP: 46
  rank 12 - Send QP: 23 Recv QP: 23 Total QP: 46
  rank 13 - Send QP: 22 Recv QP: 23 Total QP: 45
  rank 14 - Send QP: 23 Recv QP: 23 Total QP: 46
  rank 15 - Send QP: 22 Recv QP: 23 Total QP: 45


=== Channel Mappings ===
Node 0:
  rank 0
    Channel 0: Send QP: 1 Recv QP: 2 Total QP: 3
    Channel 5: Send QP: 2 Recv QP: 0 Total QP: 2
    Channel 12: Send QP: 2 Recv QP: 0 Total QP: 2
    Channel 14: Send QP: 1 Recv QP: 1 Total QP: 2
    Channel 15: Send QP: 0 Recv QP: 2 Total QP: 2
....
....
```
## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
