### PR TITLE
Code coverage tests for param.cc

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -140,6 +140,7 @@ if(BUILD_TESTS)
     set(TEST_FIXTURE_SOURCE_FILES
       AltRsmiTests.cpp
       AllocTests.cpp
+      ParamTests.cpp
       ArgCheckTests.cpp
       IpcsocketTests.cpp
       CollRegTests.cpp

--- a/test/ParamTests.cpp
+++ b/test/ParamTests.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+#include <rccl/rccl.h>
+
+#include "param.h"
+
+namespace RcclUnitTesting
+{
+    TEST(ParamTests, initEnv_ParseValidConfFile){
+        // This function call reads and opens the conf file from the path
+        // which is set using env. variable NCCL_CONF_FILE
+        initEnv();
+
+        EXPECT_EQ(getenv("TEST_VAR_WITH_NO_VALUE"), nullptr);
+        EXPECT_STREQ(getenv("TEST_VAR"), "12345"); 
+        
+        // Clean up
+        unsetenv("TEST_VAR_WITH_NO_VALUE");
+        unsetenv("TEST_VAR");
+    }
+
+    TEST(ParamTests, ncclLoadParam_InvalidParam){
+        int64_t cache = -1;               
+        const int64_t defaultVal = 12345; // Dummy input value
+
+        // Force overflow: value exceeds int64_t max (9223372036854775807)
+        setenv("TEST_INVALID_PARAM", "99999999999999999999", 1); // Dummy variable and value 
+        ncclLoadParam("TEST_INVALID_PARAM", defaultVal, -1, &cache);
+        unsetenv("TEST_INVALID_PARAM");
+
+        EXPECT_EQ(cache, defaultVal);       // Cache should be set to default value
+    }
+}

--- a/test/ParamTests.cpp
+++ b/test/ParamTests.cpp
@@ -1,51 +1,41 @@
+#include "param.h"
 #include <gtest/gtest.h>
 #include <rccl/rccl.h>
-#include "param.h"
-#include "debug.h"
 
-namespace RcclUnitTesting
-{
-    TEST(ParamTests, initEnv_ParseValidConfFile){
-        // Skip the test if NCCL_CONF_FILE is not set
-        const char *value = getenv("NCCL_CONF_FILE");
+namespace RcclUnitTesting {
+TEST(ParamTests, initEnv_ParseValidConfFile) {
+  // Skip the test if NCCL_CONF_FILE is not set
+  const char *value = getenv("NCCL_CONF_FILE");
 
-        if (!value) {
-            INFO(NCCL_LOG_INFO, "SKIPPING TEST. Set environment variable NCCL_CONF_FILE.\n"
-                                "To run this test, create a file with the following contents and set its "
-                                "absolute path to NCCL_CONF_FILE:\n\n"
-                                "# Comment: This file is required to run unit tests for param.cc\n"
-                                "TEST_VAR_WITH_NO_VALUE\n"
-                                "TEST_VAR=12345\n");
+  if (!value) {
+    GTEST_SKIP() << "SKIPPING TEST. Set environment variable NCCL_CONF_FILE.\n"
+                 << "A sample config file has been provided at: "
+                    "rccl/test/ParamTestsConfFile.txt\n"
+                 << "Set NCCL_CONF_FILE to the absolute path of this file to "
+                    "run the test.\n";
+  }
+  // This function call reads and opens the conf file from the path
+  // which is set using env. variable NCCL_CONF_FILE
+  initEnv();
 
-            GTEST_SKIP()    << "SKIPPING TEST. Set environment variable NCCL_CONF_FILE.\n"
-                            << "To run this test, create a file with the following contents and set its "
-                                "absolute path to NCCL_CONF_FILE:\n\n"
-                            << "# Comment: This file is required to run unit tests for param.cc\n"
-                            << "TEST_VAR_WITH_NO_VALUE\n"
-                            << "TEST_VAR=12345\n";
-        }
-        
-        // This function call reads and opens the conf file from the path
-        // which is set using env. variable NCCL_CONF_FILE
-        initEnv();
+  EXPECT_EQ(getenv("TEST_VAR_WITH_NO_VALUE"), nullptr);
+  EXPECT_STREQ(getenv("TEST_VAR"), "12345");
 
-        EXPECT_EQ(getenv("TEST_VAR_WITH_NO_VALUE"), nullptr);
-        EXPECT_STREQ(getenv("TEST_VAR"), "12345"); 
-        
-        // Clean up
-        unsetenv("TEST_VAR_WITH_NO_VALUE");
-        unsetenv("TEST_VAR");
-    }
-
-    TEST(ParamTests, ncclLoadParam_InvalidParam){
-        int64_t cache = -1;               
-        const int64_t defaultVal = 12345; // Dummy input value
-
-        // Force overflow: value exceeds int64_t max (9223372036854775807)
-        setenv("TEST_INVALID_PARAM", "99999999999999999999", 1); // Dummy variable and value 
-        ncclLoadParam("TEST_INVALID_PARAM", defaultVal, -1, &cache);
-        unsetenv("TEST_INVALID_PARAM");
-
-        EXPECT_EQ(cache, defaultVal);       // Cache should be set to default value
-    }
+  // Clean up
+  unsetenv("TEST_VAR_WITH_NO_VALUE");
+  unsetenv("TEST_VAR");
 }
+
+TEST(ParamTests, ncclLoadParam_InvalidParam) {
+  int64_t cache = -1;
+  const int64_t defaultVal = 12345; // Dummy input value
+
+  // Force overflow: value exceeds int64_t max (9223372036854775807)
+  setenv("TEST_INVALID_PARAM", "99999999999999999999",
+         1); // Dummy variable and value
+  ncclLoadParam("TEST_INVALID_PARAM", defaultVal, -1, &cache);
+  unsetenv("TEST_INVALID_PARAM");
+
+  EXPECT_EQ(cache, defaultVal); // Cache should be set to default value
+}
+} // namespace RcclUnitTesting

--- a/test/ParamTests.cpp
+++ b/test/ParamTests.cpp
@@ -24,18 +24,17 @@ namespace RcclUnitTesting
                             << "TEST_VAR_WITH_NO_VALUE\n"
                             << "TEST_VAR=12345\n";
         }
-        else{
-            // This function call reads and opens the conf file from the path
-            // which is set using env. variable NCCL_CONF_FILE
-            initEnv();
+        
+        // This function call reads and opens the conf file from the path
+        // which is set using env. variable NCCL_CONF_FILE
+        initEnv();
 
-            EXPECT_EQ(getenv("TEST_VAR_WITH_NO_VALUE"), nullptr);
-            EXPECT_STREQ(getenv("TEST_VAR"), "12345"); 
-            
-            // Clean up
-            unsetenv("TEST_VAR_WITH_NO_VALUE");
-            unsetenv("TEST_VAR");
-        }
+        EXPECT_EQ(getenv("TEST_VAR_WITH_NO_VALUE"), nullptr);
+        EXPECT_STREQ(getenv("TEST_VAR"), "12345"); 
+        
+        // Clean up
+        unsetenv("TEST_VAR_WITH_NO_VALUE");
+        unsetenv("TEST_VAR");
     }
 
     TEST(ParamTests, ncclLoadParam_InvalidParam){

--- a/test/ParamTests.cpp
+++ b/test/ParamTests.cpp
@@ -1,21 +1,41 @@
 #include <gtest/gtest.h>
 #include <rccl/rccl.h>
-
 #include "param.h"
+#include "debug.h"
 
 namespace RcclUnitTesting
 {
     TEST(ParamTests, initEnv_ParseValidConfFile){
-        // This function call reads and opens the conf file from the path
-        // which is set using env. variable NCCL_CONF_FILE
-        initEnv();
+        // Skip the test if NCCL_CONF_FILE is not set
+        const char *value = getenv("NCCL_CONF_FILE");
 
-        EXPECT_EQ(getenv("TEST_VAR_WITH_NO_VALUE"), nullptr);
-        EXPECT_STREQ(getenv("TEST_VAR"), "12345"); 
-        
-        // Clean up
-        unsetenv("TEST_VAR_WITH_NO_VALUE");
-        unsetenv("TEST_VAR");
+        if (!value) {
+            INFO(NCCL_LOG_INFO, "SKIPPING TEST. Set environment variable NCCL_CONF_FILE.\n"
+                                "To run this test, create a file with the following contents and set its "
+                                "absolute path to NCCL_CONF_FILE:\n\n"
+                                "# Comment: This file is required to run unit tests for param.cc\n"
+                                "TEST_VAR_WITH_NO_VALUE\n"
+                                "TEST_VAR=12345\n");
+
+            GTEST_SKIP()    << "SKIPPING TEST. Set environment variable NCCL_CONF_FILE.\n"
+                            << "To run this test, create a file with the following contents and set its "
+                                "absolute path to NCCL_CONF_FILE:\n\n"
+                            << "# Comment: This file is required to run unit tests for param.cc\n"
+                            << "TEST_VAR_WITH_NO_VALUE\n"
+                            << "TEST_VAR=12345\n";
+        }
+        else{
+            // This function call reads and opens the conf file from the path
+            // which is set using env. variable NCCL_CONF_FILE
+            initEnv();
+
+            EXPECT_EQ(getenv("TEST_VAR_WITH_NO_VALUE"), nullptr);
+            EXPECT_STREQ(getenv("TEST_VAR"), "12345"); 
+            
+            // Clean up
+            unsetenv("TEST_VAR_WITH_NO_VALUE");
+            unsetenv("TEST_VAR");
+        }
     }
 
     TEST(ParamTests, ncclLoadParam_InvalidParam){

--- a/test/ParamTestsConfFile.txt
+++ b/test/ParamTestsConfFile.txt
@@ -1,0 +1,3 @@
+# Comment: This file is required to run unit tests for param.cc
+TEST_VAR_WITH_NO_VALUE
+TEST_VAR=12345

--- a/test/ParamTestsConfFile.txt
+++ b/test/ParamTestsConfFile.txt
@@ -1,0 +1,3 @@
+# Comment: This file has been created for param.cc code coverage
+TEST_VAR_WITH_NO_VALUE
+TEST_VAR=12345

--- a/test/ParamTestsConfFile.txt
+++ b/test/ParamTestsConfFile.txt
@@ -1,3 +1,0 @@
-# Comment: This file has been created for param.cc code coverage
-TEST_VAR_WITH_NO_VALUE
-TEST_VAR=12345


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** Internal

**What were the changes?**  
Added tests to cover uncovered functions and improve line coverage.

**Why were the changes made?**  
Improved line coverage.
Added 2 tests for uncovered function, the line code coverage is now 100.00% (71/71) from previous 64.79% (46/71).

**How was the outcome achieved?**  
| File           | State   | Function Coverage | Line Coverage   | Region Coverage | Branch Coverage |
|-----------------|---------|-------------------|-----------------|-----------------|-----------------|
| **param.cc** | Initial | 100.00% (6/6)    | 64.79% (46/71) | 56.36% (31/55) | 31.25% (10/32) |
|                 | Updated | 100.00% (6/6)    | 100.00% (71/71) | 98.18% (54/55) | 81.25% (26/32) |

**Additional Documentation:**  
To run these tests, set the `NCCL_CONF_FILE` environment variable to point to `ParamTestsConfFile.txt`.
Use the following command to execute the tests:
```bash 
NCCL_CONF_FILE=path/ParamTestsConfFile.txt ./rccl-UnitTestsFixtures --gtest_filter=*ParamTest*
```

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
