### PR TITLE
Adding usage tip for ignore cpu affinity

### DIFF
--- a/docs/how-to/rccl-usage-tips.rst
+++ b/docs/how-to/rccl-usage-tips.rst
@@ -85,8 +85,8 @@ proper large BAR addressing support.
 Ignoring CPU affinity with multi-node
 =====================================
 
-Depending on the job launcher and the requirements of your workload, performance as communication scales
-can be improved by setting ``NCCL_IGNORE_CPU_AFFINITY`` which allows the RCCL communication library to 
+Depending on the job launcher and the requirements of your workload, performance as the communication workload scales
+can be improved by setting ``NCCL_IGNORE_CPU_AFFINITY``.  This allows the RCCL communication library to 
 ignore the job's supplied CPU affinity and use the GPU affinity only.
 
 .. code-block:: shell

--- a/docs/how-to/rccl-usage-tips.rst
+++ b/docs/how-to/rccl-usage-tips.rst
@@ -93,7 +93,7 @@ ignore the job's supplied CPU affinity and use the GPU affinity only.
 
    NCCL_IGNORE_CPU_AFFINITY=1
 
-For the general case, this environment variable is not set so as to not interfere with the user or launcher
+For general usage, this environment variable is not set so it doesn't interfere with the user or launcher
 supplied preferences.
 
 Improving performance on the MI300X 

--- a/docs/how-to/rccl-usage-tips.rst
+++ b/docs/how-to/rccl-usage-tips.rst
@@ -82,6 +82,20 @@ set the HSA environment variable as follows:
 This feature requires GPUs that support peer-to-peer access along with
 proper large BAR addressing support.
 
+Ignoring CPU affinity with multi-node
+=====================================
+
+Depending on the job launcher and the requirements of your workload, performance as communication scales
+can be improved by setting ``NCCL_IGNORE_CPU_AFFINITY`` which allows the RCCL communication library to 
+ignore the job's supplied CPU affinity and use the GPU affinity only.
+
+.. code-block:: shell
+
+   NCCL_IGNORE_CPU_AFFINITY=1
+
+For the general case, this environment variable is not set so as to not interfere with the user or launcher
+supplied preferences.
+
 Improving performance on the MI300X 
 ===================================
 


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
https://ontrack-internal.amd.com/browse/LWPCLPAT-559

**What were the changes?**  
_One sentence describing the work done._
Added recommendation for setting NCCL_IGNORE_CPU_AFFINITY for multi-node in usage tips

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._
It has been observed that NCCL_IGNORE_CPU_AFFINITY=1 improves performance over baseline 
OpenMPI-5 on multi-node scales

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._
Comparison of performance between OpenMPI-4 and OpenMPI-5 with NCCL_IGNORE_CPU_AFFINITY on / off

**Additional Documentation:**  
_What else should the reviewer know?_
Only documentation was added with no change to the default setting or no code modifications

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
