### PR TITLE
Topo explorer failure to compile fix

### DIFF
--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -2154,8 +2154,8 @@ rccl_static ncclResult_t getAlgoInfo(
       regBuff = (regSendBuf && regRecvBuf && isSendValid && isRecvValid) || (ncclCudaGraphValid(comm->planner.capturingGraph) && ncclParamGraphRegister());
       if (regBuff && (info->func == ncclFuncAllGather || info->func == ncclFuncReduceScatter)) {
         if ((comm->nNodes > 1 && collNetSupport && nvlsSupport) || (comm->nNodes == 1 && nvlsSupport)) {
-          int recChannels;
-          NCCLCHECK(ncclNvlsRegResourcesQuery(comm, info, &recChannels));
+          int recChannels = info->nMaxChannels + 1; // was unset
+          //NCCLCHECK(ncclNvlsRegResourcesQuery(comm, info, &recChannels)); Disabled for topo explorer
           if (recChannels <= info->nMaxChannels) {
             info->algorithm = NCCL_ALGO_NVLS;
             info->protocol = NCCL_PROTO_SIMPLE;

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -2154,8 +2154,8 @@ rccl_static ncclResult_t getAlgoInfo(
       regBuff = (regSendBuf && regRecvBuf && isSendValid && isRecvValid) || (ncclCudaGraphValid(comm->planner.capturingGraph) && ncclParamGraphRegister());
       if (regBuff && (info->func == ncclFuncAllGather || info->func == ncclFuncReduceScatter)) {
         if ((comm->nNodes > 1 && collNetSupport && nvlsSupport) || (comm->nNodes == 1 && nvlsSupport)) {
-          int recChannels = info->nMaxChannels; // RCCL PR1899, was previously unset.  We can revisit this logic later.
-          //RCCL PR1899: NCCLCHECK(ncclNvlsRegResourcesQuery(comm, info, &recChannels));
+          int recChannels = info->nMaxChannels + 1; // RCCL: We can revisit this logic later.
+          //RCCL: NCCLCHECK(ncclNvlsRegResourcesQuery(comm, info, &recChannels));
           if (recChannels <= info->nMaxChannels) {
             info->algorithm = NCCL_ALGO_NVLS;
             info->protocol = NCCL_PROTO_SIMPLE;

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -2154,8 +2154,8 @@ rccl_static ncclResult_t getAlgoInfo(
       regBuff = (regSendBuf && regRecvBuf && isSendValid && isRecvValid) || (ncclCudaGraphValid(comm->planner.capturingGraph) && ncclParamGraphRegister());
       if (regBuff && (info->func == ncclFuncAllGather || info->func == ncclFuncReduceScatter)) {
         if ((comm->nNodes > 1 && collNetSupport && nvlsSupport) || (comm->nNodes == 1 && nvlsSupport)) {
-          int recChannels = info->nMaxChannels + 1; // was unset
-          //NCCLCHECK(ncclNvlsRegResourcesQuery(comm, info, &recChannels)); Disabled for topo explorer
+          int recChannels = info->nMaxChannels; // RCCL PR1899, was previously unset.  We can revisit this logic later.
+          //RCCL PR1899: NCCLCHECK(ncclNvlsRegResourcesQuery(comm, info, &recChannels));
           if (recChannels <= info->nMaxChannels) {
             info->algorithm = NCCL_ALGO_NVLS;
             info->protocol = NCCL_PROTO_SIMPLE;

--- a/tools/topo_expl/.gitignore
+++ b/tools/topo_expl/.gitignore
@@ -1,0 +1,2 @@
+hipify_rccl
+topo_expl

--- a/tools/topo_expl/Makefile
+++ b/tools/topo_expl/Makefile
@@ -1,5 +1,6 @@
 # Copyright (c) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
 HIP_PATH ?= $(wildcard /opt/rocm)
+ROCM_VERSION ?=$(shell sed 's/\./0/g' /opt/rocm/.info/version)
 ifeq (,$(HIP_PATH))
 HIP_PATH = ../../..
 endif
@@ -8,7 +9,7 @@ HIPCC = $(HIP_PATH)/bin/hipcc
 .DEFAULT_GOAL := all
 
 EXE = topo_expl
-CXXFLAGS = -g -ffunction-sections -fdata-sections -DROCM_VERSION=70000 -Wl,--gc-sections -fgpu-rdc -Iinclude -Ihipify_rccl/include -Ihipify_rccl/include/plugin -Ihipify_rccl/src/device/include  -Ihipify_rccl/graph -I/opt/rocm/include/ -DTOPO_EXPL -DENABLE_TRACE -DENABLE_LL128 -DNVTX_NO_IMPL -DRCCL_EXPOSE_STATIC -lpthread
+CXXFLAGS = -g -ffunction-sections -fdata-sections -DROCM_VERSION=$(ROCM_VERSION) -Wl,--gc-sections -fgpu-rdc -Iinclude -Ihipify_rccl/include -Ihipify_rccl/include/plugin -Ihipify_rccl/src/device/include  -Ihipify_rccl/graph -I/opt/rocm/include/ -DTOPO_EXPL -DENABLE_TRACE -DENABLE_LL128 -DNVTX_NO_IMPL -DRCCL_EXPOSE_STATIC -lpthread
 
 files = $(EXE).cpp model.cpp utils.cpp hipify_rccl/graph/topo.cc hipify_rccl/graph/rings.cc hipify_rccl/graph/paths.cc hipify_rccl/graph/trees.cc ../../src/misc/param.cc \
 	hipify_rccl/graph/search.cc hipify_rccl/graph/connect.cc hipify_rccl/graph/tuning.cc hipify_rccl/graph/xml.cc ../../src/misc/nvmlwrap_stub.cc hipify_rccl/graph/rome_models.cc hipify_rccl/graph/archinfo.cc \

--- a/tools/topo_expl/Makefile
+++ b/tools/topo_expl/Makefile
@@ -1,6 +1,6 @@
 # Copyright (c) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
 HIP_PATH ?= $(wildcard /opt/rocm)
-ROCM_VERSION ?=$(shell sed 's/\./0/g' /opt/rocm/.info/version)
+ROCM_VERSION ?=$(shell sed 's/\./0/g' $(HIP_PATH)/.info/version)
 ifeq (,$(HIP_PATH))
 HIP_PATH = ../../..
 endif

--- a/tools/topo_expl/Makefile
+++ b/tools/topo_expl/Makefile
@@ -8,7 +8,7 @@ HIPCC = $(HIP_PATH)/bin/hipcc
 .DEFAULT_GOAL := all
 
 EXE = topo_expl
-CXXFLAGS = -g -ffunction-sections -fdata-sections -Wl,--gc-sections -fgpu-rdc -Iinclude -Ihipify_rccl/include -Ihipify_rccl/include/plugin -Ihipify_rccl/src/device/include  -Ihipify_rccl/graph -I/opt/rocm/include/ -DTOPO_EXPL -DENABLE_TRACE -DENABLE_LL128 -DNVTX_NO_IMPL -DRCCL_EXPOSE_STATIC -lpthread
+CXXFLAGS = -g -ffunction-sections -fdata-sections -DROCM_VERSION=70000 -Wl,--gc-sections -fgpu-rdc -Iinclude -Ihipify_rccl/include -Ihipify_rccl/include/plugin -Ihipify_rccl/src/device/include  -Ihipify_rccl/graph -I/opt/rocm/include/ -DTOPO_EXPL -DENABLE_TRACE -DENABLE_LL128 -DNVTX_NO_IMPL -DRCCL_EXPOSE_STATIC -lpthread
 
 files = $(EXE).cpp model.cpp utils.cpp hipify_rccl/graph/topo.cc hipify_rccl/graph/rings.cc hipify_rccl/graph/paths.cc hipify_rccl/graph/trees.cc ../../src/misc/param.cc \
 	hipify_rccl/graph/search.cc hipify_rccl/graph/connect.cc hipify_rccl/graph/tuning.cc hipify_rccl/graph/xml.cc ../../src/misc/nvmlwrap_stub.cc hipify_rccl/graph/rome_models.cc hipify_rccl/graph/archinfo.cc \


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal

**What were the changes?**  
Fix topo_explorer

**Why were the changes made?**  
We need this tool to work.

**How was the outcome achieved?**  
Fix problems albeit in a hacky way.

**Additional Documentation:**  
It now compiles and runs.  Yay.  The main issues are an nvls call is not defined at link time.  We could create a stub for that in topo explorer or hipify the file the nvls function is included in.  I think neither of these is worth it to be honest, but I can make the change if reviewers see fit.

Another problem was that the file now needs something that only exists post ROCm 6.0.  So we include the ROCm version.  This means topo_expl won't compile pre-ROCm 6.0.  I'm actually fine with that.  This tool is for us (the RCCL developers).

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
