### PR TITLE
Fix issue where staging/mainline build commit hash doesn't match actual

### DIFF
--- a/cmake/scripts/git_version.cmake
+++ b/cmake/scripts/git_version.cmake
@@ -19,6 +19,7 @@
 # SOFTWARE.
 
 # Attempt to collect the latest git hash
+set(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 execute_process(COMMAND git log --pretty=format:'%h' -n 1
                 OUTPUT_VARIABLE GIT_REV
                 ERROR_QUIET)


### PR DESCRIPTION


## Details


**What were the changes?**  
CMake git hash fetching function call should be made from RCCL source directory.

**Why were the changes made?**  
Our staging and release build versioning when set NCCL_DEBUG=version shows different git hash and we cannot trace back to our commit. This is due to build pipeline of our packaging team. 

**How was the outcome achieved?**  
Edit our CMake function.

**Additional Documentation:**  


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
