### PR TITLE
Treat PIX and PXB as same GDR distance

### DIFF
--- a/src/graph/rome_models.cc
+++ b/src/graph/rome_models.cc
@@ -1791,6 +1791,10 @@ static bool permuteNetIds(int *n, int *g, int s, int last, struct rcclRomeModel*
       for (j = 0; j < ref->nGpus; j++) {
         // enabling PXN override paths over PHB and SYS
         if (topo->gdrLevel[n[i]*ref->nGpus+g[j]] == PATH_PXN) continue;
+        // treat PIX and PXB as same
+        if ((ref->gdrLevel[i*ref->nGpus+j] == PATH_PXB && topo->gdrLevel[n[i]*ref->nGpus+g[j]] == PATH_PIX) ||
+          (ref->gdrLevel[i*ref->nGpus+j] == PATH_PIX && topo->gdrLevel[n[i]*ref->nGpus+g[j]] == PATH_PXB))
+          continue;
         if (ref->gdrLevel[i*ref->nGpus+j] != topo->gdrLevel[n[i]*ref->nGpus+g[j]]) break;
       }
       if (j < ref->nGpus) break;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
SWDEV-552381

**What were the changes?**  
Treat PIX and PXB as same GDR distance

**Why were the changes made?**  
Not all PCIe switches are passed into VM. This results in differences in GDR distance between BM and VM.

**How was the outcome achieved?**  
Treat PIX and PXB as same GDR distance

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
