### PR TITLE
[AzureCI] Build topo_expl as part of RCCL CI

### DIFF
--- a/.azuredevops/slurm/build.sh
+++ b/.azuredevops/slurm/build.sh
@@ -39,6 +39,9 @@ cmake -G Ninja -DCMAKE_INSTALL_PREFIX="$BINARIES_DIR" -DCMAKE_BUILD_TYPE=Release
 cmake --build .
 cmake --build . --target install
 
+## Building RCCL topo_explorer
+cd ../tools/topo_expl
+make
 
 cd "${SLURM_SUBMIT_DIR:-$PWD}"
 ## Building RCCL-Tests


### PR DESCRIPTION
## Details

**Work item:**
Internal (LWPCOMMLIBS-676)

**What were the changes?**  
Add `rccl/tools/topo_expl` build as part of AzureCI pipeline.

**Why were the changes made?**  
Catch topo_expl build fails when RCCL source code changes.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
