### PR TITLE
Change to use -O0 instead of -O1 in debug build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -886,6 +886,15 @@ foreach(file ${GENERATED_FILES})
   list(APPEND HIP_SOURCES ${file})
 endforeach()
 
+# Apply -O1 optimization for generated files in debug builds
+# This is needed for device object to not go over the stacksize limit at link time while allowing
+# -O0 for host code in debug build.
+if(CMAKE_BUILD_TYPE MATCHES "Debug" AND NOT DEFINED ENV{CXXFLAGS})
+  message(STATUS "Setting -O1 optimization for device code in ${GEN_DIR} (Debug build)")
+  set_source_files_properties(${GENERATED_FILES} PROPERTIES COMPILE_OPTIONS "-O1")
+endif()
+
+
 # Create an initial git_version.cpp file (that will be updated with latest git version)
 #==================================================================================================
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp "")

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -13,7 +13,7 @@ else()
 endif()
 
 if (NOT DEFINED ENV{CXXFLAGS})
-  set(CMAKE_CXX_FLAGS_DEBUG "-g -O1")
+  set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
   set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 endif()
 
@@ -24,6 +24,6 @@ else()
 endif()
 
 if (NOT DEFINED ENV{CFLAGS})
-  set(CMAKE_C_FLAGS_DEBUG "-g -O1")
+  set(CMAKE_C_FLAGS_DEBUG "-g -O0")
   set(CMAKE_C_FLAGS_RELEASE "-O3")
 endif()


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** SWDEV-556961

**What were the changes?**  
Using -O0 for debug build.

**Why were the changes made?**  
-O1 still does compiler optimization.

**How was the outcome achieved?**  
Change cmake config.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
