### PR TITLE
Add cstring header explictly as it is removed from HIP

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -12,6 +12,7 @@
 #include "bitops.h"
 #include "checks.h"
 #include <stdint.h>
+#include <string.h>
 #include <time.h>
 #include <sched.h>
 #include <algorithm>


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Add < cstring > header to fix the below errors such as "./utils.h:238: error: use of undeclared identifier 'memcpy'".


**Why were the changes made?**  
As part of 7.0 breaking changes, HIP runtime header files (hip_runtime.h) stopped including headers such as < cstring > or < string.h > since they were not used in hip runtime. But the apps depending on that header file will fail with the errors and those need to add the header explicitly. Though as such this isn't a problem with RCCL compilation, for AMD Network Plugin compilation where it pulls the hipified version of some files from RCCL (like the ibvwrap/ibvsymbols) which includes alloc.h/utils.h and it fails with compilation error.
This change is in similar lines as with the changes made to RCCL-Tests repo PR https://github.com/ROCm/rccl-tests/pull/132

**How was the outcome achieved?**  
By adding < string.h > header.

