### PR TITLE
Enabling gdrcopy option for gfx950

### DIFF
--- a/src/include/gdrwrap.h
+++ b/src/include/gdrwrap.h
@@ -169,7 +169,8 @@ static gdr_t ncclGdrInit() {
     return NULL;
   }
   GcnArchNameFormat(devProp.gcnArchName, gcnArchNameSubstr);
-  if (IsArchMatch(gcnArchNameSubstr, "gfx942")) {
+  if (IsArchMatch(gcnArchNameSubstr, "gfx942") ||
+      IsArchMatch(gcnArchNameSubstr, "gfx950")) {
     INFO(NCCL_INIT, "Enabled GDRCopy equivalent memory allocation on %s", gcnArchNameSubstr);
     return (gdr_t)0x12345678L;
   } else {


### PR DESCRIPTION
## Details
Enabling gdrcopy for gfx950.
Currently setting NCCL_GDRCOPY_ENABLE=1 will only active the gdrcopy path for gfx942.
This code enables NCCL_GDRCOPY_ENABLE=1 to be active for gfx950 as well

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Added gfx950 to gdrcopy initialization filter

**Why were the changes made?**  
Investigate gdrcopy performance for gfx950

**How was the outcome achieved?**  
One line code addition

**Additional Documentation:**  
This is an opt-in feature that user still needs to enable by setting NCCL_GDRCOPY_ENABLE=1

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
