### PR TITLE
Changed `TestBedChild` protocol to send the result code before the return value

### DIFF
--- a/test/common/TestBed.cpp
+++ b/test/common/TestBed.cpp
@@ -142,11 +142,11 @@ namespace RcclUnitTesting
     // Tell first rank to get ncclUniqueId
     int getIdCmd = TestBedChild::CHILD_GET_UNIQUE_ID;
     PIPE_WRITE(0, getIdCmd);
+    PIPE_CHECK(0);
 
     // Receive back unique ID from first rank
     ncclUniqueId id;
     PIPE_READ(0, id);
-    PIPE_CHECK(0);
 
     // Send InitComms command to each active child process
     int const cmd = TestBedChild::CHILD_INIT_COMMS;

--- a/test/common/TestBedChild.hpp
+++ b/test/common/TestBedChild.hpp
@@ -91,7 +91,7 @@ namespace RcclUnitTesting
 
   protected:
     // Calls ncclGetUniqueId and returns it to parent
-    ErrCode GetUniqueId();
+    ErrCode GetUniqueId(std::vector<char>& retValBuf);
 
     // Initialize RCCL communicators
     ErrCode InitComms();


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**What were the changes?**  
Changed `TestBedChild` protocol to send the result code before the return value.

**Why were the changes made?**  
To avoid a hang when `ncclGetUniqueId` failed. `TestBed` was expecting a return value from `TestBedChild` but the child had already returned an error code and moved on.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
