### PR TITLE
[Cherry-Pick] [ROCm 7.0.2] Add cstring header explictly as it is removed from HIP

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -12,6 +12,7 @@
 #include "bitops.h"
 #include "checks.h"
 #include <stdint.h>
+#include <string.h>
 #include <time.h>
 #include <sched.h>
 #include <algorithm>


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**
Cherry-pick https://github.com/ROCm/rccl/commit/6d41e5ba9993754b6e9caf718026f763bdcb1265
Add < cstring > header to fix the below errors, such as `./utils.h:238: error: use of undeclared identifier 'memcpy'`.

**Why were the changes made?**  
As part of 7.0 breaking changes, HIP runtime header files (hip_runtime.h) stopped including headers such as `<cstring>` or `<string.h>` since they were not used in HIP runtime. However, apps that depend on that header file will fail with errors, and they need to add the header explicitly.
This issue does not arise with RCCL compilation. Instead, it occurs with AMD Network Plugin compilation, where the hipified version of specific files from RCCL (such as ibvwrap/ibvsymbols) is pulled, including alloc.h/utils.h, which then fails to compile due to an error.
This change is in similar lines as with the changes made to RCCL-Tests repo PR https://github.com/ROCm/rccl-tests/pull/132

**How was the outcome achieved?**  
By adding `<string.h>` header to `src/include/utils.h`

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
