### PR TITLE
Print out the hipRuntimeVersion message from WARN to always show up

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -141,7 +141,8 @@ ncclResult_t checkHsaEnvSetting() {
   CUDACHECK(hipGetDeviceProperties(&devProp, 0));
   INFO(NCCL_INIT, "Hipruntime version: %d, firmware version: %d", hipRuntimeVersion, firmwareVersion);
   if (!validHsaScratchEnvSetting(hsaScratchEnv, hipRuntimeVersion, firmwareVersion, devProp.gcnArchName)) {
-    WARN("HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid RCCL perf hit, rocm ver:%d", hipRuntimeVersion);
+    // Always print out this warning message
+    printf("HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid RCCL perf hit, rocm ver:%d", hipRuntimeVersion);
     return ncclSystemError;
   }
   return ncclSuccess;

--- a/src/init.cc
+++ b/src/init.cc
@@ -142,7 +142,7 @@ ncclResult_t checkHsaEnvSetting() {
   INFO(NCCL_INIT, "Hipruntime version: %d, firmware version: %d", hipRuntimeVersion, firmwareVersion);
   if (!validHsaScratchEnvSetting(hsaScratchEnv, hipRuntimeVersion, firmwareVersion, devProp.gcnArchName)) {
     // Always print out this warning message
-    printf("HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid RCCL perf hit, rocm ver:%d", hipRuntimeVersion);
+    printf("Fatal Error: HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid performance degradation with HIP Runtime version:%d, GPU Firmware version:%d\n", hipRuntimeVersion, firmwareVersion);
     return ncclSystemError;
   }
   return ncclSuccess;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_Change the format of this warning message from WARN only to always printing out.

**Why were the changes made?**  
_Display hipruntime version directly, instead of only when NCCL_DEBUG=WARN.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
