### PR TITLE
Enable LL128 and use same tuning table for gfx942 4 NICs

### DIFF
--- a/src/graph/rome_models.cc
+++ b/src/graph/rome_models.cc
@@ -1140,7 +1140,7 @@ static struct rcclRomeModel rome_model_87 = {
                "N1 7 3 2 6 0 4 1 5 N2|"
                "N2 4 0 3 7 2 5 1 6 N1|",
 
-  .options = "noCpuCheck=1,netOverride=1",
+  .options = "noCpuCheck=1,netOverride=1,tuning=5,ll128Enabled=1",
 };
 
 static struct rcclRomeModel romeTopoModels[] = {


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal

**What were the changes?**  
Enable LL128 and use same tuning table for gfx942 4 NICs

**Why were the changes made?**  
LL128 and tuning table is currently only enabled on gfx942 with 8 NICs. Enable them for 4 NICs as well.

**How was the outcome achieved?**  
Add options to model

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
