### PR TITLE
Fix hang on MI350 for both cached and uncached memory

### DIFF
--- a/src/device/prims_ll.h
+++ b/src/device/prims_ll.h
@@ -261,15 +261,6 @@ private:
 
   __device__ void storeLL(union ncclLLFifoLine* dst, uint64_t val, uint32_t flag) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-#if (defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY))
-    using Vec = uint32_t __attribute__((ext_vector_type(4)));
-    Vec i4;
-    i4[0] = val & 0xffffffff;
-    i4[1] = flag;
-    i4[2] = (val >> 32);
-    i4[3] = flag;
-    asm volatile ("flat_store_dwordx4 %0, %1 sc0 sc1 nt" :: "v"(dst), "v"(i4));
-#else
     union ncclLLFifoLine i4;
     i4.data1 = val & 0xffffffff;
     i4.flag1 = flag;
@@ -277,6 +268,8 @@ private:
     i4.flag2 = flag;
     __builtin_nontemporal_store(i4.v[0], dst->v);
     __builtin_nontemporal_store(i4.v[1], dst->v+1);
+#if defined(__gfx950__)
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, ""); // flush cache
 #endif
 #else
     asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(&dst->i4), "r"((uint32_t)val), "r"(flag), "r"((uint32_t)(val >> 32)), "r"(flag) : "memory");
@@ -351,6 +344,9 @@ private:
       __builtin_nontemporal_store(u4, (uint32_t*)dst);
     else
       __builtin_nontemporal_store(u8, (uint64_t*)dst);
+#if defined(__gfx950__)
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, ""); // flush cache
+#endif
 #else
     if(sizeof(U) == 1)
       asm volatile("st.volatile.global.b8 [%0],%1;" :: "l"(dst), "r"(u4) : "memory");
@@ -432,11 +428,7 @@ private:
   }
 
   template <int RECV, int SEND, int SrcBuf, int DstBuf>
-#if defined(__gfx950__)
-  __device__ __attribute__((noinline)) void LLGenericOp(intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp) {
-#else
   __device__ void LLGenericOp(intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp) {
-#endif
     constexpr int SRC = SrcBuf != -1 ? 1 : 0;
     constexpr int DST = DstBuf != -1 ? 1 : 0;
     T *srcElts = SrcBuf == -1 ? nullptr : userBufs[SrcBuf] + srcIx;


### PR DESCRIPTION
## Details
- add missing fences, this fixes the hangs, they aren't needed if pages are UC
- remove asm store_dwordx4, not needed since compiler fuses adjacent stores

**Work item:** 
Internal

**What were the changes?**  
Described above

_One sentence describing the work done._
Fixed the hang on MI350

**Why were the changes made?**  
There was a persistent hanging problem when inlining LLGenericOp in prims_ll.h. This was thought to be a compiler problem. In fact, it turned out that there were missing memory fences so stores were not globally visible.

**How was the outcome achieved?**  
Two calls to __builtin_amdgcn_fence(__ATOMIC_RELEASE, "") cause the GPU cache to be flushed to system scope and makes the stores visible to the external reader. The inline asm store was not needed since the compiler fuses two adjacent calls to __buitin_nonterminal_store into a single flat_store_dwordx4 ..

**Additional Documentation:**  
The performance vs. the old non-inlined code seems to have improved by about 30%, but extensive benchmarking on MI350 still needs to be done, and the code has not been tested on MI300. When UC memory is properly deployed in ROCr for MI350, the two fences can be removed, for a modest performance improvement.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
 No such changes were made.
