### PR TITLE
[BUILD] Populate host_table entries only for 1 unroll

### DIFF
--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -267,6 +267,7 @@ def equivalent_primary(coll, algo, proto, redop, ty, acc, unroll):
   return (coll, algo, proto, redop, ty, acc, unroll)
 
 # Order rows are enumerated must match formula of `ncclDevFuncId()`:
+# outermost loop should be for unroll factor; refer to host_table section
 def enumerate_func_rows():
   for unroll in all_unroll:
     for acc in use_acc:
@@ -474,6 +475,10 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
   out("//   bits 16-19:  ty index\n")
   out("#include <unordered_map>\n")
   out("extern std::unordered_map<uint64_t, int> ncclDevFuncNameToId = {\n")
+
+  # host_table entries map device functions based on collective, algorithm, protocol, redop, and datatype
+  # For GPU targets that support multiple unrolls, e.g., gfx950
+  # (or) for non-local builds, only a single set of functions are needed in the host_table.
   for fn in func_rows[:len(func_rows)//len(all_unroll)]:
     fn_id = -1
     if fn is not None:

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -474,7 +474,7 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
   out("//   bits 16-19:  ty index\n")
   out("#include <unordered_map>\n")
   out("extern std::unordered_map<uint64_t, int> ncclDevFuncNameToId = {\n")
-  for fn in func_rows:
+  for fn in func_rows[:len(func_rows)//len(all_unroll)]:
     fn_id = -1
     if fn is not None:
       fn_id = primary_to_index[equivalent_primary(*fn)]


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Modify generator.py for host_table entries to be agnostic of the no. of supported unroll factors.

**Why were the changes made?**  
host_table entries are a mapping of device functions based on collective, algorithm, protocol, redop, and datatype.
For GPU targets that support multiple unrolls, e.g., `gfx950` (or) for non-local builds, the current implementation will have duplicate entries in host_table.cpp.

**How was the outcome achieved?**  
Bring back the sweep, which is limited to the first set of valid functions, ordered by unroll.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
