### PR TITLE
Added an implementation of `ncclSymGetKernelPtr` for when `GENERATE_SYM_KERNELS` is not defined

### DIFF
--- a/src/symmetric.cc
+++ b/src/symmetric.cc
@@ -294,3 +294,9 @@ const char* ncclSymKernelIdToString(int kernelId) {
   }
   return kernelName[kernelId];
 }
+
+#ifndef GENERATE_SYM_KERNELS
+void* ncclSymGetKernelPtr(ncclSymKernelId kernelId, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
+  return nullptr;
+}
+#endif


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** SWDEV-556131

**What were the changes?**  
Added an implementation of `ncclSymGetKernelPtr` for when `GENERATE_SYM_KERNELS` is not defined

**Why were the changes made?**  
Function is normally generated code, and was undefined when not generating symmetric kernels.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
