### PR TITLE
gx950 multi-node tuning for LL/LL128

### DIFF
--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -396,9 +396,9 @@ static struct tuningModel tuning_model_6 {
   // Follow order in RcclTunableColls
   .llProtoRanges = {
     /*ReduceScatter*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 131071, 1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {131071, 4194304, 1, 64}},
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 131072, 1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {131072, 4194304, 1, 64}},
     /*AllGather*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 7,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {7, 8388608, 1, 64}},
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 4096,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {4096, 8388608, 1, 64}},
     /*AllReduce*/
     {/*LL (min/max/factor/thread_threshold)*/ {0, 262144, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {131071, 17660227, 3145728, 0}},
     /*Reduce*/

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -400,7 +400,7 @@ static struct tuningModel tuning_model_6 {
     /*AllGather*/
     {/*LL (min/max/factor/thread_threshold)*/ {0, 7,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {7, 8388608, 1, 64}},
     /*AllReduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 131071, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {131071, 17660227, 3145728, 0}},
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 262144, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {131071, 17660227, 3145728, 0}},
     /*Reduce*/
     {/*LL (min/max/factor/thread_threshold)*/ {0, 16383, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {16383, 16777216, 1, 0}},
     /*Broadcast*/

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -398,9 +398,9 @@ static struct tuningModel tuning_model_6 {
     /*ReduceScatter*/
     {/*LL (min/max/factor/thread_threshold)*/ {0, 131072, 1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {131072, 4194304, 1, 64}},
     /*AllGather*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 4096,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {4096, 8388608, 1, 64}},
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 4095,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {4095, 8388608, 1, 64}},
     /*AllReduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 262144, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {131071, 17660227, 3145728, 0}},
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 262144, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {262144, 17660227, 3145728, 0}},
     /*Reduce*/
     {/*LL (min/max/factor/thread_threshold)*/ {0, 16383, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {16383, 16777216, 1, 0}},
     /*Broadcast*/

--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -396,9 +396,9 @@ static struct tuningModel tuning_model_6 {
   // Follow order in RcclTunableColls
   .llProtoRanges = {
     /*ReduceScatter*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 131072, 1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {131072, 4194304, 1, 64}},
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 65536, 1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {65536, 4194304, 1, 64}},
     /*AllGather*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 4095,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {4095, 8388608, 1, 64}},
+    {/*LL (min/max/factor/thread_threshold)*/ {0, 32768,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {32768, 8388608, 1, 64}},
     /*AllReduce*/
     {/*LL (min/max/factor/thread_threshold)*/ {0, 262144, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {262144, 17660227, 3145728, 0}},
     /*Reduce*/


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
AllReduce: increased LL max threshold to boost performance on 128KB and 256KB
AllGather: increased LL max threshold to 4095 bytes per rank
ReduceScatter: increased LL max threshold to 131072 bytes per rank

**Why were the changes made?**  
LL performance was lower than LL128 on several message sizes.
However, a recent LL inline fix restored performance for LL protocol.
As such, protocol selection requires re-tuning.

**How was the outcome achieved?**  
Updated min/max LL/LL128 thresholds in tuning model.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
