### PR TITLE
Enable Presubmit CI Gating for develop Branch (TheRock CI for RCCL)

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -1,12 +1,14 @@
 name: TheRock CI for rccl
 
 on:
-  pull_request:
-    branches:
-      - develop
   push:
     branches:
       - develop
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - synchronize
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -1,6 +1,9 @@
 name: TheRock CI for rccl
 
 on:
+  pull_request:
+    branches:
+      - develop
   push:
     branches:
       - develop


### PR DESCRIPTION
Description

This PR enables TheRock CI for RCCL to automatically run on all pull requests targeting the develop branch. The goal is to introduce presubmit gating, preventing direct merges into develop until all CI jobs pass successfully.

Key Highlights

Adds presubmit CI trigger (pull_request → develop).

Reuses existing postsubmit CI (push → develop) for regression validation.

Includes therock-ci-linux matrix builds for:

RCCL and RCCL-tests integration.

Single-node tests on gfx942.

Multi-node tests on gfx950 (via Slurm cluster).

Impact

Once this PR is merged and configured as a required status check, no PR can be merged into develop unless all TheRock CI for RCCL jobs complete successfully.

Next Steps

Add branch protection rules on develop to require this workflow’s success.