### PR TITLE
[Cherry-Pick] LL protocol: Fix hang on MI350 for both cached and uncached memory

### DIFF
--- a/src/device/prims_ll.h
+++ b/src/device/prims_ll.h
@@ -267,7 +267,7 @@ private:
     i4.flag2 = flag;
     __builtin_nontemporal_store(i4.v[0], dst->v);
     __builtin_nontemporal_store(i4.v[1], dst->v+1);
-#if defined(__gfx950__)
+#if defined(__gfx950__) && ROCM_VERSION < 70200
     __builtin_amdgcn_fence(__ATOMIC_RELEASE, ""); // flush cache
 #endif
 #else
@@ -343,7 +343,7 @@ private:
       __builtin_nontemporal_store(u4, (uint32_t*)dst);
     else
       __builtin_nontemporal_store(u8, (uint64_t*)dst);
-#if defined(__gfx950__)
+#if defined(__gfx950__) && ROCM_VERSION < 70200
     __builtin_amdgcn_fence(__ATOMIC_RELEASE, ""); // flush cache
 #endif
 #else

--- a/src/device/prims_ll.h
+++ b/src/device/prims_ll.h
@@ -260,15 +260,6 @@ private:
 
   __device__ void storeLL(union ncclLLFifoLine* dst, uint64_t val, uint32_t flag) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-#if (defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY))
-    using Vec = uint32_t __attribute__((ext_vector_type(4)));
-    Vec i4;
-    i4[0] = val & 0xffffffff;
-    i4[1] = flag;
-    i4[2] = (val >> 32);
-    i4[3] = flag;
-    asm volatile ("flat_store_dwordx4 %0, %1 sc0 sc1 nt" :: "v"(dst), "v"(i4));
-#else
     union ncclLLFifoLine i4;
     i4.data1 = val & 0xffffffff;
     i4.flag1 = flag;
@@ -276,6 +267,8 @@ private:
     i4.flag2 = flag;
     __builtin_nontemporal_store(i4.v[0], dst->v);
     __builtin_nontemporal_store(i4.v[1], dst->v+1);
+#if defined(__gfx950__)
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, ""); // flush cache
 #endif
 #else
     asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(&dst->i4), "r"((uint32_t)val), "r"(flag), "r"((uint32_t)(val >> 32)), "r"(flag) : "memory");
@@ -350,6 +343,9 @@ private:
       __builtin_nontemporal_store(u4, (uint32_t*)dst);
     else
       __builtin_nontemporal_store(u8, (uint64_t*)dst);
+#if defined(__gfx950__)
+    __builtin_amdgcn_fence(__ATOMIC_RELEASE, ""); // flush cache
+#endif
 #else
     if(sizeof(U) == 1)
       asm volatile("st.volatile.global.b8 [%0],%1;" :: "l"(dst), "r"(u4) : "memory");
@@ -431,11 +427,7 @@ private:
   }
 
   template <int RECV, int SEND, int SrcBuf, int DstBuf>
-#if defined(__gfx950__)
-  __device__ __attribute__((noinline)) void LLGenericOp(intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp) {
-#else
   __device__ void LLGenericOp(intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp) {
-#endif
     constexpr int SRC = SrcBuf != -1 ? 1 : 0;
     constexpr int DST = DstBuf != -1 ? 1 : 0;
     T *srcElts = SrcBuf == -1 ? nullptr : userBufs[SrcBuf] + srcIx;


### PR DESCRIPTION
## Details

**Work item:**
Internal (SWDEV-553136)
Cherry-pick https://github.com/ROCm/rccl/commit/cb14fccdccacb7598192d886dc639ba94791ea70 and https://github.com/ROCm/rccl/commit/45166f6586c91b08298afa1ab13a6ea267bcca59

**What were the changes?**  
- add missing fences, this fixes the hangs, they aren't needed if pages are UC
- remove asm store_dwordx4, not needed since compiler fuses adjacent stores
- add check for ROCr version

**Why were the changes made?**  
- The performance of inlined LL vs. the old non-inlined LL code improves by about 30% on MI350 for small messages.
- With the UC memory fix in ROCr for MI350 (SWDEV-555866), the two fences can be removed for a modest performance improvement. This is acheived with a ROCm version check for 7.0.2.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
