### PR TITLE
disabling msccl for fp8 datatype

### DIFF
--- a/src/collectives.cc
+++ b/src/collectives.cc
@@ -124,7 +124,7 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
     NCCLCHECK(Recorder::instance().record(rrAllReduce, info));
   }
 
-  if (mscclAvailable(comm) && !mscclIsCaller()) {
+  if ((datatype != ncclFloat8e4m3 && datatype != ncclFloat8e5m2) && mscclAvailable(comm) && !mscclIsCaller()) {
     if (datatype != ncclBfloat16 || (count * ncclTypeSize(datatype) <= 8388608)) {
 	return mscclEnqueueCheck(
                 sendbuff, nullptr, nullptr, recvbuff, nullptr, nullptr,

--- a/src/collectives.cc
+++ b/src/collectives.cc
@@ -124,7 +124,7 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
     NCCLCHECK(Recorder::instance().record(rrAllReduce, info));
   }
 
-if (mscclAvailable(comm) && !mscclIsCaller()) {
+  if (mscclAvailable(comm) && !mscclIsCaller()) {
     //MSCCL not supported for FP8 datatype
     if (datatype != ncclFloat8e4m3 && datatype != ncclFloat8e5m2) {
       // MSCCL threshold for Bfloat16 = 8MB
@@ -132,8 +132,8 @@ if (mscclAvailable(comm) && !mscclIsCaller()) {
         return mscclEnqueueCheck(
                       sendbuff, nullptr, nullptr, recvbuff, nullptr, nullptr,
                       count, datatype, 0, 0, op, mscclFuncAllReduce, comm, stream);
+      }
     }
-  }
   }
 
   return ncclEnqueueCheck(&info);

--- a/src/collectives.cc
+++ b/src/collectives.cc
@@ -124,12 +124,16 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
     NCCLCHECK(Recorder::instance().record(rrAllReduce, info));
   }
 
-  if ((datatype != ncclFloat8e4m3 && datatype != ncclFloat8e5m2) && mscclAvailable(comm) && !mscclIsCaller()) {
-    if (datatype != ncclBfloat16 || (count * ncclTypeSize(datatype) <= 8388608)) {
-	return mscclEnqueueCheck(
-                sendbuff, nullptr, nullptr, recvbuff, nullptr, nullptr,
-                count, datatype, 0, 0, op, mscclFuncAllReduce, comm, stream);	
+if (mscclAvailable(comm) && !mscclIsCaller()) {
+    //MSCCL not supported for FP8 datatype
+    if (datatype != ncclFloat8e4m3 && datatype != ncclFloat8e5m2) {
+      // MSCCL threshold for Bfloat16 = 8MB
+      if (datatype != ncclBfloat16 || (count * ncclTypeSize(datatype) <= 8388608)) {
+        return mscclEnqueueCheck(
+                      sendbuff, nullptr, nullptr, recvbuff, nullptr, nullptr,
+                      count, datatype, 0, 0, op, mscclFuncAllReduce, comm, stream);
     }
+  }
   }
 
   return ncclEnqueueCheck(&info);


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:LWPCOMMLIBS-667

**What were the changes?**  
Disabling MSCCL for fp8 datatype

**Why were the changes made?**  
There is a validation issue when MSCCL is enabled for vector addition on MI300X.

**How was the outcome achieved?**  
Disabling MSCCL will address the issue.
**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
