### PR TITLE
[SYM] Fix undefined symbol issue: ncclSymGetKernelPtr

### DIFF
--- a/src/symmetric.cc
+++ b/src/symmetric.cc
@@ -294,3 +294,7 @@ const char* ncclSymKernelIdToString(int kernelId) {
   }
   return kernelName[kernelId];
 }
+
+#ifndef GENERATE_SYM_KERNELS
+void* ncclSymGetKernelPtr(ncclSymKernelId kernelId, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty) { /* NO IMPL */ }
+#endif


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
SWDEV-556131

**What were the changes?**  
_One sentence describing the work done._
Add a compile time check for `ncclSymGetKernelPtr()` dummy definition. Symmetric kernels are not built by default and the definition of this function is in the generator script which is not used when this feature is disabled.  

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._
Causes undefined symbol error in python.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
