### PR TITLE
Revert disabling of context tracking for Radeon

### DIFF
--- a/docs/how-to/rccl-usage-tips.rst
+++ b/docs/how-to/rccl-usage-tips.rst
@@ -254,3 +254,12 @@ set during the benchmark in the following manner:
 The default allreduce PyTorch benchmark peak bus bandwidth performance is
 ~170 GB/s on a single OAM with ROCm 6.2.4, while the optimized run for CPX on a
 single OAM peaks at ~315 GB/s.
+
+Context tracking on Radeon GPUs
+----------------------------------------
+Context tracking disabled for MI series for better performance, but keeps enabled for Radeon GPUs.
+To disable context tracking for Radeon GPUs, set the following environment variable:
+
+.. code-block:: shell
+
+   export NCCL_DISABLE_CONTEXT_TRACKING=1

--- a/docs/how-to/rccl-usage-tips.rst
+++ b/docs/how-to/rccl-usage-tips.rst
@@ -262,4 +262,4 @@ To disable context tracking for Radeon GPUs, set the following environment varia
 
 .. code-block:: shell
 
-   export NCCL_DISABLE_CONTEXT_TRACKING=1
+   export RCCL_DISABLE_CONTEXT_TRACKING=1

--- a/docs/how-to/rccl-usage-tips.rst
+++ b/docs/how-to/rccl-usage-tips.rst
@@ -257,7 +257,7 @@ single OAM peaks at ~315 GB/s.
 
 Context tracking on Radeon GPUs
 ----------------------------------------
-Context tracking disabled for MI series for better performance, but keeps enabled for Radeon GPUs.
+Context tracking is disabled on the AMD Instinct™ series of GPUs for better performance but is enabled for Radeon GPUs.
 To disable context tracking for Radeon GPUs, set the following environment variable:
 
 .. code-block:: shell

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -68,6 +68,8 @@ inline ncclResult_t getRandomData(void* buffer, size_t bytes) {
   return ret;
 }
 
+bool ncclNeedEnableContextTrack(int cuDeviceId);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 template<typename Int>

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -68,7 +68,7 @@ inline ncclResult_t getRandomData(void* buffer, size_t bytes) {
   return ret;
 }
 
-bool ncclNeedEnableContextTrack(int cuDeviceId);
+bool rcclNeedEnableContextTrack(int cuDeviceId);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/init.cc
+++ b/src/init.cc
@@ -532,7 +532,7 @@ static ncclResult_t commFree(ncclComm_t comm) {
   NCCLCHECK(ncclNetFinalize(comm));
   // Disable until we validate NCCL_LAUNCH_IMPLICIT_ORDER support.
   // but enable for Radeon due to big impact on performance
-  if (ncclNeedEnableContextTrack(comm->cudaDev)) {
+  if (rcclNeedEnableContextTrack(comm->cudaDev)) {
     ncclCudaContextDrop(comm->context);
     INFO(NCCL_INIT, "cudaDev %d context tracking destroyed", comm->cudaDev);
   }
@@ -633,7 +633,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
 
   // Disable until we validate NCCL_LAUNCH_IMPLICIT_ORDER support.
   // but enable for Radeon due to big impact on performance
-  if (ncclNeedEnableContextTrack(comm->cudaDev)) {
+  if (rcclNeedEnableContextTrack(comm->cudaDev)) {
     NCCLCHECK(ncclCudaContextTrack(&comm->context));
     INFO(NCCL_INIT, "cudaDev %d context tracking created", comm->cudaDev);
   }

--- a/src/init.cc
+++ b/src/init.cc
@@ -531,7 +531,12 @@ static ncclResult_t commFree(ncclComm_t comm) {
   NCCLCHECK(ncclProfilerPluginFinalize(comm));
   NCCLCHECK(ncclNetFinalize(comm));
   // Disable until we validate NCCL_LAUNCH_IMPLICIT_ORDER support.
-  //ncclCudaContextDrop(comm->context);
+  // but enable for Radeon due to big impact on performance
+  if (ncclNeedEnableContextTrack(comm->cudaDev)) {
+    ncclCudaContextDrop(comm->context);
+    INFO(NCCL_INIT, "cudaDev %d context tracking destroyed", comm->cudaDev);
+  }
+
   free(comm);
 
   return ncclSuccess;
@@ -627,7 +632,11 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   CUDACHECK(cudaGetDevice(&comm->cudaDev));
 
   // Disable until we validate NCCL_LAUNCH_IMPLICIT_ORDER support.
-  //NCCLCHECK(ncclCudaContextTrack(&comm->context));
+  // but enable for Radeon due to big impact on performance
+  if (ncclNeedEnableContextTrack(comm->cudaDev)) {
+    NCCLCHECK(ncclCudaContextTrack(&comm->context));
+    INFO(NCCL_INIT, "cudaDev %d context tracking created", comm->cudaDev);
+  }
 
   NCCLCHECK(getBusId(comm->cudaDev, &comm->busId));
   char busId[]="0000:00:00.0";

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -4,10 +4,11 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#include "archinfo.h"
-#include "core.h"
-#include "nvmlwrap.h"
 #include "utils.h"
+#include "core.h"
+
+#include "nvmlwrap.h"
+#include "archinfo.h"
 
 #include <unistd.h>
 #include <stdlib.h>
@@ -193,7 +194,7 @@ bool matchIfList(const char* string, int port, struct netIf* ifList, int listSiz
 }
 
 RCCL_PARAM(DisableContextTracking, "DISABLE_CONTEXT_TRACKING", 0);
-bool ncclNeedEnableContextTrack(int cuDeviceId) {
+bool rcclNeedEnableContextTrack(int cuDeviceId) {
   hipDeviceProp_t devProp;
   if (rcclParamDisableContextTracking() == 1)
     return false;

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -194,6 +194,9 @@ bool matchIfList(const char* string, int port, struct netIf* ifList, int listSiz
 
 bool ncclNeedEnableContextTrack(int cuDeviceId) {
   hipDeviceProp_t devProp;
+  const char* disableContextTracking = ncclGetEnv("NCCL_DISABLE_CONTEXT_TRACKING");
+  if (disableContextTracking && atoi(disableContextTracking) == 1)
+    return false;
   if (hipGetDeviceProperties(&devProp, cuDeviceId) != 0)
     return false;
   return IsArchMatch(devProp.gcnArchName,"gfx11")

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -192,10 +192,10 @@ bool matchIfList(const char* string, int port, struct netIf* ifList, int listSiz
   return false;
 }
 
+RCCL_PARAM(DisableContextTracking, "DISABLE_CONTEXT_TRACKING", 0);
 bool ncclNeedEnableContextTrack(int cuDeviceId) {
   hipDeviceProp_t devProp;
-  const char* disableContextTracking = ncclGetEnv("NCCL_DISABLE_CONTEXT_TRACKING");
-  if (disableContextTracking && atoi(disableContextTracking) == 1)
+  if (rcclParamDisableContextTracking() == 1)
     return false;
   if (hipGetDeviceProperties(&devProp, cuDeviceId) != 0)
     return false;

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -4,10 +4,11 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#include "utils.h"
+#include "archinfo.h"
 #include "core.h"
-
 #include "nvmlwrap.h"
+#include "utils.h"
+
 #include <unistd.h>
 #include <stdlib.h>
 
@@ -189,6 +190,15 @@ bool matchIfList(const char* string, int port, struct netIf* ifList, int listSiz
     }
   }
   return false;
+}
+
+bool ncclNeedEnableContextTrack(int cuDeviceId) {
+  hipDeviceProp_t devProp;
+  if (hipGetDeviceProperties(&devProp, cuDeviceId) != 0)
+    return false;
+  return IsArchMatch(devProp.gcnArchName,"gfx11")
+         || IsArchMatch(devProp.gcnArchName,"gfx12")
+         || IsArchMatch(devProp.gcnArchName,"gfx10");
 }
 
 __thread struct ncclThreadSignal ncclThreadSignalLocalInstance = ncclThreadSignalStaticInitializer();


### PR DESCRIPTION
Revert  original commit 6fc228e2  `Disable context tracking for the current version. (#1839)`  for Radeon due to performance degradation for e2e workload, e.g. : 
* resnet50 training - 5%
* Llama-3.2-1B inference - up to 17%

In the PR introduced util function for checking should we enable context tracking or not.

Issues: 
SWDEV-550527
SWDEV-551679
SWDEV-552896
SWDEV-553739

