### PR TITLE
[rocprofiler-sdk] Add codeowner for `api-trace.h`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,5 @@ docs/ @ROCm/rocm-documentation
 *.md @ROCm/rocm-documentation
 *.rst @ROCm/rocm-documentation
 .readthedocs.yaml @ROCm/rocm-documentation
+
+src/include/api_trace.h @mythreyak


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___
Add codeowner for `api_trace.h` for rocprofiler-sdk

**What were the changes?**  

Update codeowners file

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

There were API breaks in the `api_trace.h` header which took a few CI jobs to be detected in `rocprofiler-sdk` CI. We can add CI checks to automate this, but as a first step, getting notified when this header changes will help us track updates closer to the source. 

**How was the outcome achieved?**  

No functional change. Codeowner file requests a review when the file changes. 

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
