### PR TITLE
[Device] Add dynamic fetch/reduce pipelining for reduction collectives - Simple protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Multi-node tuning for AllGather, AllReduce, and ReduceScatter that leverages LL/LL64/LL128 protocol to use nontemporal vector load/store for tunable message size ranges.
 * LL/LL128 usage ranges for AR, AG, and RS are part of the tuning models, which enable architecture-specific tuning in conjunction with the existing Rome Models scheme in RCCL.
 * Two new APIs are exposed as part of an initiative to separate RCCL code. These APIs are `rcclGetAlgoInfo` and `rcclFuncMaxSendRecvCount`. However, user-level invocation requires that RCCL be built with `RCCL_EXPOSE_STATIC` enabled.
-* Enabled double-buffering in `reduceCopyPacks` to trigger pipelining, especially to overlap bf16 arithmetic.
-* Added `--force-reduce-pipeline` as an option that can be passed to the `install.sh` script. Passing this option will enable software-triggered pipelining `bfloat16` reductions (i.e. `all_reduce`, `reduce_scatter` and `reduce`).
+* Enabled double-buffering in `reduceCopyPacks` to trigger pipelining, especially to overlap bf16 arithmetic and bridge the gap between fp32 performance and bf16 for both `gfx942` and `gfx950`. Pipelining has been made a tunable via `rcclSetPipelining`, similar to algorithms/protocols so that regression is avoided in certain message sizes.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Multi-node tuning for AllGather, AllReduce, and ReduceScatter that leverages LL/LL64/LL128 protocol to use nontemporal vector load/store for tunable message size ranges.
 * LL/LL128 usage ranges for AR, AG, and RS are part of the tuning models, which enable architecture-specific tuning in conjunction with the existing Rome Models scheme in RCCL.
 * Two new APIs are exposed as part of an initiative to separate RCCL code. These APIs are `rcclGetAlgoInfo` and `rcclFuncMaxSendRecvCount`. However, user-level invocation requires that RCCL be built with `RCCL_EXPOSE_STATIC` enabled.
-* Enabled double-buffering in `reduceCopyPacks` to trigger pipelining, especially to overlap bf16 arithmetic and bridge the gap between fp32 performance and bf16 for both `gfx942` and `gfx950`. Pipelining has been made a tunable via `rcclSetPipelining`, similar to algorithms/protocols so that regression is avoided in certain message sizes.
+* Enabled double-buffering in `reduceCopyPacks` to trigger pipelining, especially to overlap `bf16` arithmetic and bridge the gap between `fp32` performance and `bf16` for both `gfx942` and `gfx950`. Pipelining has been made tunable via `rcclSetPipelining`, similar to algorithms/protocols so that regression is avoided in certain message sizes.
 * Added a direct allgather algorithm. This is enabled by default for multi-node if there are 16 nodes or fewer. The message size threshold is 4MB.
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ option(PROFILE                                 "Enable profiling"               
 option(TIMETRACE                               "Enable time-trace during compilation"          OFF)
 option(TRACE                                   "Enable additional tracing"                     OFF)
 option(FAULT_INJECTION                         "Enable fault injection"                        ON)
-option(FORCE_REDUCE_PIPELINING                 "Force reduce pipelining"                       OFF)
 
 # Default GPU architectures to build
 #==================================================================================================
@@ -846,18 +845,6 @@ file(GLOB GENERATED_FILES "${GEN_DIR}/*")
 # Append all found generated files to the list
 foreach(file ${GENERATED_FILES})
   list(APPEND HIP_SOURCES ${file})
-endforeach()
-
-# Enable SW pipelining where needed
-foreach(SOURCE_FILE ${HIP_SOURCES})
-    # TODO: enable bf16 pipelining by default upon having the pipelined/scalar switching feature
-    # if (FORCE_REDUCE_PIPELINING AND (SOURCE_FILE MATCHES "gensrc/reduce_.*" OR SOURCE_FILE MATCHES "gensrc/reduce_scatter_.*" OR SOURCE_FILE MATCHES "gensrc/all_reduce_.*"))
-    #   message(STATUS "RCCL_ENABLE_SW_PIPELINE enabled for ${SOURCE_FILE}")
-    #   set_source_files_properties(${SOURCE_FILE} PROPERTIES COMPILE_FLAGS "-DRCCL_ENABLE_SW_PIPELINE")
-    if(FORCE_REDUCE_PIPELINING AND SOURCE_FILE MATCHES "gensrc/(reduce|reduce_scatter|all_reduce).*_bf16\\.cpp$")
-      message(STATUS "BF16 pipelining support enabled for ${SOURCE_FILE}")
-      set_source_files_properties(${SOURCE_FILE} PROPERTIES COMPILE_FLAGS "-DRCCL_ENABLE_SW_PIPELINE")
-    endif()
 endforeach()
 
 # Create an initial git_version.cpp file (that will be updated with latest git version)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ RCCL build & installation helper script
     -t|--tests_build           Build rccl unit tests, but do not run
        --time-trace            Plot the build time of RCCL (requires `ninja-build` package installed on the system)
        --verbose               Show compile commands
-       --force-reduce-pipeline Force reduce_copy sw pipeline to be used for every reduce-based collectives and datatypes
 ```
 
 By default, RCCL builds for all GPU targets defined in `DEFAULT_GPUS` in `CMakeLists.txt`. To target specific GPU(s), and potentially reduce build time, use `--amdgpu_targets` as a `;` separated string listing GPU(s) to target.

--- a/cmake/scripts/add_unroll.sh
+++ b/cmake/scripts/add_unroll.sh
@@ -21,13 +21,22 @@
 HIP_FILE=$1
 
 if [[ "$HIP_FILE" =~ .*/src/device/.*\.h ]]; then
-  perl -pi -e 's/(template<typename T, typename RedOp(?:, typename Proto)?)(, bool isNetOffload.*?)?>/\1, int USE_ACC, int COLL_UNROLL\2>/g' "$HIP_FILE"
+  perl -pi -e 's/(template<typename T, typename RedOp(?:, typename Proto)?)(, bool isNetOffload.*?)?>/\1, int USE_ACC, int COLL_UNROLL, int Pipeline\2>/g' "$HIP_FILE"
+  perl -pi -e 's/(template<typename T, typename RedOp(?:, typename Proto)?(?:, int RCCLMetadata)?)(, bool isNetOffload.*?)?>/\1, int USE_ACC, int COLL_UNROLL, int Pipeline\2>/g' "$HIP_FILE"
   perl -pi -e 's/(ProtoSimple<[^,]*?,[^,]+?)>/\1, USE_ACC, COLL_UNROLL>/g' "$HIP_FILE"
   perl -pi -e 's/(runRing<T.*?)((, (true|false))?>\()/\1, USE_ACC, COLL_UNROLL\2/g' "$HIP_FILE"
   perl -pi -e 's/(runTreeUpDown<T.*?)>\(/\1, USE_ACC, COLL_UNROLL>(/' "$HIP_FILE"
   perl -pi -e 's/(runTreeSplit<T.*?)>\(/\1, USE_ACC, COLL_UNROLL>(/' "$HIP_FILE"
-  sed -i "s/\\(struct RunWorkColl<ncclFunc[^>]*\\)>*/\\1, USE_ACC, COLL_UNROLL>/" "$HIP_FILE"
-  sed -i "s/\\(struct RunWorkBatch<ncclFunc[^>]*\\)>*/\\1, USE_ACC, COLL_UNROLL>/" "$HIP_FILE"
-  echo "Added COLL_UNROLL and USE_ACC template arguments to $HIP_FILE"
 
+  perl -pi -e 's/(runTreeSplit<T, RedOp, (ProtoLL|ProtoLL128), USE_ACC, COLL_UNROLL.*?)>/\1, 0>/' "$HIP_FILE"
+  perl -pi -e 's/(runTreeUpDown<T, RedOp, (ProtoLL|ProtoLL128), USE_ACC, COLL_UNROLL.*?)>/\1, 0>/' "$HIP_FILE"
+  perl -pi -e 's/(runRing<T, RedOp, (ProtoLL|ProtoLL128), USE_ACC, COLL_UNROLL.*?)>/\1, 0>/' "$HIP_FILE"
+  perl -pi -e 's/(runRing<T, RedOp, (ProtoLL|ProtoLL128), (RCCL_ONE_NODE_RING_SIMPLE|RCCL_METADATA_EMPTY), USE_ACC, COLL_UNROLL.*?)>/\1, 0>/' "$HIP_FILE"
+
+  perl -pi -e 's/(runRing<T, RedOp, Proto, (RCCL_ONE_NODE_RING_SIMPLE|RCCL_METADATA_EMPTY), USE_ACC, COLL_UNROLL.*?)>/\1, Pipeline>/' "$HIP_FILE"
+  perl -pi -e 's/(runRing<T, RedOp, Proto, USE_ACC, COLL_UNROLL.*?)>/\1, Pipeline>/' "$HIP_FILE"
+  perl -pi -e 's/(runTreeSplit<T, RedOp, Proto, USE_ACC, COLL_UNROLL.*?)>/\1, Pipeline>/' "$HIP_FILE"
+  perl -pi -e 's/(runTreeUpDown<T, RedOp, Proto, USE_ACC, COLL_UNROLL.*?)>/\1, Pipeline>/' "$HIP_FILE"
+  sed -i "s/\\(struct RunWorkBatch<ncclFunc[^>]*\\)>*/\\1, USE_ACC, COLL_UNROLL, Pipeline>/" "$HIP_FILE"
+  sed -i "s/\\(RunWorkColl<[^,]*,[^,]*,[^,]*,[^,]*,[^>]*\\)>/\\1, USE_ACC, COLL_UNROLL, Pipeline>/" "$HIP_FILE"
 fi

--- a/src/device/common.h
+++ b/src/device/common.h
@@ -672,14 +672,14 @@ __global__ void ncclDevKernelDebug_Generic_4(ncclDevKernelArgs4K NCCL_GRID_CONST
   __global__ void ncclDevKernel_##suffix(ncclDevKernelArgs4K NCCL_GRID_CONSTANT const args4K) {}
 
 #ifdef USE_INDIRECT_FUNCTION_CALL
-#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, unroll) \
+#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
   __device__ void ncclDevFunc_##suffix() { \
-    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll>().run(); \
+    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \
   }
 #else
-#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, unroll) \
+#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
   __device__ __attribute__((noinline)) void ncclDevFunc_##suffix() { \
-    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll>().run(); \
+    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \
   }
 #endif
 

--- a/src/device/common.h
+++ b/src/device/common.h
@@ -437,7 +437,7 @@ struct RunWorkBatch {
       // Coverity reports a possible thread divergence due to not all threads participating in the collective.
       // However, the code ensures that the participation is on a per-warp basis.
       // coverity[device_thread_diverged:FALSE]
-      if (tid < subtn) RunWorkColl<Fn, T, RedOp, Algo, Proto, USE_ACC, COLL_UNROLL, Pipeline>().run(tid, subtn, work);
+      if (tid < subtn) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid, subtn, work);
     }
   }
 };

--- a/src/device/common.h
+++ b/src/device/common.h
@@ -392,14 +392,14 @@ __device__ __forceinline__ void loadWorkBatchToShmem(
   }
 }
 
-template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL>
+template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline>
 struct RunWorkColl {
   __device__ void run(int tid, int tn, struct ncclDevWorkColl* work) {
     // Put NOT IMPLEMENTED behavior here.
   }
 };
 
-template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL>
+template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline>
 struct RunWorkBatch;
 
 // Specialized for P2p in sendrecv.h
@@ -407,7 +407,7 @@ template<typename T, typename RedOp>
 struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE>;
 
 // Specialized here for non-P2p (Coll and CollReg)
-template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto,  int USE_ACC, int COLL_UNROLL>
+template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto,  int USE_ACC, int COLL_UNROLL, int Pipeline>
 struct RunWorkBatch {
   // This __forceinline__ is necessary. The compiler was inserting a function call
   // here from the LL ncclKernel.
@@ -437,7 +437,7 @@ struct RunWorkBatch {
       // Coverity reports a possible thread divergence due to not all threads participating in the collective.
       // However, the code ensures that the participation is on a per-warp basis.
       // coverity[device_thread_diverged:FALSE]
-      if (tid < subtn) RunWorkColl<Fn, T, RedOp, Algo, Proto, USE_ACC, COLL_UNROLL>().run(tid, subtn, work);
+      if (tid < subtn) RunWorkColl<Fn, T, RedOp, Algo, Proto, USE_ACC, COLL_UNROLL, Pipeline>().run(tid, subtn, work);
     }
   }
 };

--- a/src/device/common_kernel.h
+++ b/src/device/common_kernel.h
@@ -27,12 +27,6 @@ inline __device__ int loadInt(int* ptr) {
   return v;
 }
 
-#if defined(__gfx942__) || defined(__gfx950__)
-#define REDUCE_INLINE_ATTR __device__ __forceinline__
-#else
-#define REDUCE_INLINE_ATTR __device__ __attribute__((noinline))
-#endif
-
 template<typename RedFn, typename T, int Unroll, int BytePerPack,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
@@ -45,7 +39,7 @@ template<typename RedFn, typename T, int Unroll, int BytePerPack,
          typename IntBytes, typename SrcPtrFn, typename DstPtrFn>
 struct reduceCopyPacks<RedFn, T, Unroll, BytePerPack, MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, 0> {
 
-REDUCE_INLINE_ATTR static void run(
+__device__ __forceinline__ static void run(
     int nThreads, int &thread,
     uint64_t redArg, uint64_t *preOpArgs, bool postOp,
     int nSrcs, SrcPtrFn const &srcPtrFn, int nDsts, DstPtrFn const &dstPtrFn,
@@ -311,7 +305,7 @@ template<typename RedFn, typename T, int Unroll, int BytePerPack,
          typename IntBytes, typename SrcPtrFn, typename DstPtrFn>
 struct reduceCopyPacks<RedFn, T, Unroll, BytePerPack, MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, 1> {
 
-REDUCE_INLINE_ATTR static void run(
+__device__ __forceinline__ static void run(
     int nThreads, int &thread,
     uint64_t redArg, uint64_t *preOpArgs, bool postOp,
     int nSrcs, SrcPtrFn const &srcPtrFn, int nDsts, DstPtrFn const &dstPtrFn,
@@ -440,11 +434,7 @@ template<typename RedFn, typename T, int Unroll, int BytePerPack,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
          typename IntBytes, typename SrcPtrFn, typename DstPtrFn, typename AccPtrFn>
-#if defined(__gfx942__) || defined(__gfx950__)
 __device__ __forceinline__ void reduceCopyPacksWithBias(
-#else
-__device__ __attribute__((noinline)) void reduceCopyPacksWithBias(
-#endif
     int nThreads, int &thread,
     uint64_t redArg, uint64_t *preOpArgs, bool postOp,
     int nSrcs, SrcPtrFn const &srcPtrFn, int nDsts, DstPtrFn const &dstPtrFn,

--- a/src/device/common_kernel.h
+++ b/src/device/common_kernel.h
@@ -223,7 +223,6 @@ REDUCE_INLINE_ATTR static void run(
 
 };
 
-#ifdef RCCL_ENABLE_SW_PIPELINE
 template <typename RedFn, typename SrcPtrFn, typename IntBytes, int MultimemSrcs, int MinSrcs, int MaxSrcs, int PreOpSrcs, int Unroll, int BytePerPack>
 __device__ __forceinline__ void loadSources(
   const RedFn& redFn,
@@ -436,7 +435,6 @@ REDUCE_INLINE_ATTR static void run(
   thread = warp*WARP_SIZE + lane;
 }
 };
-#endif
 
 template<typename RedFn, typename T, int Unroll, int BytePerPack,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,

--- a/src/device/common_kernel.h
+++ b/src/device/common_kernel.h
@@ -30,16 +30,8 @@ inline __device__ int loadInt(int* ptr) {
 template<typename RedFn, typename T, int Unroll, int BytePerPack,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
-         typename IntBytes, typename SrcPtrFn, typename DstPtrFn, int Pipeline>
-struct reduceCopyPacks;
-
-template<typename RedFn, typename T, int Unroll, int BytePerPack,
-         int MultimemSrcs, int MinSrcs, int MaxSrcs,
-         int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
          typename IntBytes, typename SrcPtrFn, typename DstPtrFn>
-
-struct reduceCopyPacks<RedFn, T, Unroll, BytePerPack, MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, 0> {
-__device__ __forceinline__ static void run(
+__device__ __forceinline__ static void reduceCopyPacks(
     int nThreads, int &thread,
     uint64_t redArg, uint64_t *preOpArgs, bool postOp,
     int nSrcs, SrcPtrFn const &srcPtrFn, int nDsts, DstPtrFn const &dstPtrFn,
@@ -215,8 +207,6 @@ __device__ __forceinline__ static void run(
   thread = warp*WARP_SIZE + lane;
 }
 
-};
-
 template <typename RedFn, typename SrcPtrFn, typename IntBytes, int MultimemSrcs, int MinSrcs, int MaxSrcs, int PreOpSrcs, int Unroll, int BytePerPack>
 __device__ __forceinline__ void loadSources(
   const RedFn& redFn,
@@ -303,9 +293,7 @@ template<typename RedFn, typename T, int Unroll, int BytePerPack,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
          typename IntBytes, typename SrcPtrFn, typename DstPtrFn>
-struct reduceCopyPacks<RedFn, T, Unroll, BytePerPack, MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, 1> {
-
-__device__ __forceinline__ static void run(
+__device__ __forceinline__ static void reduceCopyPacksPipelined(
     int nThreads, int &thread,
     uint64_t redArg, uint64_t *preOpArgs, bool postOp,
     int nSrcs, SrcPtrFn const &srcPtrFn, int nDsts, DstPtrFn const &dstPtrFn,
@@ -428,7 +416,6 @@ __device__ __forceinline__ static void run(
   warp = -nHunksAhead;
   thread = warp*WARP_SIZE + lane;
 }
-};
 
 template<typename RedFn, typename T, int Unroll, int BytePerPack,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
@@ -657,37 +644,56 @@ __device__ __forceinline__ void reduceCopy(
     aligned = !(__any(!aligned));
     if (aligned) {
 #if defined(__gfx90a__)
-      if (useAcc)
-      reduceCopyPacksWithBias<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize,
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, thread, redArg, preOpArgs, postOp,
-         nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead, accPtrFn);
+      if constexpr (useAcc)
+        reduceCopyPacksWithBias<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize,
+          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+          (nThreads, thread, redArg, preOpArgs, postOp,
+          nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead, accPtrFn);
+      else if constexpr (Pipeline)
+        reduceCopyPacksPipelined<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize,
+          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+          (nThreads, thread, redArg, preOpArgs, postOp,
+          nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
       else
-      reduceCopyPacks<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize,
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, thread, redArg, preOpArgs, postOp,
-         nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
+        reduceCopyPacks<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize,
+          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+          (nThreads, thread, redArg, preOpArgs, postOp,
+          nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
 #else
-      if (useAcc)
-      reduceCopyPacksWithBias<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize,
+      if constexpr (useAcc)
+        reduceCopyPacksWithBias<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize,
+          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+          (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+      else if constexpr  (Pipeline)
+        reduceCopyPacksPipelined<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize,
         MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
         (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
-         nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
-      else
-      reduceCopyPacks<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize,
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, /*&*/thread, redArg, preOpArgs, postOp,
          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+      else
+        reduceCopyPacks<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize,
+          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+          (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
 #endif
       if (nBytesAhead == 0) return;
 
-      if (useAcc)
-      reduceCopyPacksWithBias<RedFn, T, /*Unroll=*/1, BigPackSize,
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
-         nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+      if constexpr (useAcc)
+        reduceCopyPacksWithBias<RedFn, T, /*Unroll=*/1, BigPackSize,
+          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+          (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+      else if constexpr (Pipeline)
+        reduceCopyPacksPipelined<RedFn, T, /*Unroll=*/1, BigPackSize,
+          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+          (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
       else
-      reduceCopyPacks<RedFn, T, /*Unroll=*/1, BigPackSize,
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, /*&*/thread, redArg, preOpArgs, postOp,
-         nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+        reduceCopyPacks<RedFn, T, /*Unroll=*/1, BigPackSize,
+          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+          (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+
       if (nBytesAhead == 0) return;
     }
   }
@@ -714,48 +720,74 @@ __device__ __forceinline__ void reduceCopy(
 */
 #if defined(__gfx90a__)
   if (MinSrcs > 1) {
-    if (useAcc)
-    reduceCopyPacksWithBias<RedFn, T, (Unroll*4 + sizeof(T) - 1)/sizeof(T), sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-    (nThreads, thread, redArg, preOpArgs, postOp,
-     nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead, accPtrFn);
+    if constexpr (useAcc)
+      reduceCopyPacksWithBias<RedFn, T, (Unroll*4 + sizeof(T) - 1)/sizeof(T), sizeof(T),
+        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+        (nThreads, thread, redArg, preOpArgs, postOp,
+        nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead, accPtrFn);
+    else if constexpr (Pipeline)
+      reduceCopyPacksPipelined<RedFn, T, (Unroll*4 + sizeof(T) - 1)/sizeof(T), sizeof(T),
+        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+        (nThreads, thread, redArg, preOpArgs, postOp,
+        nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
     else
-    reduceCopyPacks<RedFn, T, (Unroll*4 + sizeof(T) - 1)/sizeof(T), sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, thread, redArg, preOpArgs, postOp,
-     nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
+      reduceCopyPacks<RedFn, T, (Unroll*4 + sizeof(T) - 1)/sizeof(T), sizeof(T),
+        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+        (nThreads, thread, redArg, preOpArgs, postOp,
+        nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
   } else {
-    if (useAcc)
-    reduceCopyPacksWithBias<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-    (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
-     nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+    if constexpr (useAcc)
+      reduceCopyPacksWithBias<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
+        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+        (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+        nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+    else if constexpr (Pipeline)
+      reduceCopyPacksPipelined<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
+        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+        (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+        nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
     else
-    reduceCopyPacks<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, /*&*/thread, redArg, preOpArgs, postOp,
-     nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+      reduceCopyPacks<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
+        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+        (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+        nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
   }
 #else
-  if (useAcc)
-  reduceCopyPacksWithBias<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-    (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
-     nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+  if constexpr (useAcc)
+    reduceCopyPacksWithBias<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
+      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+      (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+  else if constexpr (Pipeline)
+    reduceCopyPacksPipelined<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
+      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+      (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
   else
-  reduceCopyPacks<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, /*&*/thread, redArg, preOpArgs, postOp,
-     nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+    reduceCopyPacks<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
+      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+      (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+
 #endif
   if (nBytesAhead == 0) return;
 
-  if (useAcc)
-  reduceCopyPacksWithBias<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-    (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
-     nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+  if constexpr (useAcc)
+    reduceCopyPacksWithBias<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T),
+      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+      (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+  else if constexpr (Pipeline)
+    reduceCopyPacksPipelined<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T),
+      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+      (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
   else
-  reduceCopyPacks<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, /*&*/thread, redArg, preOpArgs, postOp,
-     nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+    reduceCopyPacks<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T),
+      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
+      (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+
 }
 
 

--- a/src/device/common_kernel.h
+++ b/src/device/common_kernel.h
@@ -653,12 +653,8 @@ __device__ __forceinline__ void reduceCopy(
 
   IntBytes nBytesBehind = 0;
   IntBytes nBytesAhead = nElts*sizeof(T);
-<<<<<<< HEAD
   //bool useAcc = accPtrFn() != nullptr;
 
-=======
-  bool useAcc = accPtrFn() != nullptr;
->>>>>>> 836fe995 (Support pipelining codegen and template specialization)
   #if __cpp_if_constexpr
   if constexpr (BigPackSize > sizeof(T)) {
   #else
@@ -772,9 +768,7 @@ __device__ __forceinline__ void reduceCopy(
      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
 }
 
-<<<<<<< HEAD
-template<int Unroll, int useAcc, typename RedFn, typename T,
-=======
+
 struct PtrFn {
   void** ptrs;
   __device__ void* operator()(int i) const { return ptrs[i]; }
@@ -785,8 +779,7 @@ struct AccPtrFn {
   __device__ void* operator()() const { return ptr; }
 };
 
-template<int Unroll, typename RedFn, typename T,
->>>>>>> 836fe995 (Support pipelining codegen and template specialization)
+template<int Unroll, int useAcc, typename RedFn, typename T,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
          typename IntBytes, int Pipeline = 0>

--- a/src/device/common_kernel.h
+++ b/src/device/common_kernel.h
@@ -772,7 +772,7 @@ struct AccPtrFn {
 template<int Unroll, int useAcc, typename RedFn, typename T,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
-         typename IntBytes, int Pipeline = 0>
+         int Pipeline = 0, typename IntBytes>
 __device__ __forceinline__ void reduceCopy(
     int thread, int nThreads,
     uint64_t redArg, uint64_t *preOpArgs, bool postOp,

--- a/src/device/common_kernel.h
+++ b/src/device/common_kernel.h
@@ -610,7 +610,7 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
 template<int Unroll, int  useAcc, typename RedFn, typename T,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
-         typename IntBytes, typename SrcPtrFn, typename DstPtrFn, typename AccPtrFn, int Pipeline>
+         typename IntBytes, int Pipeline, typename SrcPtrFn, typename DstPtrFn, typename AccPtrFn>
 __device__ __forceinline__ void reduceCopy(
     int thread, int nThreads,
     uint64_t redArg, uint64_t *preOpArgs, bool postOp,
@@ -791,16 +791,6 @@ __device__ __forceinline__ void reduceCopy(
 }
 
 
-struct PtrFn {
-  void** ptrs;
-  __device__ void* operator()(int i) const { return ptrs[i]; }
-};
-
-struct AccPtrFn {
-  void* ptr;
-  __device__ void* operator()() const { return ptr; }
-};
-
 template<int Unroll, int useAcc, typename RedFn, typename T,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
@@ -813,11 +803,10 @@ __device__ __forceinline__ void reduceCopy(
   ) {
   reduceCopy<Unroll, useAcc, RedFn, T,
              MultimemSrcs, MinSrcs, MaxSrcs,
-             MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes,
-             PtrFn, PtrFn, AccPtrFn, Pipeline>
+             MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, Pipeline>
     (thread, nThreads, redArg, preOpArgs, postOp,
-     nSrcs, PtrFn{srcPtrs},
-     nDsts, PtrFn{dstPtrs}, nElts, AccPtrFn{accPtr});
+     nSrcs, [=]__device__(int i) { return srcPtrs[i]; },
+     nDsts, [=]__device__(int i) { return dstPtrs[i]; }, nElts, [=]__device__() { return accPtr; });
 }
 
 #endif // COMMON_KERNEL_H_

--- a/src/device/common_kernel.h
+++ b/src/device/common_kernel.h
@@ -27,16 +27,25 @@ inline __device__ int loadInt(int* ptr) {
   return v;
 }
 
-#ifndef RCCL_ENABLE_SW_PIPELINE
+#if defined(__gfx942__) || defined(__gfx950__)
+#define REDUCE_INLINE_ATTR __device__ __forceinline__
+#else
+#define REDUCE_INLINE_ATTR __device__ __attribute__((noinline))
+#endif
+
+template<typename RedFn, typename T, int Unroll, int BytePerPack,
+         int MultimemSrcs, int MinSrcs, int MaxSrcs,
+         int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
+         typename IntBytes, typename SrcPtrFn, typename DstPtrFn, int Pipeline>
+struct reduceCopyPacks;
+
 template<typename RedFn, typename T, int Unroll, int BytePerPack,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
          typename IntBytes, typename SrcPtrFn, typename DstPtrFn>
-#if defined(__gfx942__) || defined(__gfx950__)
-__device__ __forceinline__ void reduceCopyPacks(
-#else
-__device__ __attribute__((noinline)) void reduceCopyPacks(
-#endif
+struct reduceCopyPacks<RedFn, T, Unroll, BytePerPack, MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, 0> {
+
+REDUCE_INLINE_ATTR static void run(
     int nThreads, int &thread,
     uint64_t redArg, uint64_t *preOpArgs, bool postOp,
     int nSrcs, SrcPtrFn const &srcPtrFn, int nDsts, DstPtrFn const &dstPtrFn,
@@ -211,16 +220,18 @@ __device__ __attribute__((noinline)) void reduceCopyPacks(
   warp = -nHunksAhead;
   thread = warp*WARP_SIZE + lane;
 }
-#else
 
+};
+
+#ifdef RCCL_ENABLE_SW_PIPELINE
 template <typename RedFn, typename SrcPtrFn, typename IntBytes, int MultimemSrcs, int MinSrcs, int MaxSrcs, int PreOpSrcs, int Unroll, int BytePerPack>
 __device__ __forceinline__ void loadSources(
-  const RedFn& redFn, 
-  const SrcPtrFn& srcPtrFn, 
-  IntBytes& globalOffset, 
-  uintptr_t* minSrcs, 
+  const RedFn& redFn,
+  const SrcPtrFn& srcPtrFn,
+  IntBytes& globalOffset,
+  uintptr_t* minSrcs,
   uint64_t *preOpArgs,
-  BytePack<BytePerPack> buff[MaxSrcs + !MaxSrcs][Unroll], 
+  BytePack<BytePerPack> buff[MaxSrcs + !MaxSrcs][Unroll],
   int nSrcs
 ) {
   #pragma unroll Unroll
@@ -299,7 +310,9 @@ template<typename RedFn, typename T, int Unroll, int BytePerPack,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
          typename IntBytes, typename SrcPtrFn, typename DstPtrFn>
-__device__ __forceinline__ void reduceCopyPacks(
+struct reduceCopyPacks<RedFn, T, Unroll, BytePerPack, MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, 1> {
+
+REDUCE_INLINE_ATTR static void run(
     int nThreads, int &thread,
     uint64_t redArg, uint64_t *preOpArgs, bool postOp,
     int nSrcs, SrcPtrFn const &srcPtrFn, int nDsts, DstPtrFn const &dstPtrFn,
@@ -358,12 +371,12 @@ __device__ __forceinline__ void reduceCopyPacks(
     loadSources<RedFn, SrcPtrFn, IntBytes, MultimemSrcs, MinSrcs, MaxSrcs, PreOpSrcs, Unroll, BytePerPack>(
       redFn, srcPtrFn, threadBytesBehind, minSrcs, preOpArgs, acc1, nSrcs
     );
-    
+
     if(tailProcess) {
       reduceAndStore<RedFn, DstPtrFn, IntBytes, MultimemDsts, MinSrcs, MaxSrcs, MinDsts, MaxDsts, PreOpSrcs, Unroll, BytePerPack>(
         redFn, preOpArgs, acc2, minDsts, postOp, nDsts, dstPtrFn, tailThreadBytesBehind, nSrcs
       );
-      
+
       #pragma unroll
       for (int d=0; d < MinDsts; d++) {
         minDsts[d] += (nWarps-1)*BytePerHunk;
@@ -377,7 +390,7 @@ __device__ __forceinline__ void reduceCopyPacks(
     threadBytesAhead -= nWarps*BytePerHunk;
     nHunksAhead -= nWarps;
     tailProcess = Unroll==1 ? (BytePerPack <= threadBytesAhead) : (0 < nHunksAhead);
-    
+
     tailThreadBytesBehind = threadBytesBehind;
     threadBytesBehind += nWarps*BytePerHunk;
     if(tailProcess) {
@@ -404,7 +417,7 @@ __device__ __forceinline__ void reduceCopyPacks(
       nHunksAhead -= nWarps;
     }
   }
-  
+
   if(tailProcess) {
     reduceAndStore<RedFn, DstPtrFn, IntBytes, MultimemDsts, MinSrcs, MaxSrcs, MinDsts, MaxDsts, PreOpSrcs, Unroll, BytePerPack>(
       redFn, preOpArgs, acc2, minDsts, postOp, nDsts, dstPtrFn, tailThreadBytesBehind, nSrcs
@@ -422,6 +435,7 @@ __device__ __forceinline__ void reduceCopyPacks(
   warp = -nHunksAhead;
   thread = warp*WARP_SIZE + lane;
 }
+};
 #endif
 
 template<typename RedFn, typename T, int Unroll, int BytePerPack,
@@ -621,7 +635,7 @@ __device__ __attribute__((noinline)) void reduceCopyPacksWithBias(
 template<int Unroll, int  useAcc, typename RedFn, typename T,
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
-         typename IntBytes, typename SrcPtrFn, typename DstPtrFn, typename AccPtrFn>
+         typename IntBytes, typename SrcPtrFn, typename DstPtrFn, typename AccPtrFn, int Pipeline>
 __device__ __forceinline__ void reduceCopy(
     int thread, int nThreads,
     uint64_t redArg, uint64_t *preOpArgs, bool postOp,
@@ -641,8 +655,12 @@ __device__ __forceinline__ void reduceCopy(
 
   IntBytes nBytesBehind = 0;
   IntBytes nBytesAhead = nElts*sizeof(T);
+<<<<<<< HEAD
   //bool useAcc = accPtrFn() != nullptr;
 
+=======
+  bool useAcc = accPtrFn() != nullptr;
+>>>>>>> 836fe995 (Support pipelining codegen and template specialization)
   #if __cpp_if_constexpr
   if constexpr (BigPackSize > sizeof(T)) {
   #else
@@ -662,8 +680,7 @@ __device__ __forceinline__ void reduceCopy(
          nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead, accPtrFn);
       else
       reduceCopyPacks<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize,
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, thread, redArg, preOpArgs, postOp,
+        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, thread, redArg, preOpArgs, postOp,
          nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
 #else
       if (useAcc)
@@ -673,8 +690,7 @@ __device__ __forceinline__ void reduceCopy(
          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
       else
       reduceCopyPacks<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize,
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, /*&*/thread, redArg, preOpArgs, postOp,
          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
 #endif
       if (nBytesAhead == 0) return;
@@ -686,8 +702,7 @@ __device__ __forceinline__ void reduceCopy(
          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
       else
       reduceCopyPacks<RedFn, T, /*Unroll=*/1, BigPackSize,
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, /*&*/thread, redArg, preOpArgs, postOp,
          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
       if (nBytesAhead == 0) return;
     }
@@ -722,8 +737,7 @@ __device__ __forceinline__ void reduceCopy(
      nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead, accPtrFn);
     else
     reduceCopyPacks<RedFn, T, (Unroll*4 + sizeof(T) - 1)/sizeof(T), sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-    (nThreads, thread, redArg, preOpArgs, postOp,
+    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, thread, redArg, preOpArgs, postOp,
      nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
   } else {
     if (useAcc)
@@ -733,8 +747,7 @@ __device__ __forceinline__ void reduceCopy(
      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
     else
     reduceCopyPacks<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-    (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, /*&*/thread, redArg, preOpArgs, postOp,
      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
   }
 #else
@@ -745,8 +758,7 @@ __device__ __forceinline__ void reduceCopy(
      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
   else
   reduceCopyPacks<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-    (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, /*&*/thread, redArg, preOpArgs, postOp,
      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
 #endif
   if (nBytesAhead == 0) return;
@@ -758,15 +770,28 @@ __device__ __forceinline__ void reduceCopy(
      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
   else
   reduceCopyPacks<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T),
-    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-    (nThreads, /*&*/thread, redArg, preOpArgs, postOp,
+    MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, SrcPtrFn, DstPtrFn, Pipeline>::run(nThreads, /*&*/thread, redArg, preOpArgs, postOp,
      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
 }
 
+<<<<<<< HEAD
 template<int Unroll, int useAcc, typename RedFn, typename T,
+=======
+struct PtrFn {
+  void** ptrs;
+  __device__ void* operator()(int i) const { return ptrs[i]; }
+};
+
+struct AccPtrFn {
+  void* ptr;
+  __device__ void* operator()() const { return ptr; }
+};
+
+template<int Unroll, typename RedFn, typename T,
+>>>>>>> 836fe995 (Support pipelining codegen and template specialization)
          int MultimemSrcs, int MinSrcs, int MaxSrcs,
          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
-         typename IntBytes>
+         typename IntBytes, int Pipeline = 0>
 __device__ __forceinline__ void reduceCopy(
     int thread, int nThreads,
     uint64_t redArg, uint64_t *preOpArgs, bool postOp,
@@ -775,10 +800,11 @@ __device__ __forceinline__ void reduceCopy(
   ) {
   reduceCopy<Unroll, useAcc, RedFn, T,
              MultimemSrcs, MinSrcs, MaxSrcs,
-             MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes>
+             MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes,
+             PtrFn, PtrFn, AccPtrFn, Pipeline>
     (thread, nThreads, redArg, preOpArgs, postOp,
-     nSrcs, [=]__device__(int i) { return srcPtrs[i]; },
-     nDsts, [=]__device__(int i) { return dstPtrs[i]; }, nElts, [=]__device__() { return accPtr; });
+     nSrcs, PtrFn{srcPtrs},
+     nDsts, PtrFn{dstPtrs}, nElts, AccPtrFn{accPtr});
 }
 
 #endif // COMMON_KERNEL_H_

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -496,12 +496,13 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
       fn_id = primary_to_index[equivalent_primary(*fn)]
       comment = " // " + paste(" ", *fn[:-1])
       # Build the function signature string: "<coll> <algo> <proto> <redop> <ty>"
+      # get parts indexes in order (coll, algo, proto, redop, ty, acc, pipeline, unroll)
       coll_idx = all_colls.index(fn[0])
       algo_idx = all_algos.index(fn[1])
       proto_idx = all_protos.index(fn[2])
       redop_idx = all_redops.index(fn[3])
       ty_idx = all_tys.index(fn[4])
-      pipeline_idx = all_pipeline.index(fn[5])
+      pipeline_idx = all_pipeline.index(fn[6])
       # Assert that 4 bits (16 values) is enough to map all_colls, all_algos, etc.
       assert len(all_colls) <= 16, "Error: all_colls has more than 16 values, which exceeds 4-bit capacity."
       assert len(all_algos) <= 16, "Error: all_algos has more than 16 values, which exceeds 4-bit capacity."

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -116,24 +116,25 @@ redops_of_coll = {
 }
 
 tys_of_coll = {
-  "AllGather":     ["i8"],
-  "AllReduce":     all_tys,
+  "AllGather":             ["i8"],
+  "AllReduce":             all_tys,
   "AllReduceWithBias":     all_tys,
-  "AllToAllPivot": ["i8"],
-  "Broadcast":     ["i8"],
-  "Reduce":        all_tys,
-  "ReduceScatter": all_tys,
-  "SendRecv":      ["i8"]
+  "AllToAllPivot":         ["i8"],
+  "Broadcast":             ["i8"],
+  "Reduce":                all_tys,
+  "ReduceScatter":         all_tys,
+  "SendRecv":              ["i8"]
 }
 
 pipelines_of_coll = {
-  "AllGather":     ["0"],
-  "AllReduce":     all_pipeline,
-  "AllToAllPivot": ["0"],
-  "Broadcast":     ["0"],
-  "Reduce":        all_pipeline,
-  "ReduceScatter": all_pipeline,
-  "SendRecv":      ["0"]
+  "AllGather":             ["0"],
+  "AllReduce":             all_pipeline,
+  "AllReduceWithBias":     ["0"],
+  "AllToAllPivot":         ["0"],
+  "Broadcast":             ["0"],
+  "Reduce":                all_pipeline,
+  "ReduceScatter":         all_pipeline,
+  "SendRecv":              ["0"]
 }
 
 coll_camel_to_lower = {

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -3,16 +3,25 @@ import os
 import sys
 import subprocess
 
+<<<<<<< HEAD
 # Order of redops, tys, protos, algos must match src/include/device.h
 all_colls =  ["AllGather","AllReduce","AllReduceWithBias","AllToAllPivot","Broadcast","Reduce","ReduceScatter","SendRecv"]
+=======
+# Order of colls, redops, tys, protos, algos must match src/include/device.h
+all_colls = ["Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce", "SendRecv", "", "", "AllToAllPivot"]
+>>>>>>> c380955f (Refactor: Replace row-based lookup with hash-based logic in ncclDevFuncId)
 all_redops = ["Sum","Prod","MinMax","PreMulSum","SumPostDiv"]
 all_tys =    ["i8","u8","i32","u32","i64","u64","f16","f32","f64","bf16","f8e4m3","f8e5m2"]
 all_protos = ["LL","LL128","SIMPLE"]
 all_algos =  ["TREE","RING", "PAT"]
 all_unroll = ["1", "2", "4"]
+<<<<<<< HEAD
 use_acc    = ["0", "1"]
 
 all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, use_acc, all_unroll]
+=======
+all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, all_unroll]
+>>>>>>> c380955f (Refactor: Replace row-based lookup with hash-based logic in ncclDevFuncId)
 
 ################################################################################
 # The first command line argument is the path to the directory to generate and
@@ -187,6 +196,8 @@ def func_validate(coll, algo, proto, redop, ty, acc, unroll):
     return False
   if redop == "SumPostDiv" and ty[0] not in ("i","u"):
     return False
+  if coll == "":
+    return False
   if algo not in algos_of_coll[coll] or proto not in protos_of_coll[coll] or redop not in redops_of_coll[coll] or ty not in tys_of_coll[coll] or unroll not in all_unroll:
     return False
   return True
@@ -219,12 +230,12 @@ def func_filter(function_params, current_idx, item_list=None):
       # Check if the current element is recognized
       elements = current_element.split("/")
       current_param = all_params[current_idx]
-      
+
       # Iterate over the elements in the elements list
       for item in elements:
         if item not in current_param:
           raise ValueError(f"Error: {item} is unrecognized or does not belong to this category {current_param}.")
-        
+
       for item in elements:
         item_list.append(item)
         yield from func_filter(function_params, current_idx+1, item_list)
@@ -279,8 +290,8 @@ def enumerate_func_rows():
 
 # Sort the hashmap based on custom key <coll> <algo> <proto> <redop> <ty>
 def custom_sort_key(fn):
-    coll, algo, proto, redop, ty, acc, unroll = fn
-    
+    coll, algo, proto, redop, ty, unroll = fn
+
     return (
         all_unroll.index(unroll),
         use_acc.index(acc),
@@ -380,7 +391,7 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
     index4 += 1
   out("nullptr};\n")
   out("\n")
-  
+
   if not is_ifc:
     out("template<unsigned short f, unsigned short l>\n"
       "struct Caller1 {\n"
@@ -445,7 +456,7 @@ if is_colltrace:
     out = f.write
     out('#include "nccl_common.h"\n#include "device.h"\n')
     out("\n")
-    
+
     seen_fns = set()
     out("const char* funcNames[FUNC_INDEX_TOTAL] = {\n")
     for fn in primary_funcs:
@@ -464,18 +475,47 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
   out = f.write
   out('#include "device.h"\n')
   out("\n")
-
-  # The mapping from function rows to valid primary function ids.
-  out("extern int const ncclDevFuncRowToId[] = {\n")
-  index = 0
-  for fn in func_rows[:len(func_rows)//len(all_unroll)]:
-    fn_id, comment = -1, ""
+  out("// The key for the ncclDevFuncNameToId map is a 64-bit unsigned integer.\n")
+  out("// Each field (coll, algo, proto, redop, ty) is packed into 4 bits,\n")
+  out("// This allows up to 16 unique values per field. The layout is:\n")
+  out("//   bits  0-3:   coll index\n")
+  out("//   bits  4-7:   algo index\n")
+  out("//   bits  8-11:  proto index\n")
+  out("//   bits 12-15:  redop index\n")
+  out("//   bits 16-19:  ty index\n")
+  out("#include <unordered_map>\n")
+  out("extern std::unordered_map<uint64_t, int> ncclDevFuncNameToId = {\n")
+  for fn in func_rows:
+    fn_id = -1
     if fn is not None:
       fn_id = primary_to_index[equivalent_primary(*fn)]
       comment = " // " + paste(" ", *fn[:-1])
-    out("/*%4d*/ %d,%s\n" % (index, fn_id, comment))
-    index += 1
-  out(f"{index}")
+      # Build the function signature string: "<coll> <algo> <proto> <redop> <ty>"
+      coll_idx = all_colls.index(fn[0])
+      algo_idx = all_algos.index(fn[1])
+      proto_idx = all_protos.index(fn[2])
+      redop_idx = all_redops.index(fn[3])
+      ty_idx = all_tys.index(fn[4])
+      # Assert that 4 bits (16 values) is enough to map all_colls, all_algos, etc.
+      assert len(all_colls) <= 16, "Error: all_colls has more than 16 values, which exceeds 4-bit capacity."
+      assert len(all_algos) <= 16, "Error: all_algos has more than 16 values, which exceeds 4-bit capacity."
+      assert len(all_protos) <= 16, "Error: all_protos has more than 16 values, which exceeds 4-bit capacity."
+      assert len(all_redops) <= 16, "Error: all_redops has more than 16 values, which exceeds 4-bit capacity."
+      assert len(all_tys) <= 16, "Error: all_tys has more than 16 values, which exceeds 4-bit capacity."
+      # Create a 64-bit unsigned integer key and pack the indices into 4 bits each
+      key = (
+        (coll_idx & 0xF)
+        | ((algo_idx & 0xF) << 4)
+        | ((proto_idx & 0xF) << 8)
+        | ((redop_idx & 0xF) << 12)
+        | ((ty_idx & 0xF) << 16)
+      )
+      fn_str = f"{coll_idx} {algo_idx} {proto_idx} {redop_idx} {ty_idx}"
+      if fn[0] == "Broadcast":
+        key = ((coll_idx & 0x3F) | ((proto_idx & 0x3F) << 8))
+      if fn[0] in ["SendRecv", "AllToAllPivot"]:
+        key = ((coll_idx & 0x3F))
+      out(f'  {{{key}, {fn_id}}}, {comment}\n')
   out("};\n")
 
 # Maps to .cu filename which implements this func. The only constraint is that

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -461,7 +461,7 @@ if is_colltrace:
     out("\n")
 
     seen_fns = set()
-    out("const char* funcNames[FUNC_INDEX_TOTAL] = {\n")
+    out("const char* funcNames[] = {\n")
     for fn in primary_funcs:
       fn_no_unroll = fn[:-1]
       if fn_no_unroll not in seen_fns:

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -11,6 +11,8 @@ all_protos = ["LL","LL128","SIMPLE"]
 all_algos =  ["TREE","RING", "", "", "", "", "PAT"]
 all_unroll = ["1", "2", "4"]
 use_acc    = ["0", "1"]
+# Pipelining is not supported for LL/LL64 prims, so "1" is not a valid value for low latency protocols.
+# However, if it needs to be supported, equivalent_primary() can be modified to avoid the "non-zero"->"0" mapping.
 all_pipeline = ["0", "1"]
 pipelined_types = ["bf16"]
 all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, use_acc, all_pipeline, all_unroll]
@@ -277,6 +279,10 @@ def equivalent_primary(coll, algo, proto, redop, ty, acc, pipeline, unroll):
     # map signed integer min/max to unsigned for non-NVLS
     elif redop=="MinMax" and ty[0]=="i" and ("NVLS" not in algo):
       ty = "u"+ty[1:]
+    # map pipelined to non-pipelined for LL/LL128 to avoid extra device codegen
+    if (pipeline != "0" and proto != "SIMPLE"):
+      pipeline = "0"
+
   return (coll, algo, proto, redop, ty, acc, pipeline, unroll)
 
 # Order rows are enumerated must match formula of `ncclDevFuncId()`:

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -3,31 +3,17 @@ import os
 import sys
 import subprocess
 
-<<<<<<< HEAD
-# Order of redops, tys, protos, algos must match src/include/device.h
-all_colls =  ["AllGather","AllReduce","AllReduceWithBias","AllToAllPivot","Broadcast","Reduce","ReduceScatter","SendRecv"]
-=======
 # Order of colls, redops, tys, protos, algos must match src/include/device.h
-all_colls = ["Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce", "SendRecv", "", "", "AllToAllPivot"]
->>>>>>> c380955f (Refactor: Replace row-based lookup with hash-based logic in ncclDevFuncId)
+all_colls = ["Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce", "AllReduceWithBias", "SendRecv", "", "", "AllToAllPivot"]
 all_redops = ["Sum","Prod","MinMax","PreMulSum","SumPostDiv"]
 all_tys =    ["i8","u8","i32","u32","i64","u64","f16","f32","f64","bf16","f8e4m3","f8e5m2"]
 all_protos = ["LL","LL128","SIMPLE"]
 all_algos =  ["TREE","RING", "", "", "", "", "PAT"]
 all_unroll = ["1", "2", "4"]
-<<<<<<< HEAD
-<<<<<<< HEAD
 use_acc    = ["0", "1"]
-
-all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, use_acc, all_unroll]
-=======
-all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, all_unroll]
->>>>>>> c380955f (Refactor: Replace row-based lookup with hash-based logic in ncclDevFuncId)
-=======
 all_pipeline = ["0", "1"]
 pipelined_types = ["bf16"]
-all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, all_pipeline, all_unroll]
->>>>>>> 836fe995 (Support pipelining codegen and template specialization)
+all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, use_acc, all_pipeline, all_unroll]
 
 ################################################################################
 # The first command line argument is the path to the directory to generate and

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -16,12 +16,18 @@ all_protos = ["LL","LL128","SIMPLE"]
 all_algos =  ["TREE","RING", "", "", "", "", "PAT"]
 all_unroll = ["1", "2", "4"]
 <<<<<<< HEAD
+<<<<<<< HEAD
 use_acc    = ["0", "1"]
 
 all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, use_acc, all_unroll]
 =======
 all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, all_unroll]
 >>>>>>> c380955f (Refactor: Replace row-based lookup with hash-based logic in ncclDevFuncId)
+=======
+all_pipeline = ["0", "1"]
+pipelined_types = ["bf16"]
+all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, all_pipeline, all_unroll]
+>>>>>>> 836fe995 (Support pipelining codegen and template specialization)
 
 ################################################################################
 # The first command line argument is the path to the directory to generate and
@@ -134,6 +140,16 @@ tys_of_coll = {
   "SendRecv":      ["i8"]
 }
 
+pipelines_of_coll = {
+  "AllGather":     ["0"],
+  "AllReduce":     all_pipeline,
+  "AllToAllPivot": ["0"],
+  "Broadcast":     ["0"],
+  "Reduce":        all_pipeline,
+  "ReduceScatter": all_pipeline,
+  "SendRecv":      ["0"]
+}
+
 coll_camel_to_lower = {
   "AllGather":             "all_gather",
   "AllReduce":             "all_reduce",
@@ -189,7 +205,7 @@ def calc_unroll_for_local_arch():
     return all_unroll
 
 # Helper function to check if the conditions for the collective is being met
-def func_validate(coll, algo, proto, redop, ty, acc, unroll):
+def func_validate(coll, algo, proto, redop, ty, acc,  pipeline, unroll):
   if acc == "1" and coll != "AllReduceWithBias":
     return False
   if acc == "0" and coll == "AllReduceWithBias":
@@ -198,7 +214,7 @@ def func_validate(coll, algo, proto, redop, ty, acc, unroll):
     return False
   if coll == "" or algo == "":
     return False
-  if algo not in algos_of_coll[coll] or proto not in protos_of_coll[coll] or redop not in redops_of_coll[coll] or ty not in tys_of_coll[coll] or unroll not in all_unroll:
+  if algo not in algos_of_coll[coll] or proto not in protos_of_coll[coll] or redop not in redops_of_coll[coll] or ty not in tys_of_coll[coll] or unroll not in all_unroll or pipeline not in pipelines_of_coll[coll] or (pipeline in ["1"] and ty not in pipelined_types):
     return False
   return True
 
@@ -243,10 +259,10 @@ def func_filter(function_params, current_idx, item_list=None):
         # For each loop layer remove the last element in item_list
         item_list.pop()
   else:
-    coll, algo, proto, redop, ty, acc, unroll = item_list
+    coll, algo, proto, redop, ty, acc, pipeline, unroll = item_list
+    if func_validate(coll, algo, proto, redop, ty, acc, pipeline, unroll):
+      yield(coll, algo, proto, redop, ty, acc, pipeline, unroll)
 
-    if func_validate(coll, algo, proto, redop, ty, acc, unroll):
-      yield(coll, algo, proto, redop, ty, acc, unroll)
 
 # Parse ONLY_FUNCS input and feed it to func_filter
 def parse_input(func_pattern):
@@ -266,7 +282,7 @@ def parse_input(func_pattern):
 
 # Maps functions to the chosen representative for the equivalence class it
 # belongs to. For instance (sum, signed int) maps to (sum, unsigned int).
-def equivalent_primary(coll, algo, proto, redop, ty, acc, unroll):
+def equivalent_primary(coll, algo, proto, redop, ty, acc, pipeline, unroll):
   if coll in ("AllReduce", "AllReduceWithBias", "Reduce", "ReduceScatter"):
     # map signed integer sum/prod to unsigned
     if redop in ("Sum","Prod","PreMulSum","SumPostDiv") and ty[0]=="i":
@@ -274,7 +290,7 @@ def equivalent_primary(coll, algo, proto, redop, ty, acc, unroll):
     # map signed integer min/max to unsigned for non-NVLS
     elif redop=="MinMax" and ty[0]=="i" and ("NVLS" not in algo):
       ty = "u"+ty[1:]
-  return (coll, algo, proto, redop, ty, acc, unroll)
+  return (coll, algo, proto, redop, ty, acc, pipeline, unroll)
 
 # Order rows are enumerated must match formula of `ncclDevFuncId()`:
 def enumerate_func_rows():
@@ -285,12 +301,12 @@ def enumerate_func_rows():
           for proto in all_protos:
             for redop in all_redops:
               for ty in all_tys:
-                  if func_validate(coll, algo, proto, redop, ty, acc, unroll):
-                    yield (coll, algo, proto, redop, ty, acc, unroll)
-
+                for pipeline in all_pipeline:
+                  if func_validate(coll, algo, proto, redop, ty, acc, pipeline, unroll):
+                    yield (coll, algo, proto, redop, ty, acc, pipeline, unroll)
 # Sort the hashmap based on custom key <coll> <algo> <proto> <redop> <ty>
 def custom_sort_key(fn):
-    coll, algo, proto, redop, ty, unroll = fn
+    coll, algo, proto, redop, ty, acc, pipeline, unroll = fn
 
     return (
         all_unroll.index(unroll),
@@ -299,7 +315,8 @@ def custom_sort_key(fn):
         all_algos.index(algo),
         all_protos.index(proto),
         all_redops.index(redop),
-        all_tys.index(ty)
+        all_tys.index(ty),
+        all_pipeline.index(pipeline)
     )
 
 ################################################################################
@@ -343,7 +360,7 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
   out("__device__ ncclDevFuncPtr_t const ncclDevFuncTable_1[] = {\n")
   index1 = 0
   for fn in primary_funcs:
-    coll, algo, proto, redop, ty, acc, unroll = fn
+    coll, algo, proto, redop, ty, acc, pipeline, unroll = fn
     if unroll != "1": continue
     sym = paste("_", "ncclDevFunc", *fn)
     if fn[2] == "LL128":
@@ -360,7 +377,7 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
   out("__device__ ncclDevFuncPtr_t const ncclDevFuncTable_2[] = {\n")
   index2 = 0
   for fn in primary_funcs:
-    coll, algo, proto, redop, ty, acc, unroll = fn
+    coll, algo, proto, redop, ty, acc, pipeline, unroll = fn
     if unroll != "2": continue
     sym = paste("_", "ncclDevFunc", *fn)
     if fn[2] == "LL128":
@@ -377,7 +394,7 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
   out("__device__ ncclDevFuncPtr_t const ncclDevFuncTable_4[] = {\n")
   index4 = 0
   for fn in primary_funcs:
-    coll, algo, proto, redop, ty, acc, unroll = fn
+    coll, algo, proto, redop, ty, acc, pipeline, unroll = fn
     if unroll != "4": continue
     sym = paste("_", "ncclDevFunc", *fn)
     if fn[2] == "LL128":
@@ -476,13 +493,14 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
   out('#include "device.h"\n')
   out("\n")
   out("// The key for the ncclDevFuncNameToId map is a 64-bit unsigned integer.\n")
-  out("// Each field (coll, algo, proto, redop, ty) is packed into 4 bits,\n")
+  out("// Each field (coll, algo, proto, redop, ty, pipeline) is packed into 4 bits,\n")
   out("// This allows up to 16 unique values per field. The layout is:\n")
   out("//   bits  0-3:   coll index\n")
   out("//   bits  4-7:   algo index\n")
   out("//   bits  8-11:  proto index\n")
   out("//   bits 12-15:  redop index\n")
   out("//   bits 16-19:  ty index\n")
+  out("//   bits 20-23:  pipeline index\n")
   out("#include <unordered_map>\n")
   out("extern std::unordered_map<uint64_t, int> ncclDevFuncNameToId = {\n")
   for fn in func_rows:
@@ -496,12 +514,14 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
       proto_idx = all_protos.index(fn[2])
       redop_idx = all_redops.index(fn[3])
       ty_idx = all_tys.index(fn[4])
+      pipeline_idx = all_pipeline.index(fn[5])
       # Assert that 4 bits (16 values) is enough to map all_colls, all_algos, etc.
       assert len(all_colls) <= 16, "Error: all_colls has more than 16 values, which exceeds 4-bit capacity."
       assert len(all_algos) <= 16, "Error: all_algos has more than 16 values, which exceeds 4-bit capacity."
       assert len(all_protos) <= 16, "Error: all_protos has more than 16 values, which exceeds 4-bit capacity."
       assert len(all_redops) <= 16, "Error: all_redops has more than 16 values, which exceeds 4-bit capacity."
       assert len(all_tys) <= 16, "Error: all_tys has more than 16 values, which exceeds 4-bit capacity."
+      assert len(all_pipeline) <= 16, "Error: all_pipeline has more than 16 values, which exceeds 4-bit capacity."
       # Create a 64-bit unsigned integer key and pack the indices into 4 bits each
       key = (
         (coll_idx & 0xF)
@@ -509,8 +529,9 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
         | ((proto_idx & 0xF) << 8)
         | ((redop_idx & 0xF) << 12)
         | ((ty_idx & 0xF) << 16)
+        | ((pipeline_idx & 0xF) << 20)
       )
-      fn_str = f"{coll_idx} {algo_idx} {proto_idx} {redop_idx} {ty_idx}"
+      fn_str = f"{coll_idx} {algo_idx} {proto_idx} {redop_idx} {ty_idx} {pipeline_idx}"
       if fn[0] == "Broadcast":
         key = ((coll_idx & 0x3F) | ((proto_idx & 0x3F) << 8))
       if fn[0] in ["SendRecv", "AllToAllPivot"]:
@@ -521,7 +542,7 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
 # Maps to .cu filename which implements this func. The only constraint is that
 # "coll" is reflected in the name: formally that no two funcs having different
 # coll's map to the same filename.
-def impl_filename(coll, algo, proto, redop, ty, acc, unroll):
+def impl_filename(coll, algo, proto, redop, ty, acc, pipeline, unroll):
   return "%s.cpp" % paste("_", coll_camel_to_lower[coll], redop and redop.lower(), ty)
 
 # Partition the functions and kernels to the .cu filenames. The partition is
@@ -579,14 +600,14 @@ for name in name_to_funcs.keys():
     )
 
     for fn in fns:
-      (coll, algo, proto, redop, ty, acc, unroll) = fn
-      sym = paste("_", coll, algo, proto, redop, ty, acc, unroll)
+      (coll, algo, proto, redop, ty, acc, pipeline, unroll) = fn
+      sym = paste("_", coll, algo, proto, redop, ty, acc, pipeline, unroll)
       if proto == "LL128":
         out("#if (defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__)) && defined(ENABLE_LL128)\n")
       out(
-        "DEFINE_ncclDevFunc({sym}, ncclFunc{coll}, {redop_cxx}, {ty_cxx}, NCCL_ALGO_{algo}, NCCL_PROTO_{proto}, {acc}, {unroll})\n"
+        "DEFINE_ncclDevFunc({sym}, ncclFunc{coll}, {redop_cxx}, {ty_cxx}, NCCL_ALGO_{algo}, NCCL_PROTO_{proto}, {acc}, {pipeline}, {unroll})\n"
         .format(sym=sym, coll=coll, redop_cxx=redop_to_cxx[redop], ty_cxx=ty_to_cxx[ty],
-                algo=(algo or "RING"), proto=(proto or "SIMPLE"), acc=acc, unroll=unroll)
+                algo=(algo or "RING"), proto=(proto or "SIMPLE"), acc=acc, pipeline=pipeline, unroll=unroll)
       )
       if proto == "LL128":
         out("#endif\n")

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -203,7 +203,7 @@ def func_validate(coll, algo, proto, redop, ty, acc,  pipeline, unroll):
     return False
   if coll == "" or algo == "":
     return False
-  if algo not in algos_of_coll[coll] or proto not in protos_of_coll[coll] or redop not in redops_of_coll[coll] or ty not in tys_of_coll[coll] or unroll not in all_unroll or pipeline not in pipelines_of_coll[coll] or (pipeline in ["1"] and ty not in pipelined_types):
+  if algo not in algos_of_coll[coll] or proto not in protos_of_coll[coll] or redop not in redops_of_coll[coll] or ty not in tys_of_coll[coll] or acc not in use_acc or unroll not in all_unroll or pipeline not in pipelines_of_coll[coll] or (pipeline in ["1"] and ty not in pipelined_types):
     return False
   return True
 
@@ -287,8 +287,8 @@ def equivalent_primary(coll, algo, proto, redop, ty, acc, pipeline, unroll):
 
 # Order rows are enumerated must match formula of `ncclDevFuncId()`:
 def enumerate_func_rows():
-  for acc in use_acc:
-    for unroll in all_unroll:
+  for unroll in all_unroll:
+    for acc in use_acc:
       for coll in all_colls:
         for algo in all_algos:
           for proto in all_protos:

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -497,7 +497,7 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
   out("//   bits 16-19:  ty index\n")
   out("//   bits 20-23:  pipeline index\n")
   out("#include <unordered_map>\n")
-  out("extern std::unordered_map<uint64_t, int> ncclDevFuncNameToId = {\n")
+  out("std::unordered_map<uint64_t, int> ncclDevFuncNameToId = {\n")
   for fn in func_rows:
     fn_id = -1
     if fn is not None:

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -13,7 +13,7 @@ all_colls = ["Broadcast", "Reduce", "AllGather", "ReduceScatter", "AllReduce", "
 all_redops = ["Sum","Prod","MinMax","PreMulSum","SumPostDiv"]
 all_tys =    ["i8","u8","i32","u32","i64","u64","f16","f32","f64","bf16","f8e4m3","f8e5m2"]
 all_protos = ["LL","LL128","SIMPLE"]
-all_algos =  ["TREE","RING", "PAT"]
+all_algos =  ["TREE","RING", "", "", "", "", "PAT"]
 all_unroll = ["1", "2", "4"]
 <<<<<<< HEAD
 use_acc    = ["0", "1"]
@@ -196,7 +196,7 @@ def func_validate(coll, algo, proto, redop, ty, acc, unroll):
     return False
   if redop == "SumPostDiv" and ty[0] not in ("i","u"):
     return False
-  if coll == "":
+  if coll == "" or algo == "":
     return False
   if algo not in algos_of_coll[coll] or proto not in protos_of_coll[coll] or redop not in redops_of_coll[coll] or ty not in tys_of_coll[coll] or unroll not in all_unroll:
     return False

--- a/src/device/primitives.h
+++ b/src/device/primitives.h
@@ -137,7 +137,7 @@ struct FanSymmetric {
 };
 
 // The primitives class. Specialized per protocol in the other headers.
-template<typename T, typename RedOp, typename Fan, int Direct, typename Proto, int P2p, bool isNetOffload = false, int Metadata = RCCL_METADATA_EMPTY, int Pipeline = 0>
+template<typename T, typename RedOp, typename Fan, int Direct, typename Proto, int P2p, bool isNetOffload = false, int Metadata = RCCL_METADATA_EMPTY, int Pipeline = 0, int useAcc = 0>
 class Primitives;
 
 // Used by LL & LL128 to implement direct members in the naive way.

--- a/src/device/primitives.h
+++ b/src/device/primitives.h
@@ -137,7 +137,7 @@ struct FanSymmetric {
 };
 
 // The primitives class. Specialized per protocol in the other headers.
-template<typename T, typename RedOp, typename Fan, int Direct, typename Proto, int P2p, bool isNetOffload = false, int Metadata = RCCL_METADATA_EMPTY>
+template<typename T, typename RedOp, typename Fan, int Direct, typename Proto, int P2p, bool isNetOffload = false, int Metadata = RCCL_METADATA_EMPTY, int Pipeline = 0>
 class Primitives;
 
 // Used by LL & LL128 to implement direct members in the naive way.

--- a/src/device/primitives.h
+++ b/src/device/primitives.h
@@ -55,7 +55,7 @@
  * to how that protocol operates with a consistent interface so that our
  * algorithm code can operate protocol parametrically.
  */
-template<int SlicePerChunk_1, int StepPerSlice_1,int useAcc, int Unroll_1, int MultimemSrcs_1 = 0, int MultimemDsts_1 = 0>
+template<int SlicePerChunk_1, int StepPerSlice_1, int useAcc, int Unroll_1, int MultimemSrcs_1 = 0, int MultimemDsts_1 = 0>
 struct ProtoSimple {
   static constexpr int Id = NCCL_PROTO_SIMPLE;
   static constexpr int SlicePerChunk = SlicePerChunk_1;

--- a/src/device/prims_simple.h
+++ b/src/device/prims_simple.h
@@ -24,7 +24,7 @@ enum primsMode {
 template<typename T, typename RedOp, typename Fan, int Direct,
          int SlicePerChunk, int StepPerSlice, int Unroll, int P2p, int MultimemSrcs, int MultimemDsts, bool isNetOffload, int Metadata, int Pipeline, int useAcc>
 class Primitives<
-    T, RedOp, Fan, Direct, ProtoSimple<SlicePerChunk, StepPerSlice, Unroll, MultimemSrcs, MultimemDsts>, P2p, isNetOffload, Metadata, Pipeline, useAcc
+    T, RedOp, Fan, Direct, ProtoSimple<SlicePerChunk, StepPerSlice, useAcc, Unroll, MultimemSrcs, MultimemDsts>, P2p, isNetOffload, Metadata, Pipeline, useAcc
   > {
   static constexpr int MaxRecv = Fan::MaxRecv, MaxSend = Fan::MaxSend;
   static constexpr int Input=0, Output=1;

--- a/src/device/prims_simple.h
+++ b/src/device/prims_simple.h
@@ -22,9 +22,9 @@ enum primsMode {
 };
 
 template<typename T, typename RedOp, typename Fan, int Direct,
-         int SlicePerChunk, int StepPerSlice, int Unroll, int P2p, int MultimemSrcs, int MultimemDsts, bool isNetOffload, int Metadata, int useAcc>
+         int SlicePerChunk, int StepPerSlice, int Unroll, int P2p, int MultimemSrcs, int MultimemDsts, bool isNetOffload, int Metadata, int Pipeline, int useAcc>
 class Primitives<
-    T, RedOp, Fan, Direct, ProtoSimple<SlicePerChunk, StepPerSlice, useAcc, Unroll, MultimemSrcs, MultimemDsts>, P2p, isNetOffload, Metadata
+    T, RedOp, Fan, Direct, ProtoSimple<SlicePerChunk, StepPerSlice, Unroll, MultimemSrcs, MultimemDsts>, P2p, isNetOffload, Metadata, Pipeline, useAcc
   > {
   static constexpr int MaxRecv = Fan::MaxRecv, MaxSend = Fan::MaxSend;
   static constexpr int Input=0, Output=1;
@@ -80,9 +80,9 @@ private:
 
   // Don't use barrier 0 as it's used by the final sync
   inline __device__ void barrier() {
-    if (nthreads == WARP_SIZE) 
+    if (nthreads == WARP_SIZE)
       __syncwarp();
-    else 
+    else
       #if defined(__gfx942__) || defined(__gfx950__)
         barrier_generic(__threadfence_block(), nworkers, barrier_next, barriers);
       #else
@@ -380,7 +380,7 @@ private:
             // this case should only be directCopySend() with registered buffers and send to net peer
             reduceCopy<Unroll, useAcc, RedOp, T,
               0, Recv + Src, Recv * MaxRecv + Src,
-              0, 1, 1, PreOpSrcs>
+              0, 1, 1, PreOpSrcs, decltype(workSize), Pipeline>
               (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, postOp,
                 Recv * fan.nrecv() + Src, ncclShmem.groups[group].srcs,
                 1, ncclShmem.groups[group].dsts,
@@ -388,7 +388,7 @@ private:
           } else {
             reduceCopy<Unroll, useAcc, RedOp, T,
               MultimemSrcs, Recv + Src, Recv * MaxRecv + Src,
-              MultimemDsts, Send + Dst, Send * MaxSend + Dst, PreOpSrcs>
+              MultimemDsts, Send + Dst, Send * MaxSend + Dst, PreOpSrcs, decltype(workSize), Pipeline>
               (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, postOp,
                 Recv * fan.nrecv() + Src, ncclShmem.groups[group].srcs,
                 Send * fan.nsend() + Dst, ncclShmem.groups[group].dsts,
@@ -458,10 +458,10 @@ private:
         srcs[nsrcs] = dsts[0];
         nsrcs++;
         if (MULTISRCS){
-          reduceCopy<Unroll, useAcc, RedOp, T, 0, 3, MSCCL_MAX_REDUCE_FUSION, 0, 1, 1, 0>
+          reduceCopy<Unroll, useAcc, RedOp, T, 0, 3, MSCCL_MAX_REDUCE_FUSION, 0, 1, 1, 0, decltype(nelem), Pipeline>
             (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, nsrcs, (void **)srcs, 1, (void **)dsts, nelem);
         } else {
-          reduceCopy<Unroll, useAcc, RedOp, T, 0, 2, 2, 0, 1, 1, 0>
+          reduceCopy<Unroll, useAcc, RedOp, T, 0, 2, 2, 0, 1, 1, 0, decltype(nelem), Pipeline>
             (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, 2, (void **)srcs, 1, (void **)dsts, nelem);
         }
       }

--- a/src/device/prims_simple.h
+++ b/src/device/prims_simple.h
@@ -380,7 +380,7 @@ private:
             // this case should only be directCopySend() with registered buffers and send to net peer
             reduceCopy<Unroll, useAcc, RedOp, T,
               0, Recv + Src, Recv * MaxRecv + Src,
-              0, 1, 1, PreOpSrcs, decltype(workSize), Pipeline>
+              0, 1, 1, PreOpSrcs, Pipeline>
               (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, postOp,
                 Recv * fan.nrecv() + Src, ncclShmem.groups[group].srcs,
                 1, ncclShmem.groups[group].dsts,
@@ -388,7 +388,7 @@ private:
           } else {
             reduceCopy<Unroll, useAcc, RedOp, T,
               MultimemSrcs, Recv + Src, Recv * MaxRecv + Src,
-              MultimemDsts, Send + Dst, Send * MaxSend + Dst, PreOpSrcs, decltype(workSize), Pipeline>
+              MultimemDsts, Send + Dst, Send * MaxSend + Dst, PreOpSrcs, Pipeline>
               (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, postOp,
                 Recv * fan.nrecv() + Src, ncclShmem.groups[group].srcs,
                 Send * fan.nsend() + Dst, ncclShmem.groups[group].dsts,
@@ -458,10 +458,10 @@ private:
         srcs[nsrcs] = dsts[0];
         nsrcs++;
         if (MULTISRCS){
-          reduceCopy<Unroll, useAcc, RedOp, T, 0, 3, MSCCL_MAX_REDUCE_FUSION, 0, 1, 1, 0, decltype(nelem), Pipeline>
+          reduceCopy<Unroll, useAcc, RedOp, T, 0, 3, MSCCL_MAX_REDUCE_FUSION, 0, 1, 1, 0, Pipeline>
             (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, nsrcs, (void **)srcs, 1, (void **)dsts, nelem);
         } else {
-          reduceCopy<Unroll, useAcc, RedOp, T, 0, 2, 2, 0, 1, 1, 0, decltype(nelem), Pipeline>
+          reduceCopy<Unroll, useAcc, RedOp, T, 0, 2, 2, 0, 1, 1, 0, Pipeline>
             (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, 2, (void **)srcs, 1, (void **)dsts, nelem);
         }
       }

--- a/src/device/reduce.h
+++ b/src/device/reduce.h
@@ -31,7 +31,7 @@ namespace {
     // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
     // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
     // coverity[callee_ptr_arith:FALSE]
-    Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0>
+    Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline>
       prims(tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, 0, work->connIndex, work->connIndex);
 
     if (prevRank == root) {

--- a/src/device/reduce_scatter.h
+++ b/src/device/reduce_scatter.h
@@ -56,7 +56,7 @@ namespace {
     // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
     // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
     // coverity[callee_ptr_arith:FALSE]
-    Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0>
+    Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline>
       prims(tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, 0, work->connIndex, work->connIndex);
 
 #if defined(ENABLE_NPKIT)
@@ -213,7 +213,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SI
       int nGroups = nworkers / groupSize;
       int tidInGroup = tid - group*groupSize;
       // We don't use recvPeers/sendPeers so let's pass shmem structs instead
-      Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0> prims
+      Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline> prims
         (tidInGroup, groupSize, (int*)shmem->recvDims, (int*)shmem->sendDims, inputBuf, outputBuf, work->redOpArg, group, 0, 0, nullptr, nullptr, 0, primsModePatRs);
 
       int step = group;

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -480,6 +480,7 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
         struct ncclTaskColl* next = aggBeg->next;
         aggBeg->algorithm = agg.algorithm;
         aggBeg->protocol = agg.protocol;
+        aggBeg->pipeline = agg.pipeline;
         if (aggBeg->protocol == NCCL_PROTO_LL) aggBeg->trafficBytes *= 4;
         aggBeg->nMaxChannels = agg.nMaxChannels;
         aggBeg->nWarps = agg.nWarps;

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -457,7 +457,7 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
       }
 
       NCCLCHECK(getAlgoInfo(comm, &agg, collNetSupport, nvlsSupport, nTasksPerChannel, simInfo));
-      agg.devFuncId = ncclDevFuncId(agg.func, agg.opDev.op, agg.datatype, agg.algorithm, agg.protocol);
+      agg.devFuncId = ncclDevFuncId(agg.func, agg.opDev.op, agg.datatype, agg.algorithm, agg.protocol, agg.pipeline);
       if (agg.devFuncId < 0) {
         WARN("%s: unsupported collective. Please ensure the collective has been enabled in build.", __func__);
         return ncclInvalidUsage;
@@ -1941,6 +1941,7 @@ static ncclResult_t topoGetAlgoInfo(
     return (algoEnv || protoEnv) ? ncclInvalidUsage : ncclInternalError;
   }
   rcclUpdateCollectiveProtocol(comm, nBytes, info);
+  rcclSetPipelining(comm, nBytes, info);
   if (simInfo) simInfo->estimatedTime = time;
   TRACE(NCCL_COLL, "%ld Bytes -> Algo %d proto %d time %f", nBytes, info->algorithm, info->protocol, time);
 

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -334,7 +334,7 @@ static struct tuningModel tuning_model_5 {
     /*AllGather*/
     {/*LL (min/max/factor/thread_threshold)*/ {0, 98304,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {98304, 5046272, 1, 64}},
     /*AllReduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 1048576, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {1048576, 9437184, 3145728, 0}},
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 1048576, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {1048576, 9437184, 81205728, 0}},
   },
 };
 

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -334,7 +334,7 @@ static struct tuningModel tuning_model_5 {
     /*AllGather*/
     {/*LL (min/max/factor/thread_threshold)*/ {0, 98304,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {98304, 5046272, 1, 64}},
     /*AllReduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 1048576, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {1048576, 9437184, 81205728, 0}},
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 1048576, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {1048576, 9437184, 3145728, 0}},
   },
 };
 

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -207,7 +207,7 @@ struct ncclTaskColl {
   size_t trafficBytes;
   int32_t nMaxChannels:8;
   int32_t nWarps:8;
-  int32_t algorithm:8, protocol:8;
+  int32_t algorithm:8, protocol:8, pipeline:1;
   uint32_t isCollnet:1, isNvls:1;
   uint32_t devFuncId:30;
   int regBufType;

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -207,7 +207,7 @@ struct ncclTaskColl {
   size_t trafficBytes;
   int32_t nMaxChannels:8;
   int32_t nWarps:8;
-  int32_t algorithm:8, protocol:8, pipeline:2;
+  int32_t algorithm:8, protocol:8, pipeline:8;
   uint32_t isCollnet:1, isNvls:1;
   uint32_t devFuncId:30;
   int regBufType;

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -207,7 +207,7 @@ struct ncclTaskColl {
   size_t trafficBytes;
   int32_t nMaxChannels:8;
   int32_t nWarps:8;
-  int32_t algorithm:8, protocol:8, pipeline:1;
+  int32_t algorithm:8, protocol:8, pipeline:2;
   uint32_t isCollnet:1, isNvls:1;
   uint32_t devFuncId:30;
   int regBufType;

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -726,7 +726,7 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, 
     row = it->second;
   }
   if(row < 0) {
-    WARN("Fatal error: ncclDevFuncId: %llu not found for coll: %d, algo: %d, proto: %d, devRedOp: %d, type: %d", key, coll, algo, proto, devRedOp, type);
+    WARN("Fatal error: ncclDevFuncId: %lu not found for coll: %d, algo: %d, proto: %d, devRedOp: %d, type: %d", key, coll, algo, proto, devRedOp, type);
     return -1;
   }
   return row;

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -20,6 +20,9 @@
 #include <algorithm>
 #include <stdint.h>
 #include <sys/types.h>
+#include <unordered_map>
+#include <string>
+#include "debug.h"
 
 extern const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+2];
 
@@ -124,6 +127,9 @@ static_assert(NCCL_LL_CLEAN_MASK % NCCL_STEPS == 0, "Invalid NCCL_LL_CLEAN_MASK 
 #define NCCL_IPC_REG_BUFFER 0x01
 #define NCCL_NVLS_REG_BUFFER 0x02
 #define NCCL_NET_REG_BUFFER 0x04
+
+#define RCCL_FUNC_ID_MASK 0xF
+#define RCCL_FUNC_ID_SHIFT 4
 
 struct ncclConnInfo {
   // Regular comm mechanism
@@ -687,74 +693,42 @@ inline bool ncclNvlsSupported(int devRedOp, int type) {
   }
 }
 
-// Map the rowIdx to funcIdx
-extern int const ncclDevFuncRowToId[];
+// Map the uint64_t key to funcIdx
+extern std::unordered_map<uint64_t, int> ncclDevFuncNameToId;
 
 // `ncclDevFuncId()` needs to be in sync with 'all_colls' in generate.py
 inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto) {
-  int row = 0;
-  do {
-    // RING/PAT | <all_protos> | Sum | int8_t
-    int nAlgos = 2;
-    if (coll == ncclFuncAllGather) {
-      int algo1 = algo == NCCL_ALGO_RING ? 0 :
-                /*algo == NCCL_ALGO_PAT*/ 1;
-      row += algo1 * NCCL_NUM_PROTOCOLS + proto;
-      break;
-    }
-    row += nAlgos * NCCL_NUM_PROTOCOLS;
-
-    // RING/TREE | <all_protos> | <all_redops> | <all_types>
-    nAlgos = 2;
-    if (coll == ncclFuncAllReduce) {
-      int algo1 = algo == NCCL_ALGO_TREE ? 0 :
-                /*algo == NCCL_ALGO_RING*/ 1;
-      row += (((algo1 * NCCL_NUM_PROTOCOLS + proto) * ncclNumDevRedOps + devRedOp) * ncclNumTypes + type) - NCCL_NUM_FLOATS * (algo1 * NCCL_NUM_PROTOCOLS + proto);
-      break;
-    }
-    row += nAlgos * NCCL_NUM_PROTOCOLS * (ncclNumDevRedOps * ncclNumTypes - NCCL_NUM_FLOATS);
-
-    // RING | SIMPLE | Sum | int8_t
-    nAlgos = 1;
-    if (coll == ncclFuncAllToAllPivot) break;
-    row += nAlgos * 1;
-
-    // RING | <all_protos> | Sum | int8_t
-    nAlgos = 1;
-    if (coll == ncclFuncBroadcast) {
-      row += proto;
-      break;
-    }
-    row += nAlgos * NCCL_NUM_PROTOCOLS;
-
-    // RING | <all_protos> | <all_redops> | <all_types>
-    nAlgos = 1;
-    if (coll == ncclFuncReduce) {
-      row += ((proto * ncclNumDevRedOps + devRedOp) * ncclNumTypes + type) - NCCL_NUM_FLOATS * proto; 
-      break;
-    }
-    row += nAlgos * NCCL_NUM_PROTOCOLS * (ncclNumDevRedOps * ncclNumTypes - NCCL_NUM_FLOATS);
-
-    // RING/PAT | <all_protos> | <all_redops> | <all_types>
-    nAlgos = 2;
-    if (coll == ncclFuncReduceScatter) {
-      int algo1 = algo == NCCL_ALGO_RING ? 0 :
-                /*algo == NCCL_ALGO_PAT*/ 1;
-      row += (((algo1 * NCCL_NUM_PROTOCOLS + proto) * ncclNumDevRedOps + devRedOp) * ncclNumTypes + type) - NCCL_NUM_FLOATS * (algo1 * NCCL_NUM_PROTOCOLS + proto);
-      break;
-    }
-    row += NCCL_NUM_PROTOCOLS * (ncclNumDevRedOps * ncclNumTypes - NCCL_NUM_FLOATS);
-
-    // RING | SIMPLE | Sum | int8_t
-    nAlgos = 1;
-    if (coll == ncclFuncSendRecv) break;
-    row += nAlgos * 1;
-
-  } while (false);
-
-  return ncclDevFuncRowToId[row];
+  int row = -1;
+  uint64_t key;
+  // Pack 4-bit fields from right (LSB) to left in order:
+  // coll, algo, proto, devRedOp, type
+  // This logic must be in sync with the key generation logic in generate.py
+  if (coll == ncclFuncBroadcast) {
+    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK)) |
+          ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*2));
+  } else if (coll == ncclFuncSendRecv || coll == ncclFuncAllToAllPivot) {
+    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK));
+  } else {
+    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK)) |
+          ((uint64_t)(algo     & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT))   |
+          ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*2)) |
+          ((uint64_t)(devRedOp & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*3)) |
+          ((uint64_t)(type     & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*4));
+  }
+  auto it = ncclDevFuncNameToId.find(key);
+  if (it != ncclDevFuncNameToId.end()) {
+    row = it->second;
+  }
+  if(row < 0) {
+    WARN("Fatal error: ncclDevFuncId: %llu not found", key);
+    return -1;
+  }
+  return row;
 }
 
-inline int ncclDevFuncId_P2p() { return ncclDevFuncRowToId[FUNC_INDEX_TOTAL - AR_WITH_BIAS_FUNC_COUNTS - NCCL_NUM_ONERANK - 1]; }
+inline int ncclDevFuncId_P2p() {
+  static int ncclDevFuncIdP2p = ncclDevFuncId(ncclFuncSendRecv, -1 , -1 , NCCL_ALGO_UNDEF, NCCL_PROTO_UNDEF);
+  return ncclDevFuncIdP2p;
+}
 
 #endif

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -135,12 +135,6 @@ static_assert(NCCL_LL_CLEAN_MASK % NCCL_STEPS == 0, "Invalid NCCL_LL_CLEAN_MASK 
 #define RCCL_REDOP_SHIFT 12
 #define RCCL_DTYPE_SHIFT 16
 
-    // key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK)) |
-    //       ((uint64_t)(algo     & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT))   |
-    //       ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*2)) |
-    //       ((uint64_t)(devRedOp & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*3)) |
-    //       ((uint64_t)(type     & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*4));
-
 struct ncclConnInfo {
   // Regular comm mechanism
   char *buffs[NCCL_NUM_PROTOCOLS]; // Local for recv, remote for send

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -129,7 +129,17 @@ static_assert(NCCL_LL_CLEAN_MASK % NCCL_STEPS == 0, "Invalid NCCL_LL_CLEAN_MASK 
 #define NCCL_NET_REG_BUFFER 0x04
 
 #define RCCL_FUNC_ID_MASK 0xF
-#define RCCL_FUNC_ID_SHIFT 4
+#define RCCL_COLL_SHIFT 0
+#define RCCL_ALGO_SHIFT 4
+#define RCCL_PROTO_SHIFT 8
+#define RCCL_REDOP_SHIFT 12
+#define RCCL_DTYPE_SHIFT 16
+
+    // key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK)) |
+    //       ((uint64_t)(algo     & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT))   |
+    //       ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*2)) |
+    //       ((uint64_t)(devRedOp & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*3)) |
+    //       ((uint64_t)(type     & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*4));
 
 struct ncclConnInfo {
   // Regular comm mechanism
@@ -704,16 +714,16 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto) 
   // coll, algo, proto, devRedOp, type
   // This logic must be in sync with the key generation logic in generate.py
   if (coll == ncclFuncBroadcast) {
-    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK)) |
-          ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*2));
+    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT ) |
+          ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << RCCL_PROTO_SHIFT);
   } else if (coll == ncclFuncSendRecv || coll == ncclFuncAllToAllPivot) {
-    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK));
+    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT );
   } else {
-    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK)) |
-          ((uint64_t)(algo     & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT))   |
-          ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*2)) |
-          ((uint64_t)(devRedOp & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*3)) |
-          ((uint64_t)(type     & RCCL_FUNC_ID_MASK) << (RCCL_FUNC_ID_SHIFT*4));
+    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT ) |
+          ((uint64_t)(algo     & RCCL_FUNC_ID_MASK) << RCCL_ALGO_SHIFT ) |
+          ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << RCCL_PROTO_SHIFT) |
+          ((uint64_t)(devRedOp & RCCL_FUNC_ID_MASK) << RCCL_REDOP_SHIFT) |
+          ((uint64_t)(type     & RCCL_FUNC_ID_MASK) << RCCL_DTYPE_SHIFT);
   }
   auto it = ncclDevFuncNameToId.find(key);
   if (it != ncclDevFuncNameToId.end()) {

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -30,7 +30,7 @@ extern const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS];
 
 extern const char* ncclProtoStr[NCCL_NUM_PROTOCOLS];
 
-extern const char* funcNames[FUNC_INDEX_TOTAL];
+extern const char* funcNames[];
 
 #define NCCL_MAX_OPS 2048
 #define NCCL_STEPS 8

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -730,7 +730,7 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto) 
     row = it->second;
   }
   if(row < 0) {
-    WARN("Fatal error: ncclDevFuncId: %llu not found", key);
+    WARN("Fatal error: ncclDevFuncId: %llu not found for coll: %d, algo: %d, proto: %d, devRedOp: %d, type: %d", key, coll, algo, proto, devRedOp, type);
     return -1;
   }
   return row;

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -701,7 +701,7 @@ inline bool ncclNvlsSupported(int devRedOp, int type) {
 extern std::unordered_map<uint64_t, int> ncclDevFuncNameToId;
 
 // `ncclDevFuncId()` needs to be in sync with 'all_colls' in generate.py
-inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto) {
+inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, int pipeline = 0) {
   int row = -1;
   uint64_t key;
   // Pack 4-bit fields from right (LSB) to left in order:

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -134,6 +134,7 @@ static_assert(NCCL_LL_CLEAN_MASK % NCCL_STEPS == 0, "Invalid NCCL_LL_CLEAN_MASK 
 #define RCCL_PROTO_SHIFT 8
 #define RCCL_REDOP_SHIFT 12
 #define RCCL_DTYPE_SHIFT 16
+#define RCCL_PIPELINE_SHIFT 20
 
 struct ncclConnInfo {
   // Regular comm mechanism
@@ -717,7 +718,8 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, 
           ((uint64_t)(algo     & RCCL_FUNC_ID_MASK) << RCCL_ALGO_SHIFT ) |
           ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << RCCL_PROTO_SHIFT) |
           ((uint64_t)(devRedOp & RCCL_FUNC_ID_MASK) << RCCL_REDOP_SHIFT) |
-          ((uint64_t)(type     & RCCL_FUNC_ID_MASK) << RCCL_DTYPE_SHIFT);
+          ((uint64_t)(type     & RCCL_FUNC_ID_MASK) << RCCL_DTYPE_SHIFT) |
+          ((uint64_t)(pipeline & RCCL_FUNC_ID_MASK) << RCCL_PIPELINE_SHIFT);
   }
   auto it = ncclDevFuncNameToId.find(key);
   if (it != ncclDevFuncNameToId.end()) {

--- a/src/include/nccl_common.h
+++ b/src/include/nccl_common.h
@@ -39,10 +39,13 @@ typedef enum {
 
 typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char *file, int line, const char *fmt, ...);
 
+<<<<<<< HEAD
 #define NCCL_NUM_ONERANK 12
 #define AR_WITH_BIAS_FUNC_COUNTS 324
 #define FUNC_INDEX_TOTAL 821 + AR_WITH_BIAS_FUNC_COUNTS + NCCL_NUM_ONERANK
 
+=======
+>>>>>>> cb40ec4f (Remove need for FUNC_INDEX_TOTAL)
 #define NCCL_NUM_FUNCTIONS 5 // Send/Recv not included for now
 typedef enum {
   ncclFuncBroadcast = 0,

--- a/src/include/nccl_common.h
+++ b/src/include/nccl_common.h
@@ -39,13 +39,6 @@ typedef enum {
 
 typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char *file, int line, const char *fmt, ...);
 
-<<<<<<< HEAD
-#define NCCL_NUM_ONERANK 12
-#define AR_WITH_BIAS_FUNC_COUNTS 324
-#define FUNC_INDEX_TOTAL 821 + AR_WITH_BIAS_FUNC_COUNTS + NCCL_NUM_ONERANK
-
-=======
->>>>>>> cb40ec4f (Remove need for FUNC_INDEX_TOTAL)
 #define NCCL_NUM_FUNCTIONS 5 // Send/Recv not included for now
 typedef enum {
   ncclFuncBroadcast = 0,

--- a/src/include/rccl_common.h
+++ b/src/include/rccl_common.h
@@ -83,6 +83,7 @@ inline size_t rcclGetSizePerRank(ncclFunc_t const& func, size_t const& nBytes, i
 }
 void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info);
 void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info, int& threadThreshold);
+void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info);
 ncclResult_t rcclGetAlgoInfo(struct ncclComm* comm, ncclFunc_t coll, uint64_t count, ncclDataType_t dataType,
                              int collNetSupport, int nvlsSupport, int numPipeOps,
                              int* algo, int* protocol, int* maxChannels);

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -25,6 +25,10 @@ THE SOFTWARE.
 #include "graph/topo.h"
 #include "enqueue.h"
 
+// This is used to experiment pipelining new data types
+// Make sure you generate the device code with the new data type (i.e. in generate.py)
+RCCL_PARAM(PipelineAllDTypes, "PIPELINE_ALL_DATA_TYPES", 0);
+
 void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info) {
   // Honor user input for protocol choice
   static int userProtocolInput = -2;
@@ -102,11 +106,27 @@ void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, stru
 
 void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info) {
   info->pipeline = 0; // Default to no pipelining
-  if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942")) {
-    if(info->datatype == ncclBfloat16) {
-     if (comm->nNodes == 1 || (comm->nNodes > 1 &&  nBytes <= (512 * 1024 * 1024) * (1 << (log2i(comm->nNodes) - 1)))) {
+
+  if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") && (info->datatype == ncclBfloat16 || rcclParamPipelineAllDTypes())) {
+    switch (info->func) {
+      // For multi-node case, we check if the number of bytes (`nBytes`) satisfies
+      // the Bf16 Limit Equation for bf16 all_reduce on MI300:
+      // 512MB × 2^(log2[nNodes] - 1), nNodes > 1
+      // The above equation is derived from the tuning results of the bf16 all_reduce on MI300.
+      case ncclFuncAllReduce:
+        if (comm->nNodes == 1 ||
+            (comm->nNodes > 1 && nBytes <= (512 * 1024 * 1024) * (1 << (log2i(comm->nNodes) - 1)))) {
+          info->pipeline = 1;
+        }
+        break;
+
+      case ncclFuncReduceScatter:
+      case ncclFuncReduce:
         info->pipeline = 1;
-      }
+        break;
+
+      default:
+        break;
     }
   }
 }

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -114,9 +114,10 @@ void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclT
       // 512MB × 2^(log2[nNodes] - 1), nNodes > 1
       // The above equation is derived from the tuning results of the bf16 all_reduce on MI300.
       case ncclFuncAllReduce:
-        if (comm->nNodes == 1 ||
-            (comm->nNodes > 1 && nBytes <= (512 * 1024 * 1024) * (1 << (log2i(comm->nNodes) - 1)))) {
-          info->pipeline = 1;
+        if ( comm->nNodes == 1 ||
+           ((comm->nNodes  > 1) &&
+             nBytes <= (1ULL << 29 /*512MB*/)  * (1ULL << (log2i(comm->nNodes) - 1)))) {
+            info->pipeline = 1;
         }
         break;
 

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -107,7 +107,25 @@ void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, stru
 void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info) {
   info->pipeline = 0; // Default to no pipelining
 
-  if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") && (info->datatype == ncclBfloat16 || rcclParamPipelineAllDTypes())) {
+  const bool dtypeOK = (info->datatype == ncclBfloat16) || rcclParamPipelineAllDTypes();
+
+  if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && dtypeOK) {
+    if (comm->nNodes > 1) {
+      switch (info->func) {
+        case ncclFuncAllReduce:
+        case ncclFuncReduceScatter:
+        case ncclFuncReduce:
+          // Enable for multi-node
+          info->pipeline = 1;
+          break;
+        default:
+          break;
+      }
+    }
+    return;
+  }
+
+  if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") && dtypeOK) {
     switch (info->func) {
       // For multi-node case, we check if the number of bytes (`nBytes`) satisfies
       // the Bf16 Limit Equation for bf16 all_reduce on MI300:
@@ -115,9 +133,9 @@ void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclT
       // The above equation is derived from the tuning results of the bf16 all_reduce on MI300.
       case ncclFuncAllReduce:
         if ( comm->nNodes == 1 ||
-           ((comm->nNodes  > 1) &&
-             nBytes <= (1ULL << 29 /*512MB*/)  * (1ULL << (log2i(comm->nNodes) - 1)))) {
-            info->pipeline = 1;
+             ((comm->nNodes > 1) &&
+               nBytes <= (1ULL << 29 /*512MB*/) * (1ULL << (log2i(comm->nNodes) - 1))) ) {
+          info->pipeline = 1;
         }
         break;
 

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -100,6 +100,17 @@ void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, stru
   }
 }
 
+void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info) {
+  info->pipeline = 0; // Default to no pipelining
+  if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942")) {
+    if(info->datatype == ncclBfloat16) {
+     if (comm->nNodes == 1 || (comm->nNodes > 1 &&  nBytes <= (512 * 1024 * 1024) * (1 << (log2i(comm->nNodes) - 1)))) {
+        info->pipeline = 1;
+      }
+    }
+  }
+}
+
 extern ncclResult_t getAlgoInfo(
     struct ncclComm* comm, struct ncclTaskColl* task,
     int collNetSupport, int nvlsSupport, int numPipeOps, ncclSimInfo_t* simInfo = NULL

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -25,9 +25,13 @@ THE SOFTWARE.
 #include "graph/topo.h"
 #include "enqueue.h"
 
-// This is used to experiment pipelining new data types
+// Use this param to experiment pipelining new data types besides bfloat16
 // Make sure you generate the device code with the new data type (i.e. in generate.py)
 RCCL_PARAM(PipelineAllDTypes, "PIPELINE_ALL_DATA_TYPES", 0);
+
+// Use this to assess impact of pipelining on performance.
+// Otherwise, it is automatically set for certain archs, datatypes and reduction collectives
+RCCL_PARAM(disableReduceCopyPipelining, "DISABLE_REDUCE_COPY_PIPELINING", 0);
 
 void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info) {
   // Honor user input for protocol choice
@@ -106,7 +110,9 @@ void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, stru
 
 void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info) {
   info->pipeline = 0; // Default to no pipelining
-
+  if (rcclParamdisableReduceCopyPipelining()) {
+    return;
+  }
   const bool dtypeOK = (info->datatype == ncclBfloat16) || rcclParamPipelineAllDTypes();
 
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && dtypeOK) {


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  

- Added a Pipeline dimension across build/codegen/runtime, 
- Propagated it through templates and primitives, 
- Introduced a runtime pipelining heuristic (size/arch/datatype–gated), 
- Extended the device-function ID to encode pipeline, and updated the unroll injection script (`unroll.sh`) to pass the new template arg.

**Why were the changes made?**  
- To enable software-triggered pipelining variants of collectives that can improve overlap/throughput for specific message sizes and to select those variants at runtime with clear, size- and arch-aware gating with `rcclSetPipelining` function
- This also enables optimization opportunities on future hardware and data types

**How was the outcome achieved?**  
- device.h: ncclDevFuncId(...) now includes a pipeline parameter; device function IDs are resolved via a packed 64-bit key (coll|algo|proto|redop|type|pipeline) and an unordered_map generated by generate.py.
- comm.h: added a pipeline:8 bitfield to ncclTaskColl 
- enqueue.cc: passes agg.pipeline to ncclDevFuncId(...) and propagates pipeline to grouped tasks.
- rccl_common.h / rccl_wrap.cc: added rcclSetPipelining(...); enables pipelining under a public, deterministic heuristic:
- For gfx942 (opt-in to “all dtypes” via setting `RCCL_PIPELINE_ALL_DATA_TYPES`), and modifying `generate.py` to pipeline datatypes of interest. 
- For gfx942, bfloat16 pipelining for AllReduce is enabled if single-node, or if multi-node and nBytes ≤ 512 MiB × 2^(log2(nNodes)−1).
- To Opt-out of this feature, set `RCCL_DISABLE_REDUCE_COPY_PIPELINING`.
- ReduceScatter and Reduce unconditionally under gfx942.
- Introduced a Pipeline template parameter across RunWorkBatch, RunWorkColl, Primitives, and the reduceCopy* chain.
- common_kernel.h: reduceCopyPacks is now a templated struct specialized on Pipeline==0/1. 
- Collective call sites (all_reduce.h, reduce.h, reduce_scatter.h) instantiate Primitives<..., Pipeline, ...> as needed; LL/LL128 code paths are explicitly forced to Pipeline=0 by script rules and codegen equivalence.
- generate.py: added all_pipeline = ["0","1"], per-collective pipelines_of_coll, and mapping that collapses pipeline for LL/LL128. 
- unsized funcNames[] (no static total needed). Drop the need for emitting or manually adding `FUNC_TOTAL_INDEX`
-  `add_unroll.sh`: now injects Pipeline everywhere we add USE_ACC/COLL_UNROLL, forces Pipeline=0 for LL/LL128, and passes Pipeline in SIMPLE/Proto paths; file mode restored to 0755 so it’s executable.

**Additional Documentation:**  
#### Testing tips
- On gfx942, check bf16 AllReduce pipelines only up to the limit (just below/above 512 MiB × 2^(log2(nNodes)−1)), single-node vs multi-node. (no regression at larger messages should be observed compared to baseline develop branch which regresses for larger messages when bf16 pipelining is enabled)

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
