### PR TITLE
Adding a barrier feature to highlight delays from preceding kernels in RCCL calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,6 +444,7 @@ set(SRC_FILES
   src/transport.cc
   src/device/all_gather.h
   src/device/all_reduce.h
+  src/device/barrier.h
   src/device/alltoall_pivot.h
   src/device/broadcast.h
   src/device/common.h

--- a/src/device/barrier.h
+++ b/src/device/barrier.h
@@ -1,0 +1,168 @@
+/*************************************************************************
+ * Copyright (c) 2015-2022, NVIDIA CORPORATION. All rights reserved.
+ * Modifications Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "device.h"
+#include "collectives.h"
+#include "primitives.h"
+
+__device__ __attribute__((noinline)) void  copyShmemData(struct ncclDevComm* comm, struct channelMasks channelMask, struct ncclDevKernelArgs const* args){
+  const int tid = threadIdx.x;
+  int tn = blockDim.x;
+  int x = tid;
+  int total = 0, y;
+  int num = MAXCHANNELS/64 > 0 ? MAXCHANNELS/64 : 1;
+
+  // Copy kernel args to shmem and then only read those. Otherwise the compiler
+  // will end up putting the args into thread local stack which is very wasteful.
+  if (tid < sizeof(ncclDevKernelArgs)/sizeof(uint32_t)) {
+    ((uint32_t*)&ncclShmem.args)[tid] = ((uint32_t*)args)[tid];
+  }
+
+  // To map blockId to channelId, we need the n'th set bit of channelMask which
+  // is the inverse of counting the number of set bits among the the first n.
+  // PTX has the fns instruction which does this but is extremely slow. We can
+  // do better when we know all threads are querying the same bitmask.
+  switch (tid/WARP_SIZE) {
+  case 0:
+  //ncclShmem.channelId = blockIdx.x;
+    for (int i = 0; i < num; i++) {
+      if (channelMask.masks[i] & (1ull<<x)) {
+        y = __popcll(channelMask.masks[i] & ((1ull<<x)-1));
+        y = total + y;
+        if (blockIdx.x == y) {
+          ncclShmem.channelId = x + total;
+          break;
+        }
+      }
+      if (WARP_SIZE < 64) {
+        x = WARP_SIZE + tid;
+        if (channelMask.masks[i] & (1ull<<x)) {
+          y = __popcll(channelMask.masks[i] & ((1ull<<x)-1));
+          y = y + total;
+          if (blockIdx.x == y) {
+            ncclShmem.channelId = x + total;
+            break;
+          }
+        }
+      }
+      total = total + __popcll(channelMask.masks[i]);
+    }
+    break;
+  case 1:
+    if (tid < WARP_SIZE + NCCL_MAX_GROUPS) {
+      if (tid == WARP_SIZE) ncclShmem.barrier_pat = 0;
+      ncclShmem.groups[tid-WARP_SIZE].barrier = 0;
+    }
+    break;
+  case 2:
+#ifdef ENABLE_FAULT_INJECTION
+    /* load faults injection before first sync threads */
+    if (tid == 2*WARP_SIZE) ncclShmem.faults = comm->faults;
+#endif
+    break;
+  case 3:
+    /* set abort flag to 0 */
+    if (tid == 3*WARP_SIZE) ncclShmem.aborted = 0;
+    break;
+  default:
+    break;
+  }
+
+  __syncthreads(); // publish ncclShmem.{args, channelId}
+
+  /* set abort flag to 0 */
+  if (tid == 0) {
+    ncclShmem.aborted = 0;
+    ncclShmem.channel.workCounter = comm->channels[ncclShmem.channelId].workCounter;
+  }
+
+  // Use first 2 warps to load comm and channel, and remaining load work batch.
+  switch (tid/WARP_SIZE) {
+  case 0:
+    { void* dst = &ncclShmem.comm;
+      void* src = comm;
+      int bytes = sizeof(ncclDevComm);
+      static_assert(sizeof(ncclDevComm) <= 16*WARP_SIZE, "ncclDevComm cannot be loaded by a single warp in one insn.");
+      copyToShmem16(tid, dst, src, bytes);
+    } break;
+  case 1:
+    { // Get address of channel without incurring indirect load from ncclDevComm::channels
+      void* dst = &ncclShmem.channel;
+      void* src = &((ncclDevCommAndChannels*)comm)->channels[ncclShmem.channelId];
+      int bytes = sizeof(ncclDevChannel);
+      static_assert(sizeof(ncclDevChannel) <= 16*WARP_SIZE, "ncclDevChannel cannot be loaded by a single warp in one insn.");
+      copyToShmem16(tid-WARP_SIZE, dst, src, bytes);
+    } break;
+  default:
+    { int subtid = tid - 2*WARP_SIZE;
+      int subtn = tn - 2*WARP_SIZE;
+      // Coverity reports a possible thread divergence due to not all threads participating in the collective.
+      // However, the code ensures that the participation is on a per-warp basis.
+      // coverity[device_thread_diverged:FALSE]
+      //loadWorkBatchToShmem(subtid, subtn, args, /*batchIx=*/blockIdx.x);
+    } break;
+  }
+  __syncthreads();
+}
+
+
+
+namespace {
+  template<typename T>
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+#else
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+#endif
+
+ncclRing *ring = &ncclShmem.channel.ring;
+const int nranks = ncclShmem.comm.nRanks;
+const int rank = ncclShmem.comm.rank;
+
+const int prevRank = ring->userRanks[nranks-1];
+const int root = work->root;
+const size_t chunkCount = 4096;
+const size_t channelCount = 1;
+const size_t gridOffset = 0;
+size_t offset;
+int nelem;
+Primitives<uint8_t, FuncSum<uint8_t>, FanSymmetric<1>, 0, ProtoLL, 0>
+  prims(tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, 0, 0, 0, 0);
+
+if (prevRank == root) {
+  //printf("1111 prevRank = %d, rank = %d, root = %d channelCount = %zu, chunkCount = %zu\n", prevRank, rank, root, channelCount, chunkCount);
+  for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+    offset = gridOffset + elemOffset;
+    nelem = min(chunkCount, channelCount - elemOffset);
+    prims.send(offset, nelem);
+  }
+}
+else if (rank == root) {
+  //printf("2222 prevRank = %d, rank = %d, root = %d channelCount = %zu, chunkCount = %zu\n", prevRank, rank, root, channelCount, chunkCount);
+  for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+    offset = gridOffset + elemOffset;
+    nelem = min(chunkCount, channelCount - elemOffset);
+    prims.recvReduceCopy(offset, offset, nelem, /*postOp=*/true);
+  }
+}
+else {
+  for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+    offset = gridOffset + elemOffset;
+    nelem = min(chunkCount, channelCount - elemOffset);
+    prims.recvReduceSend(offset, nelem);
+  }
+}
+}
+}
+
+__global__ __attribute__((noinline)) void rcclWaitForAllRanksBarrier(struct ncclDevComm* comm, struct channelMasks channelMask, struct ncclDevWorkColl* work,  struct ncclDevKernelArgs const* args)
+{
+  copyShmemData(comm, channelMask, args);
+  int tid = threadIdx.x;
+  int nthreads = blockDim.x;
+  runRing<uint8_t>(tid, nthreads, work);
+}

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -27,6 +27,7 @@
 #include <cstring> // std::memcpy
 #include <cinttypes> // PRIx64
 #include <cassert>
+#include "barrier.h"
 #include "latency_profiler/CollTraceFunc.h"
 
 using namespace rccl;
@@ -1726,6 +1727,7 @@ NCCL_PARAM(MemSyncDomain, "MEM_SYNC_DOMAIN", cudaLaunchMemSyncDomainRemote);
 #endif
 
 NCCL_PARAM(NvlinkUtilCentricSchedEnable, "NVLINK_UTIL_CENTRIC_SCHED_ENABLE", 0);
+RCCL_PARAM_DECLARE(InsertBarrier);
 
 ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan) {
   ncclResult_t ret = ncclSuccess;
@@ -1740,8 +1742,14 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
   cudaStream_t launchStream = planner->streams->stream;
   void* extra[] = {plan->kernelArgs, &plan->kernelArgsSize};
 
+  if(rcclParamInsertBarrier() == 1)
+  {
+    void* temp_args[] = { &comm->devComm, &plan->channelMask, &comm->barrierWork, plan->kernelArgs, &plan->kernelArgsSize};
+    CUDACHECK(hipExtLaunchKernel((const void*)rcclWaitForAllRanksBarrier, grid, block, temp_args, 0, launchStream, NULL, comm->doneEvent, 0));
+  }
   auto event = latency_profiler::collTraceAquireEventBaseline(plan, launchStream);
   if (planner->numStreams == 1 && !plan->persistent) {
+
     latency_profiler::collTraceRecordStartEvent(comm, launchStream, event.get());
     comm->lastStream = planner->streams->stream;
     CUDACHECKGOTO(hipExtLaunchKernel(plan->kernelFn, grid, block, extra, 0, launchStream, NULL, comm->doneEvent, 0), ret, do_return);

--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -677,6 +677,12 @@ struct ncclComm {
   bool mscclppForceEnable;
 #endif
 
+  //#ifdef ENABLE_BARRIER
+  void* barrierSendBuffer;
+  void* barrierRecvBuffer;
+  ncclDevWorkColl* barrierWork;
+//#endif
+
   // Whether this comm is compatible with MSCCL
   bool mscclCompatible;
   // group job to support multi-thread FT

--- a/src/init.cc
+++ b/src/init.cc
@@ -596,6 +596,8 @@ exit:
 }
 
 RCCL_PARAM(InjectFaults, "INJECT_FAULTS", 0);
+RCCL_PARAM_DECLARE(InsertBarrier);
+RCCL_PARAM(InsertBarrier, "INSERT_BARRIER", 0);
 
 static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, int ndev, int rank) {
   if (ndev < 1) {
@@ -666,6 +668,19 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
       comm->collTraceThread = 0;
   }
 #endif
+  if (rcclParamInsertBarrier() == 1) {
+    NCCLCHECK(ncclCudaHostCalloc(&comm->barrierSendBuffer, 4 * comm->nRanks ));
+    NCCLCHECK(ncclCudaHostCalloc(&comm->barrierRecvBuffer, 4 * comm->nRanks));
+    NCCLCHECK(ncclCudaHostCalloc(&comm->barrierWork, sizeof(ncclDevWorkColl)));
+    comm->barrierWork->sendbuff = (void*)comm->barrierSendBuffer;
+    comm->barrierWork->recvbuff = (void*)comm->barrierRecvBuffer;
+    comm->barrierWork->channelLo = 1;
+    comm->barrierWork->channelHi = 1;
+    comm->barrierWork->cbd.countLo = 1;
+    comm->barrierWork->cbd.countHi = 1;
+    comm->barrierWork->root = 0;
+  }
+
 
   if (rcclParamInjectFaults() != 0) {
 #ifdef ENABLE_FAULT_INJECTION


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:**LWPCOMMLIBS-519

**What were the changes?**  
This commit implements a barrier to expose delays introduced by the preceding kernel. Currently supported only on single-node setups.
Barrier can be enabled with `RCCL_INSERT_BARRIER=1`

**Why were the changes made?**  
Captures delays caused by preceding kernels, which manifest in NCCL calls.

**How was the outcome achieved?**  


**Additional Documentation:**  


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
