### PR TITLE
add reduce/broadcast algo/proto selection table for multi-node gfx940

### DIFF
--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -335,6 +335,10 @@ static struct tuningModel tuning_model_5 {
     {/*LL (min/max/factor/thread_threshold)*/ {0, 98304,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {98304, 5046272, 1, 64}},
     /*AllReduce*/
     {/*LL (min/max/factor/thread_threshold)*/ {0, 1048576, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {1048576, 9437184, 3145728, 0}},
+    /*Reduce*/
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 4096, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {4096, 16777216, 1, 0}},
+    /*Broadcast*/
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 8192, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {8192, 33554432, 1, 0}},
   },
 };
 

--- a/src/include/rccl_common.h
+++ b/src/include/rccl_common.h
@@ -79,7 +79,7 @@ inline size_t rcclGetSizePerRank(ncclFunc_t const& func, size_t const& nBytes, i
   // For AG, this is the send size per rank
   // For RS, this is the recv size per rank
   // For AR, this is the send/recv size per rank
-  return (func == ncclFuncReduceScatter || func == ncclFuncAllGather || func == ncclFuncBroadcast) ? nBytes / nRanks : nBytes;
+  return (func == ncclFuncReduceScatter || func == ncclFuncAllGather || func == ncclFuncBroadcast || func == ncclFuncReduce) ? nBytes / nRanks : nBytes;
 }
 void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info);
 void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info, int& threadThreshold);

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -33,7 +33,7 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
     userProtocolInput = !protoStr ? 0 : 1;
   }
 
-  if(!userProtocolInput && comm->nNodes >= 2 && (info->func == ncclFuncReduceScatter || info->func == ncclFuncAllGather || info->func == ncclFuncAllReduce || info->func == ncclFuncBroadcast)) {
+  if(!userProtocolInput && comm->nNodes >= 2 && (info->func == ncclFuncReduceScatter || info->func == ncclFuncAllGather || info->func == ncclFuncAllReduce || info->func == ncclFuncBroadcast || info->func == ncclFuncReduce)) {
     auto tunableIndex = rcclGetTunableIndex(info->func);
     auto llMin = comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX];
     auto llMax = comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL][RCCL_PROTOCOL_MAX_IDX];

--- a/tools/topo_expl/topo_expl.cpp
+++ b/tools/topo_expl/topo_expl.cpp
@@ -291,7 +291,9 @@ int main(int argc,char* argv[])
   std::vector<ncclFunc_t> ncclFuncTypes = {
     ncclFuncAllReduce,
     ncclFuncReduceScatter,
-    ncclFuncAllGather
+    ncclFuncAllGather,
+    ncclFuncReduce,
+    ncclFuncBroadcast
   };
 
   std::cout << "Running fp32 production choices for algorithm/protocol/maxChannels" << std::endl;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Added protocol selection for multi-node gfx940 broadcast and reduce

**Why were the changes made?**  
Performance dip at 4MB

**How was the outcome achieved?**  
- Added LL and LL128 threshold entries for Reduce and Broadcast
- Added Reduce/Broadcast entries in topo-explorer

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
