### PR TITLE
[Tools/Replayer] Fix prohibited calls during capture mode

### DIFF
--- a/tools/RcclReplayer/rcclReplayer.cpp
+++ b/tools/RcclReplayer/rcclReplayer.cpp
@@ -270,7 +270,7 @@ void Replayer::replay()
         graphLife[call.graphID].counter--;
         if (graphLife[call.graphID].starts.contains(lineNum))
         {
-          HIP_CALL(hipStreamBeginCapture(streams[call.stream].first, hipStreamCaptureModeGlobal));
+          HIP_CALL(hipStreamBeginCapture(streams[call.stream].first, hipStreamCaptureModeRelaxed));
           printf("[INFO    ] Rank %d - Line %d : starting capture graph %llu\n", myRank, lineNum, call.graphID);
         } else if (graphLife[call.graphID].stream != call.stream) {
           printf("[WARNING ] \x1b[31mRank %d - Line %d : multi-stream graph may not replay original dependency accurately\x1b[0m\n", myRank, lineNum);
@@ -560,7 +560,9 @@ cleanup:
     }
     if (call.stream && lineNum == streams[call.stream].second)
     {
-      HIP_CALL(hipStreamSynchronize(streams[call.stream].first)); // ?
+      if (call.graphCaptured != 1) {
+        HIP_CALL(hipStreamSynchronize(streams[call.stream].first)); // ?
+      }
       HIP_CALL(hipStreamDestroy(streams[call.stream].first));
     }
     lineNum++; // change for a2av


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._
* Do graph captures in relaxed mode.
* Do not allow prohibited calls in graph capture mode.

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._
Replayer does not work with ROCm > 7.0 in capture mode.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
