### PR TITLE
Removing "Could not find any local path from gpu X to net." warning

### DIFF
--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -1545,10 +1545,12 @@ ncclResult_t ncclTopoGetLocalNet(struct ncclTopoSystem* system, int rank, int ch
   int localNets[NCCL_TOPO_MAX_NODES];
   int localNetCount;
   NCCLCHECK(ncclTopoGetLocal(system, GPU, gpu, NET, localNets, &localNetCount, NULL));
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   if (localNetCount==0) {
     WARN("Could not find any local path from gpu %d to net.", gpu);
     return ncclInternalError;
   }
+#endif
 
   int localGpus[NCCL_TOPO_MAX_NODES];
   int localGpuCount;

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -1545,12 +1545,12 @@ ncclResult_t ncclTopoGetLocalNet(struct ncclTopoSystem* system, int rank, int ch
   int localNets[NCCL_TOPO_MAX_NODES];
   int localNetCount;
   NCCLCHECK(ncclTopoGetLocal(system, GPU, gpu, NET, localNets, &localNetCount, NULL));
-#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   if (localNetCount==0) {
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
     WARN("Could not find any local path from gpu %d to net.", gpu);
+#endif
     return ncclInternalError;
   }
-#endif
 
   int localGpus[NCCL_TOPO_MAX_NODES];
   int localGpuCount;


### PR DESCRIPTION


## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** SWDEV-546101

**What were the changes?**  
Removing the warning introduced by NCCL 2.26 that caused confusion to the users.

**Why were the changes made?**  
This warning caused so many false positive when debugging issues.

**How was the outcome achieved?**  
ifdefs


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
