### PR TITLE
fix lintian warning package-contains-timestamped-gzip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1362,7 +1362,7 @@ License: See LICENSE.txt for license information\n")
 
  -- RCCL Maintainer <rccl-maintainer@amd.com>  ${TIMESTAMP}\n")
   find_program( gzip_executable gzip )
-  execute_process(COMMAND bash "-c" "${gzip_executable} -9 -c ${CMAKE_BINARY_DIR}/changelog"
+  execute_process(COMMAND bash "-c -n" "${gzip_executable} -9 -c ${CMAKE_BINARY_DIR}/changelog"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR} OUTPUT_FILE "${CMAKE_BINARY_DIR}/changelog.Debian.gz")
   rocm_install(FILES "${CMAKE_BINARY_DIR}/changelog.Debian.gz" DESTINATION ${CMAKE_INSTALL_DATADIR}/rccl)
   set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "ROCm Communication Collectives Library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1362,7 +1362,7 @@ License: See LICENSE.txt for license information\n")
 
  -- RCCL Maintainer <rccl-maintainer@amd.com>  ${TIMESTAMP}\n")
   find_program( gzip_executable gzip )
-  execute_process(COMMAND bash "-c -n" "${gzip_executable} -9 -c ${CMAKE_BINARY_DIR}/changelog"
+  execute_process(COMMAND bash "-c" "${gzip_executable} -9 -c -n ${CMAKE_BINARY_DIR}/changelog"
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR} OUTPUT_FILE "${CMAKE_BINARY_DIR}/changelog.Debian.gz")
   rocm_install(FILES "${CMAKE_BINARY_DIR}/changelog.Debian.gz" DESTINATION ${CMAKE_INSTALL_DATADIR}/rccl)
   set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "ROCm Communication Collectives Library


### PR DESCRIPTION
## Details
Fixed lintian warning package-contains-timestamped-gzip. The package contains a gzip-compressed file that has timestamps. Such files make the packages unreproducible, because their contents depend on the time when the package was built.

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
"-n" flag to gzip to avoid this issue

**Why were the changes made?**  
fix lintian warning package-contains-timestamped-gzip

**How was the outcome achieved?**  
-n flag recompile then check if lintian error is present 

**Additional Documentation:**  
https://lintian.debian.org/tags/package-contains-timestamped-gzip.html

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
