### PR TITLE
Enable multi node rccl tests on MI350x slurm cluster.

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -7,14 +7,6 @@ on:
         type: string
       extra_cmake_options:
         type: string
-  workflow_dispatch:
-    inputs:
-      amdgpu_families:
-        type: choice
-        options:
-          - gfx94X-dcgpu
-          - gfx950-dcgpu
-        default: gfx94X-dcgpu
 
 permissions:
   contents: read
@@ -121,7 +113,7 @@ jobs:
     uses: ./.github/workflows/therock-test-packages-multi-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' && 'vultr-linux-rocm' || (inputs.amdgpu_families == 'gfx950-dcgpu' && 'nova-linux-slurm-scale-runner') }}
+      test_runs_on: nova-linux-slurm-scale-runner
       artifact_run_id: ${{ github.run_id }}
 
   therock-test-linux-single-node:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -113,7 +113,7 @@ jobs:
     uses: ./.github/workflows/therock-test-packages-multi-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: vultr-linux-rocm
+      test_runs_on: nova-linux-slurm-scale-runner
       artifact_run_id: ${{ github.run_id }}
 
   therock-test-linux-single-node:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:283673fe3e1bf498d079e3f386b794af1b4f71845a9a0107c6cf7aa304dce050
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:1f1ce0ab151146c7f86ee4345be74c42d8ca83200d9d26843e8a71df01ecad4e
       options: -v /runner/config:/home/awsconfig/
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
@@ -109,18 +109,17 @@ jobs:
 
   therock-test-linux-multi-node:
     name: "Test multi-node"
+    if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-test-packages-multi-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' && 'vultr-linux-rocm' || (inputs.amdgpu_families == 'gfx950-dcgpu' && 'nova-linux-slurm-scale-runner') }}
+      test_runs_on: nova-linux-slurm-scale-runner
       artifact_run_id: ${{ github.run_id }}
 
-  # TheRock ROCm build is currently missing amd-smi which is required for this testing.
-  # TODO (saienduri): Re-enable after issue resolved (https://github.com/ROCm/TheRock/issues/1422)
   therock-test-linux-single-node:
     name: "Test single-node"
-    if: ${{ false }}
+    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-test-packages-single-node.yml
     with:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -113,11 +113,12 @@ jobs:
     uses: ./.github/workflows/therock-test-packages-multi-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: nova-linux-slurm-scale-runner
+      test_runs_on: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' && 'vultr-linux-rocm' || (inputs.amdgpu_families == 'gfx950-dcgpu' && 'nova-linux-slurm-scale-runner') }}
       artifact_run_id: ${{ github.run_id }}
 
   therock-test-linux-single-node:
     name: "Test single-node"
+    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-test-packages-single-node.yml
     with:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -7,6 +7,14 @@ on:
         type: string
       extra_cmake_options:
         type: string
+  workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        type: choice
+        options:
+          - gfx94X-dcgpu
+          - gfx950-dcgpu
+        default: gfx94X-dcgpu
 
 permissions:
   contents: read
@@ -113,7 +121,7 @@ jobs:
     uses: ./.github/workflows/therock-test-packages-multi-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: nova-linux-slurm-scale-runner
+      test_runs_on: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' && 'vultr-linux-rocm' || (inputs.amdgpu_families == 'gfx950-dcgpu' && 'nova-linux-slurm-scale-runner') }}
       artifact_run_id: ${{ github.run_id }}
 
   therock-test-linux-single-node:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -116,9 +116,11 @@ jobs:
       test_runs_on: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' && 'vultr-linux-rocm' || (inputs.amdgpu_families == 'gfx950-dcgpu' && 'nova-linux-slurm-scale-runner') }}
       artifact_run_id: ${{ github.run_id }}
 
+  # TheRock ROCm build is currently missing amd-smi which is required for this testing.
+  # TODO (saienduri): Re-enable after issue resolved (https://github.com/ROCm/TheRock/issues/1422)
   therock-test-linux-single-node:
     name: "Test single-node"
-    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
+    if: ${{ false }}
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-test-packages-single-node.yml
     with:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:1f1ce0ab151146c7f86ee4345be74c42d8ca83200d9d26843e8a71df01ecad4e
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:bcc8b37af4031d3bd3bebcf48f8059c082b510fbad8902068501148583c9a324
       options: -v /runner/config:/home/awsconfig/
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:bcc8b37af4031d3bd3bebcf48f8059c082b510fbad8902068501148583c9a324
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:1f1ce0ab151146c7f86ee4345be74c42d8ca83200d9d26843e8a71df01ecad4e
       options: -v /runner/config:/home/awsconfig/
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -4,7 +4,18 @@ on:
   push:
     branches:
       - develop
+  workflow_call:
+    inputs:
+      amdgpu_families:
+        description: The type of build version to produce ("nightly", or "dev")
+        type: string
+        default: "gfx950-dcgpu"
   workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        type: string
+        description: "Insert comma-separated list of GPU families to build and test. ex: gfx94X, gfx1201X"
+        default: "gfx950-dcgpu"
 
 permissions:
   contents: read
@@ -47,16 +58,16 @@ jobs:
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
-      amdgpu_families: "gfx950-dcgpu"
+      amdgpu_families: ${{ inputs.amdgpu_families }}
       extra_cmake_options: >
-        -DTHEROCK_ENABLE_ALL=OFF 
-        -DTHEROCK_BUILD_TESTING=ON 
-        -DTHEROCK_BUNDLE_SYSDEPS=ON 
-        -DTHEROCK_ENABLE_COMM_LIBS=ON 
-        -DTHEROCK_ENABLE_ROCPROFV3=ON 
-        -DTHEROCK_USE_EXTERNAL_RCCL=ON 
-        -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON 
-        -DTHEROCK_RCCL_SOURCE_DIR=./rccl 
+        -DTHEROCK_ENABLE_ALL=OFF
+        -DTHEROCK_BUILD_TESTING=ON
+        -DTHEROCK_BUNDLE_SYSDEPS=ON
+        -DTHEROCK_ENABLE_COMM_LIBS=ON
+        -DTHEROCK_ENABLE_ROCPROFV3=ON
+        -DTHEROCK_USE_EXTERNAL_RCCL=ON
+        -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON
+        -DTHEROCK_RCCL_SOURCE_DIR=./rccl
         -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
         -DTHEROCK_ENABLE_MPI=ON
 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -47,7 +47,7 @@ jobs:
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
-      amdgpu_families: "gfx94X-dcgpu"
+      amdgpu_families: "gfx950-dcgpu"
       extra_cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -4,18 +4,7 @@ on:
   push:
     branches:
       - develop
-  workflow_call:
-    inputs:
-      amdgpu_families:
-        description: The type of build version to produce ("nightly", or "dev")
-        type: string
-        default: "gfx950-dcgpu"
   workflow_dispatch:
-    inputs:
-      amdgpu_families:
-        type: string
-        description: "Insert comma-separated list of GPU families to build and test. ex: gfx94X, gfx1201X"
-        default: "gfx950-dcgpu"
 
 permissions:
   contents: read
@@ -58,16 +47,16 @@ jobs:
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
-      amdgpu_families: ${{ inputs.amdgpu_families }}
+      amdgpu_families: "gfx950-dcgpu"
       extra_cmake_options: >
-        -DTHEROCK_ENABLE_ALL=OFF
-        -DTHEROCK_BUILD_TESTING=ON
-        -DTHEROCK_BUNDLE_SYSDEPS=ON
-        -DTHEROCK_ENABLE_COMM_LIBS=ON
-        -DTHEROCK_ENABLE_ROCPROFV3=ON
-        -DTHEROCK_USE_EXTERNAL_RCCL=ON
-        -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON
-        -DTHEROCK_RCCL_SOURCE_DIR=./rccl
+        -DTHEROCK_ENABLE_ALL=OFF 
+        -DTHEROCK_BUILD_TESTING=ON 
+        -DTHEROCK_BUNDLE_SYSDEPS=ON 
+        -DTHEROCK_ENABLE_COMM_LIBS=ON 
+        -DTHEROCK_ENABLE_ROCPROFV3=ON 
+        -DTHEROCK_USE_EXTERNAL_RCCL=ON 
+        -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON 
+        -DTHEROCK_RCCL_SOURCE_DIR=./rccl 
         -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
         -DTHEROCK_ENABLE_MPI=ON
 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -45,9 +45,9 @@ jobs:
       contents: read
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         amdgpu_family: [gfx94X-dcgpu, gfx950-dcgpu]
-    continue-on-error: true
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -47,6 +47,7 @@ jobs:
     strategy:
       matrix:
         amdgpu_family: [gfx94X-dcgpu, gfx950-dcgpu]
+    continue-on-error: true
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -44,10 +44,13 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    strategy:
+      matrix:
+        amdgpu_family: [gfx94X-dcgpu, gfx950-dcgpu]
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
-      amdgpu_families: "gfx950-dcgpu"
+      amdgpu_families: ${{ matrix.amdgpu_family }}
       extra_cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -64,12 +64,10 @@ jobs:
              --self-contained-html
 
       # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
-      # First, scancel anything running on the slurm reservation for CI.
-      # Then, salloc will hold 4 nodes while the commands inside the EOF block run. After the block completes, salloc automatically releases the nodes.
+      # salloc will hold 4 nodes while the commands inside the EOF block run. After the block completes, salloc automatically releases the nodes.
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          scancel -p 32nodexgmi36 --reservation=ci_cd_test
           salloc -N 4 --reservation=ci_cd_test --exclusive bash <<'EOF'
           source /home/arravikum/TheRock/.venv/bin/activate
           cd /home/arravikum/cvs

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -59,5 +59,6 @@ jobs:
           pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
               --cluster_file ./input/cluster.json \
               --config_file ./input/mi350_config.json \
-              --log-file=/tmp/rccl_log.log
+              --log-file=/tmp/rccl_log.log \
+              --html=/home/arravikum/cvs/ci_test_report.html --capture=tee-sys --self-contained-html
           EOF

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -50,15 +50,34 @@ jobs:
           FETCH_ARTIFACT_ARGS: "--rccl"
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
-      - name: Test
+      # The following step tests multi node rccl tests on 3 dedicated gfx942 nodes.
+      - name: Test gfx94X
+        if: ${{ inputs.amdgpu_families == 'gfx94x-dcgpu' }}
         run: |
+          source /home/arravikum/TheRock/.venv/bin/activate
+          cd /home/arravikum/cvs
+          pytest -vvv --log-file=/tmp/rccl_log.log -s ./tests/rccl/rccl_multinode_cvs.py \
+             --cluster_file ./input/cluster.json \
+             --config_file ./input/mi300_config.json \
+             --html=/var/www/html/cvs/ci_test_report.html \
+             --capture=tee-sys \
+             --self-contained-html
+
+      # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
+      # First, scancel anything running on the slurm reservation for CI.
+      # Then, salloc will hold 4 nodes while the commands inside the EOF block run. After the block completes, salloc automatically releases the nodes.
+      - name: Test gfx950
+        if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
+        run: |
+          scancel -p 32nodexgmi36 --reservation=ci_cd_test
           salloc -N 4 --reservation=ci_cd_test --exclusive bash <<'EOF'
           source /home/arravikum/TheRock/.venv/bin/activate
           cd /home/arravikum/cvs
-          
           pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
               --cluster_file ./input/cluster.json \
               --config_file ./input/mi350_config.json \
               --log-file=/tmp/rccl_log.log \
-              --html=/home/arravikum/cvs/ci_test_report.html --capture=tee-sys --self-contained-html
+              --html=/home/arravikum/cvs/ci_test_report.html \
+              --capture=tee-sys \
+              --self-contained-html
           EOF

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -64,18 +64,18 @@ jobs:
              --self-contained-html
 
       # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
-      # salloc will hold 4 nodes while the commands inside the EOF block run. After the block completes, salloc automatically releases the nodes.
+      # salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          salloc -N 4 --reservation=ci_cd_test --exclusive bash <<'EOF'
-          source /home/arravikum/TheRock/.venv/bin/activate
-          cd /home/arravikum/cvs
+          salloc -N 4 -p meta64 --exclusive bash -c "
+          source /home/arravikum/TheRock/.venv/bin/activate &&
+          cd /home/arravikum/cvs &&
+          python input/setup.py &&
           pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
               --cluster_file ./input/cluster.json \
               --config_file ./input/mi350_config.json \
               --log-file=/tmp/rccl_log.log \
               --html=/home/arravikum/cvs/ci_test_report.html \
               --capture=tee-sys \
-              --self-contained-html
-          EOF
+              --self-contained-html"

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -52,10 +52,11 @@ jobs:
 
       - name: Test
         run: |
+          scancel -p 32nodexgmi36 --reservation=ci_cd_test <<'EOF'
           salloc -N 4 --reservation=ci_cd_test --exclusive bash <<'EOF'
           source /home/arravikum/TheRock/.venv/bin/activate
           cd /home/arravikum/cvs
-          
+
           pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
               --cluster_file ./input/cluster.json \
               --config_file ./input/mi350_config.json \

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -52,6 +52,12 @@ jobs:
 
       - name: Test
         run: |
+          salloc -N 4 --reservation=ci_cd_test --exclusive bash <<'EOF'
           source /home/arravikum/TheRock/.venv/bin/activate
           cd /home/arravikum/cvs
-          pytest -vvv --log-file=/tmp/rccl_log.log -s ./tests/rccl/rccl_multinode_cvs.py --cluster_file ./input/cluster.json --config_file ./input/mi300_config.json --html=/var/www/html/cvs/ci_test_report.html --capture=tee-sys --self-contained-html
+          
+          pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
+              --cluster_file ./input/cluster.json \
+              --config_file ./input/mi350_config.json \
+              --log-file=/tmp/rccl_log.log
+          EOF

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -52,11 +52,10 @@ jobs:
 
       - name: Test
         run: |
-          scancel -p 32nodexgmi36 --reservation=ci_cd_test <<'EOF'
           salloc -N 4 --reservation=ci_cd_test --exclusive bash <<'EOF'
           source /home/arravikum/TheRock/.venv/bin/activate
           cd /home/arravikum/cvs
-
+          
           pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
               --cluster_file ./input/cluster.json \
               --config_file ./input/mi350_config.json \

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -50,19 +50,6 @@ jobs:
           FETCH_ARTIFACT_ARGS: "--rccl"
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
-      # The following step tests multi node rccl tests on 3 dedicated gfx942 nodes.
-      - name: Test gfx94X
-        if: ${{ inputs.amdgpu_families == 'gfx94x-dcgpu' }}
-        run: |
-          source /home/arravikum/TheRock/.venv/bin/activate
-          cd /home/arravikum/cvs
-          pytest -vvv --log-file=/tmp/rccl_log.log -s ./tests/rccl/rccl_multinode_cvs.py \
-             --cluster_file ./input/cluster.json \
-             --config_file ./input/mi300_config.json \
-             --html=/var/www/html/cvs/ci_test_report.html \
-             --capture=tee-sys \
-             --self-contained-html
-
       # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
       # salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
       - name: Test gfx950

--- a/.github/workflows/therock-test-packages-single-node.yml
+++ b/.github/workflows/therock-test-packages-single-node.yml
@@ -62,8 +62,10 @@ jobs:
         timeout-minutes: 15
         # Currently, TheRock CI in RCCL always builds with MPI-supported enabled which causes the
         # RCCL correctness tests to fail on the mi325 runners which don't have MPI pre-installed.
+        # Also, TheRock ROCm build is currently missing amd-smi which is required for the unit tests.
         # TODO (geomin12): Rebuild rccl-tests without MPI to enable RCCL correctness tests.
+        # TODO (saienduri): Re-enable rccl unit tests once https://github.com/ROCm/TheRock/issues/1422 is resolved.
         run: |
           pytest ./build_tools/github_actions/test_executable_scripts/test_rccl.py -v -s \
             --log-cli-level=info \
-            -k "not test_rccl_correctness_tests"
+            -k "not test_rccl_correctness_tests not test_rccl_unittests"

--- a/.github/workflows/therock-test-packages-single-node.yml
+++ b/.github/workflows/therock-test-packages-single-node.yml
@@ -68,4 +68,4 @@ jobs:
         run: |
           pytest ./build_tools/github_actions/test_executable_scripts/test_rccl.py -v -s \
             --log-cli-level=info \
-            -k "not test_rccl_correctness_tests not test_rccl_unittests"
+            -k "not test_rccl_correctness_tests and not test_rccl_unittests"

--- a/.github/workflows/therock-test-packages-single-node.yml
+++ b/.github/workflows/therock-test-packages-single-node.yml
@@ -62,10 +62,8 @@ jobs:
         timeout-minutes: 15
         # Currently, TheRock CI in RCCL always builds with MPI-supported enabled which causes the
         # RCCL correctness tests to fail on the mi325 runners which don't have MPI pre-installed.
-        # Also, TheRock ROCm build is currently missing amd-smi which is required for the unit tests.
         # TODO (geomin12): Rebuild rccl-tests without MPI to enable RCCL correctness tests.
-        # TODO (saienduri): Re-enable rccl unit tests once https://github.com/ROCm/TheRock/issues/1422 is resolved.
         run: |
           pytest ./build_tools/github_actions/test_executable_scripts/test_rccl.py -v -s \
             --log-cli-level=info \
-            -k "not test_rccl_correctness_tests and not test_rccl_unittests"
+            -k "not test_rccl_correctness_tests"


### PR DESCRIPTION
## Details
This PR adds initial support for multi node rccl testing on 4 nodes in a MI350x slurm cluster.
Remove legacy multi node testing brittle setup.

Example of run after changes: https://github.com/ROCm/rccl/actions/runs/17909137796/job/51099707499

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
