### PR TITLE
Moved new functions to the bottom of the function table to maintain backward compatibility

### DIFF
--- a/src/include/api_trace.h
+++ b/src/include/api_trace.h
@@ -168,6 +168,7 @@ typedef ncclResult_t (*ncclCommWindowDeregister_fn_t)(ncclComm_t comm, ncclWindo
 
 typedef struct rcclApiFuncTable
 {
+    // ADD NEW FUNCTIONS AT BOTTOM ONLY
     uint64_t                      size;
     ncclAllGather_fn_t            ncclAllGather_fn;
     ncclAllReduce_fn_t            ncclAllReduce_fn;
@@ -192,7 +193,6 @@ typedef struct rcclApiFuncTable
     ncclCommFinalize_fn_t         ncclCommFinalize_fn;
     ncclCommDestroy_fn_t          ncclCommDestroy_fn;
     ncclCommAbort_fn_t            ncclCommAbort_fn;
-    ncclCommShrink_fn_t           ncclCommShrink_fn;
     ncclCommSplit_fn_t            ncclCommSplit_fn;
     ncclGetErrorString_fn_t       ncclGetErrorString_fn;
     ncclGetLastError_fn_t         ncclGetLastError_fn;
@@ -207,10 +207,11 @@ typedef struct rcclApiFuncTable
     mscclUnloadAlgo_fn_t          mscclUnloadAlgo_fn;
     ncclCommRegister_fn_t         ncclCommRegister_fn;
     ncclCommDeregister_fn_t       ncclCommDeregister_fn;
+    ncclAllReduceWithBias_fn_t    ncclAllReduceWithBias_fn;
+    ncclCommShrink_fn_t           ncclCommShrink_fn;
     ncclCommWindowRegister_fn_t   ncclCommWindowRegister_fn;
     ncclCommWindowDeregister_fn_t ncclCommWindowDeregister_fn;
-    ncclAllReduceWithBias_fn_t    ncclAllReduceWithBias_fn;
-
+    // ADD NEW FUNCTIONS HERE ONLY
 } rcclApiFuncTable;
 
 RCCL_EXTERN_C_FINI

--- a/src/misc/api_trace.cc
+++ b/src/misc/api_trace.cc
@@ -189,6 +189,7 @@ compute_table_size(size_t nmembers)
     static_assert(offsetof(TABLE, MEMBER) == compute_table_offset(IDX),                  \
                   "Do not re-arrange the table members")
 
+// DO NOT REORDER, ADD NEW ITEMS TO BOTTOM
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclAllGather_fn, 0);
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclAllReduce_fn, 1);
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclAllToAll_fn, 2);
@@ -212,24 +213,25 @@ RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommInitRankConfig_fn, 19);
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommFinalize_fn, 20);
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommDestroy_fn, 21);
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommAbort_fn, 22);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommShrink_fn, 23);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommSplit_fn, 24);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclGetErrorString_fn, 25);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclGetLastError_fn, 26);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommGetAsyncError_fn, 27);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommCount_fn, 28);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommCuDevice_fn, 29);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommUserRank_fn, 30);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclMemAlloc_fn, 31);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclMemFree_fn, 32);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, mscclLoadAlgo_fn, 33);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, mscclRunAlgo_fn, 34);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, mscclUnloadAlgo_fn, 35);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommRegister_fn, 36);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommDeregister_fn, 37);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommWindowRegister_fn, 38);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommWindowDeregister_fn, 39);
-RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclAllReduceWithBias_fn, 40);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommSplit_fn, 23);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclGetErrorString_fn, 24);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclGetLastError_fn, 25);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommGetAsyncError_fn, 26);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommCount_fn, 27);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommCuDevice_fn, 28);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommUserRank_fn, 29);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclMemAlloc_fn, 30);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclMemFree_fn, 31);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, mscclLoadAlgo_fn, 32);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, mscclRunAlgo_fn, 33);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, mscclUnloadAlgo_fn, 34);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommRegister_fn, 35);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommDeregister_fn, 36);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclAllReduceWithBias_fn, 37);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommShrink_fn, 38);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommWindowRegister_fn, 39);
+RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclCommWindowDeregister_fn, 40);
+// DO NOT REORDER, ADD NEW ITEMS HERE
 
 #undef RCCL_ASSERT_OFFSET
 
@@ -267,7 +269,6 @@ RcclGetFunctionTable_impl()
                                                &ncclCommFinalize_impl,
                                                &ncclCommDestroy_impl,
                                                &ncclCommAbort_impl,
-                                               &ncclCommShrink_impl,
                                                &ncclCommSplit_impl,
                                                &ncclGetErrorString_impl,
                                                &ncclGetLastError_impl,
@@ -282,9 +283,12 @@ RcclGetFunctionTable_impl()
                                                &mscclUnloadAlgo_impl,
                                                &ncclCommRegister_impl,
                                                &ncclCommDeregister_impl,
+                                               &ncclAllReduceWithBias_impl,
+                                               &ncclCommShrink_impl,
                                                &ncclCommWindowRegister_impl,
-                                               &ncclCommWindowDeregister_impl,
-                                               &ncclAllReduceWithBias_impl };
+                                               &ncclCommWindowDeregister_impl
+                                               // DO NOT REORDER, ADD NEW ITEMS HERE
+                                             };
 
 #if defined(RCCL_ROCPROFILER_REGISTER) && RCCL_ROCPROFILER_REGISTER > 0
     std::array<void*, 1>                       table_array{ tbl };


### PR DESCRIPTION
## Details

**Work item:** _"Internal"_

**What were the changes?**  
Moved new functions to the bottom of the function table 

**Why were the changes made?**  
to maintain backward compatibility

**Additional Documentation:**  
These functions added as part of 2.27.3

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
