### PR TITLE
Enable inlining of LLGenericOp and disable 128-bit store

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1145,8 +1145,6 @@ target_compile_options(rccl PRIVATE -Wno-format-nonliteral)
 target_compile_options(rccl PRIVATE -Wno-unused-function)
 target_compile_options(rccl PRIVATE -fgpu-rdc)
 
-target_compile_options(rccl PRIVATE -gline-tables-only)
-
 ## Set RCCL compile and linker options for unit tests and code coverage
 if(ENABLE_CODE_COVERAGE)
   if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1145,6 +1145,8 @@ target_compile_options(rccl PRIVATE -Wno-format-nonliteral)
 target_compile_options(rccl PRIVATE -Wno-unused-function)
 target_compile_options(rccl PRIVATE -fgpu-rdc)
 
+target_compile_options(rccl PRIVATE -gline-tables-only)
+
 ## Set RCCL compile and linker options for unit tests and code coverage
 if(ENABLE_CODE_COVERAGE)
   if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")

--- a/src/device/prims_ll.h
+++ b/src/device/prims_ll.h
@@ -261,7 +261,7 @@ private:
 
   __device__ void storeLL(union ncclLLFifoLine* dst, uint64_t val, uint32_t flag) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-#if (defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY))
+#if 0 //(defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY))
     using Vec = uint32_t __attribute__((ext_vector_type(4)));
     Vec i4;
     i4[0] = val & 0xffffffff;
@@ -269,6 +269,7 @@ private:
     i4[2] = (val >> 32);
     i4[3] = flag;
     asm volatile ("flat_store_dwordx4 %0, %1 sc0 sc1 nt" :: "v"(dst), "v"(i4));
+    __builtin_amdgcn_s_waitcnt(0);
 #else
     union ncclLLFifoLine i4;
     i4.data1 = val & 0xffffffff;
@@ -432,11 +433,7 @@ private:
   }
 
   template <int RECV, int SEND, int SrcBuf, int DstBuf>
-#if defined(__gfx950__)
-  __device__ __attribute__((noinline)) void LLGenericOp(intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp) {
-#else
   __device__ void LLGenericOp(intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp) {
-#endif
     constexpr int SRC = SrcBuf != -1 ? 1 : 0;
     constexpr int DST = DstBuf != -1 ? 1 : 0;
     T *srcElts = SrcBuf == -1 ? nullptr : userBufs[SrcBuf] + srcIx;


### PR DESCRIPTION
Enable inlining of LLGenericOp. Revert to 2x64-bit stores.

## Details
This improves performance vs. the non-inlined version.

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Removed noinline attribute and reverted store.

**Why were the changes made?**  
Improve performance

**How was the outcome achieved?**  

**Additional Documentation:**  

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
