### PR TITLE
[CI] Enable ccache w/ namespace for external use

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: aa315ec2801ff6772a6c9ca6799669395630c45c
+          ref: 9234082d384106960800fb658f4fe8602e5d6c7d
 
       - name: Checkout rccl repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 16ee54fb580a4dde62dc4133f978e73370a545af
+          ref: aa315ec2801ff6772a6c9ca6799669395630c45c
 
       - name: Checkout rccl repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -52,20 +52,10 @@ jobs:
             --config-preset "github-oss-presubmit" \
             --dir "$(dirname $CCACHE_CONFIGPATH)" \
             --local-path "$CACHE_DIR/ccache"
-          echo "namespace = ext_rccl" >> $CCACHE_CONFIGPATH
-          echo "[*] ccache_config contents:"
-          cat $CCACHE_CONFIGPATH
 
-      - name: Runner Health Settings
+      - name: Runner health status
         run: |
-          df -h
-          echo cmake --version
-          echo "Installed Python versions:"
-          ls -d /opt/python
-          echo "python: $(which python), python3: $(which python3)"
-          echo "Git version: $(git --version)"
-          git config --global --add safe.directory $PWD
-          git config fetch.parallel 10
+          ./build_tools/health_status.py
 
       - name: Fetch sources
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Install python deps
         run: |
           pip install -r requirements.txt
-          pip freeze
 
       # safe.directory must be set before Runner Health Status
       - name: Adjust git config

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -24,6 +24,9 @@ jobs:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       TEATIME_FORCE_INTERACTIVE: 0
       AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      CACHE_DIR: ${{ github.workspace }}/.container-cache
+      # The ccache.conf will be written by setup_ccache.py before this gets used.
+      CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
     steps:
       - name: Checkout TheRock repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -42,6 +45,16 @@ jobs:
         with:
           repository: "ROCm/rccl-tests"
           path: rccl-tests
+
+      - name: Setup ccache
+        run: |
+          ./TheRock/build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+          echo "namespace = ext_rccl" >> $CCACHE_CONFIGPATH
+          echo "[*] ccache_config contents:"
+          cat $CCACHE_CONFIGPATH
 
       - name: Runner Health Settings
         run: |
@@ -90,6 +103,10 @@ jobs:
           echo "Artifacts:"
           echo "----------"
           du -h -d 1 build/artifacts
+          echo "CCache Stats:"
+          echo "-------------"
+          ccache -s -v
+          tail -v -n +1 .ccache/compiler_check_cache/* > build/logs/ccache_compiler_check_cache.log
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -46,6 +46,11 @@ jobs:
           repository: "ROCm/rccl-tests"
           path: rccl-tests
 
+      - name: Install python deps
+        run: |
+          pip install -r requirements.txt
+          pip freeze
+
       # safe.directory must be set before Runner Health Status
       - name: Adjust git config
         run: |
@@ -66,11 +71,6 @@ jobs:
       - name: Fetch sources
         run: |
           ./build_tools/fetch_sources.py --jobs 12
-
-      - name: Install python deps
-        run: |
-          pip install -r requirements.txt
-          pip freeze
 
       - name: Configure Projects
         env:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 9234082d384106960800fb658f4fe8602e5d6c7d
+          ref: aa315ec2801ff6772a6c9ca6799669395630c45c
 
       - name: Checkout rccl repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -45,6 +45,12 @@ jobs:
         with:
           repository: "ROCm/rccl-tests"
           path: rccl-tests
+
+      # safe.directory must be set before Runner Health Status
+      - name: Adjust git config
+        run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
 
       - name: Setup ccache
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Setup ccache
         run: |
-          ./TheRock/build_tools/setup_ccache.py \
+          ./build_tools/setup_ccache.py \
             --config-preset "github-oss-presubmit" \
             --dir "$(dirname $CCACHE_CONFIGPATH)" \
             --local-path "$CACHE_DIR/ccache"


### PR DESCRIPTION
Currently, no build cache is being used and is causing each null build to take an exceedingly long time. This will enable caching like [TheRock](https://github.com/ROCm/TheRock/blob/2d9ca43c2140c5d35e4105c811bd23dbd6420c94/.github/workflows/build_portable_linux_artifacts.yml#L69-L74) repo.