### PR TITLE
Test: delete child object to address memory leak.

### DIFF
--- a/test/common/TestBed.cpp
+++ b/test/common/TestBed.cpp
@@ -537,6 +537,7 @@ namespace RcclUnitTesting
       {
         ERROR("Child process %d exited with code %d\n", childId, returnVal);
       }
+      delete(childList[childId]);
     }
 
     childList.clear();


### PR DESCRIPTION
## Details


**Work item:** SWDEV-546648

**What were the changes?**  
Properly free an object via `delete` the object allocated with `new` in RCCL unit test.

**Why were the changes made?**  
Memory leak.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
