### PR TITLE
Add reference to supported data types section

### DIFF
--- a/docs/api-reference/library-specification.rst
+++ b/docs/api-reference/library-specification.rst
@@ -109,4 +109,6 @@ This section provides all the enumerations used.
 
 .. doxygenenum:: ncclRedOp_t
 
+.. _rccl-supported-data-types:
+
 .. doxygenenum:: ncclDataType_t


### PR DESCRIPTION
## Details

We would like to link the specific section at the main precision support page:
https://rocm.docs.amd.com/en/latest/reference/precision-support.html

**What were the changes?**  

Added a reference to data type enum.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [x] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
