### PR TITLE
device: optimize threadfence for ll64 protocol

### DIFF
--- a/src/device/prims_ll128.h
+++ b/src/device/prims_ll128.h
@@ -138,13 +138,13 @@ private:
     if (recvConnHeadPtr) STORE(recvConnHeadPtr, recvConnHead += 1);
   }
   inline __device__ void postSend() {
+    __atomic_signal_fence(__ATOMIC_SEQ_CST);	  
     asm volatile("s_waitcnt lgkmcnt(0) vmcnt(0)"); 	  
+    __atomic_signal_fence(__ATOMIC_SEQ_CST);
+
     if (sendConnTailPtr) {
 #if __CUDA_ARCH__ >= 900
       __threadfence_system();
-#else
-      //__threadfence();
-      __threadfence_block();
 #endif
       STORE((unsigned long long *)sendConnTailPtr, sendConnTail += 1);
     }

--- a/src/device/prims_ll128.h
+++ b/src/device/prims_ll128.h
@@ -138,11 +138,13 @@ private:
     if (recvConnHeadPtr) STORE(recvConnHeadPtr, recvConnHead += 1);
   }
   inline __device__ void postSend() {
+    asm volatile("s_waitcnt lgkmcnt(0) vmcnt(0)"); 	  
     if (sendConnTailPtr) {
 #if __CUDA_ARCH__ >= 900
       __threadfence_system();
 #else
-      __threadfence();
+      //__threadfence();
+      __threadfence_block();
 #endif
       STORE((unsigned long long *)sendConnTailPtr, sendConnTail += 1);
     }


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___
The `postSend()` function in LL64 protocol uses a threadfence() that adds up to 5% overhead for medium message sizes. This PR minimizes this overhead by up to 2.5% on MI300X.
  
**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Instead of `__threadfence()`, `__threadfence_block()` was used along with `asm volatile("s_waitcnt lgkmcnt(0) vmcnt(0)")`;

**Why were the changes made?**  
Minimize the LL64 protocol overhead.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
Need to evaluate on MI350.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
