### PR TITLE
Add MI350x multi node rccl tests on slurm cluster.

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -113,7 +113,7 @@ jobs:
     uses: ./.github/workflows/therock-test-packages-multi-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: vultr-linux-rocm
+      test_runs_on: nova-linux-slurm-scale-runner
       artifact_run_id: ${{ github.run_id }}
 
   therock-test-linux-single-node:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -7,6 +7,14 @@ on:
         type: string
       extra_cmake_options:
         type: string
+  workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        type: choice
+        options:
+          - gfx94X-dcgpu
+          - gfx950-dcgpu
+        default: gfx94X-dcgpu
 
 permissions:
   contents: read
@@ -113,7 +121,7 @@ jobs:
     uses: ./.github/workflows/therock-test-packages-multi-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: nova-linux-slurm-scale-runner
+      test_runs_on: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' && 'vultr-linux-rocm' || (inputs.amdgpu_families == 'gfx950-dcgpu' && 'nova-linux-slurm-scale-runner') }}
       artifact_run_id: ${{ github.run_id }}
 
   therock-test-linux-single-node:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -4,7 +4,18 @@ on:
   push:
     branches:
       - develop
+  workflow_call:
+    inputs:
+      amdgpu_families:
+        description: The type of build version to produce ("nightly", or "dev")
+        type: string
+        default: "gfx950-dcgpu"
   workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        type: string
+        description: "Insert comma-separated list of GPU families to build and test. ex: gfx94X, gfx1201X"
+        default: "gfx950-dcgpu"
 
 permissions:
   contents: read
@@ -47,16 +58,16 @@ jobs:
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
-      amdgpu_families: "gfx950-dcgpu"
+      amdgpu_families: ${{ inputs.amdgpu_families }}
       extra_cmake_options: >
-        -DTHEROCK_ENABLE_ALL=OFF 
-        -DTHEROCK_BUILD_TESTING=ON 
-        -DTHEROCK_BUNDLE_SYSDEPS=ON 
-        -DTHEROCK_ENABLE_COMM_LIBS=ON 
-        -DTHEROCK_ENABLE_ROCPROFV3=ON 
-        -DTHEROCK_USE_EXTERNAL_RCCL=ON 
-        -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON 
-        -DTHEROCK_RCCL_SOURCE_DIR=./rccl 
+        -DTHEROCK_ENABLE_ALL=OFF
+        -DTHEROCK_BUILD_TESTING=ON
+        -DTHEROCK_BUNDLE_SYSDEPS=ON
+        -DTHEROCK_ENABLE_COMM_LIBS=ON
+        -DTHEROCK_ENABLE_ROCPROFV3=ON
+        -DTHEROCK_USE_EXTERNAL_RCCL=ON
+        -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON
+        -DTHEROCK_RCCL_SOURCE_DIR=./rccl
         -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
         -DTHEROCK_ENABLE_MPI=ON
 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -47,7 +47,7 @@ jobs:
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
-      amdgpu_families: "gfx94X-dcgpu"
+      amdgpu_families: "gfx950-dcgpu"
       extra_cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -59,5 +59,6 @@ jobs:
           pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
               --cluster_file ./input/cluster.json \
               --config_file ./input/mi350_config.json \
-              --log-file=/tmp/rccl_log.log
+              --log-file=/tmp/rccl_log.log \
+              --html=/home/arravikum/cvs/ci_test_report.html --capture=tee-sys --self-contained-html
           EOF

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -52,10 +52,11 @@ jobs:
 
       - name: Test
         run: |
+          scancel -p 32nodexgmi36 --reservation=ci_cd_test <<'EOF'
           salloc -N 4 --reservation=ci_cd_test --exclusive bash <<'EOF'
           source /home/arravikum/TheRock/.venv/bin/activate
           cd /home/arravikum/cvs
-          
+
           pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
               --cluster_file ./input/cluster.json \
               --config_file ./input/mi350_config.json \

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -52,6 +52,12 @@ jobs:
 
       - name: Test
         run: |
+          salloc -N 4 --reservation=ci_cd_test --exclusive bash <<'EOF'
           source /home/arravikum/TheRock/.venv/bin/activate
           cd /home/arravikum/cvs
-          pytest -vvv --log-file=/tmp/rccl_log.log -s ./tests/rccl/rccl_multinode_cvs.py --cluster_file ./input/cluster.json --config_file ./input/mi300_config.json --html=/var/www/html/cvs/ci_test_report.html --capture=tee-sys --self-contained-html
+          
+          pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
+              --cluster_file ./input/cluster.json \
+              --config_file ./input/mi350_config.json \
+              --log-file=/tmp/rccl_log.log
+          EOF


### PR DESCRIPTION
### Description:

This PR is raised to add TheRock-CI coverage for multi node rccl tests on newly added Slurm cluster.

### Design:

Present design uses amdgpu_families input to decide on the test runner to either run on the "Slurm runner" or "Vultr Cloud runner"

Pass log for multi node script on Slurm runner:

https://github.com/ROCm/rccl/actions/runs/17488796216/job/49704080355