### PR TITLE
[Tools] Use add_unroll.sh in topo_expl makefile

### DIFF
--- a/tools/topo_expl/Makefile
+++ b/tools/topo_expl/Makefile
@@ -8,7 +8,7 @@ HIPCC = $(HIP_PATH)/bin/hipcc
 .DEFAULT_GOAL := all
 
 EXE = topo_expl
-CXXFLAGS = -g -ffunction-sections -fdata-sections -Wl,--gc-sections -fgpu-rdc -Iinclude -Ihipify_rccl/include -Ihipify_rccl/include/plugin -Ihipify_rccl/device/include  -Ihipify_rccl/graph -I/opt/rocm/include/ -DTOPO_EXPL -DENABLE_TRACE -DENABLE_LL128 -DNVTX_NO_IMPL -DRCCL_EXPOSE_STATIC -lpthread
+CXXFLAGS = -g -ffunction-sections -fdata-sections -Wl,--gc-sections -fgpu-rdc -Iinclude -Ihipify_rccl/include -Ihipify_rccl/include/plugin -Ihipify_rccl/src/device/include  -Ihipify_rccl/graph -I/opt/rocm/include/ -DTOPO_EXPL -DENABLE_TRACE -DENABLE_LL128 -DNVTX_NO_IMPL -DRCCL_EXPOSE_STATIC -lpthread
 
 files = $(EXE).cpp model.cpp utils.cpp hipify_rccl/graph/topo.cc hipify_rccl/graph/rings.cc hipify_rccl/graph/paths.cc hipify_rccl/graph/trees.cc ../../src/misc/param.cc \
 	hipify_rccl/graph/search.cc hipify_rccl/graph/connect.cc hipify_rccl/graph/tuning.cc hipify_rccl/graph/xml.cc ../../src/misc/nvmlwrap_stub.cc hipify_rccl/graph/rome_models.cc hipify_rccl/graph/archinfo.cc \
@@ -48,10 +48,10 @@ $(EXE): $(files)
 
 hipify:
 	rm -rf hipify_rccl
-	mkdir -p hipify_rccl/device/include hipify_rccl/include/network/unpack
+	mkdir -p hipify_rccl/src/device/include hipify_rccl/include/network/unpack
 	cp -a ../../src/include/ hipify_rccl/
 	cp -a ../../src/graph/ hipify_rccl/
-	cp -a ../../src/device/*.h hipify_rccl/device/include
+	cp -a ../../src/device/*.h hipify_rccl/src/device/include
 	cp -a ../../src/device/network/unpack/*.h hipify_rccl/include/network/unpack
 	cp -a ../../src/enqueue.cc hipify_rccl/
 	cp -a ../../src/register/register.cc hipify_rccl/
@@ -60,9 +60,8 @@ hipify:
 	hipify-perl -inplace -quiet-warnings hipify_rccl/include/*.h
 	hipify-perl -inplace -quiet-warnings hipify_rccl/include/plugin/*.h
 	hipify-perl -inplace -quiet-warnings hipify_rccl/include/latency_profiler/*.h
-	hipify-perl -inplace -quiet-warnings hipify_rccl/device/include/*.h
-	sed -i "s/template<typename T, typename RedOp>/template<typename T, typename RedOp, int USE_ACC, int COLL_UNROLL>/g" "hipify_rccl/device/include/common.h"
-	sed -i "s/\\(struct RunWorkBatch<ncclFunc[^>]*\\)>*/\\1, USE_ACC, COLL_UNROLL>/" "hipify_rccl/device/include/common.h"
+	hipify-perl -inplace -quiet-warnings hipify_rccl/src/device/include/*.h
+	bash ../../cmake/scripts/add_unroll.sh "hipify_rccl/src/device/include/common.h"
 	hipify-perl -inplace -quiet-warnings hipify_rccl/graph/*
 	hipify-perl -inplace -quiet-warnings hipify_rccl/include/network/unpack/*
 	hipify-perl -inplace -quiet-warnings hipify_rccl/*.cc


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _Internal._

**What were the changes?**  
_Directly reference maintained `add_unroll.sh` script to be up to date with template compatibility._

**Why were the changes made?**  
_Reduce maintenance cost for topo_expl._

**How was the outcome achieved?**  
_Call script directly on imported header files and adjust path to bypass check in script._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
