### PR TITLE
Revert disabling of context tracking for Radeon (#1927)

### DIFF
--- a/docs/how-to/rccl-usage-tips.rst
+++ b/docs/how-to/rccl-usage-tips.rst
@@ -254,3 +254,12 @@ set during the benchmark in the following manner:
 The default allreduce PyTorch benchmark peak bus bandwidth performance is
 ~170 GB/s on a single OAM with ROCm 6.2.4, while the optimized run for CPX on a
 single OAM peaks at ~315 GB/s.
+
+Context tracking on Radeon GPUs
+----------------------------------------
+Context tracking is disabled on the AMD Instinct™ series of GPUs for better performance but is enabled for Radeon GPUs.
+To disable context tracking for Radeon GPUs, set the following environment variable:
+
+.. code-block:: shell
+
+   export RCCL_DISABLE_CONTEXT_TRACKING=1

--- a/docs/how-to/rccl-usage-tips.rst
+++ b/docs/how-to/rccl-usage-tips.rst
@@ -255,11 +255,11 @@ The default allreduce PyTorch benchmark peak bus bandwidth performance is
 ~170 GB/s on a single OAM with ROCm 6.2.4, while the optimized run for CPX on a
 single OAM peaks at ~315 GB/s.
 
-Context tracking on Radeon GPUs
+Context tracking on GPUs
 ----------------------------------------
-Context tracking is disabled on the AMD Instinct™ series of GPUs for better performance but is enabled for Radeon GPUs.
-To disable context tracking for Radeon GPUs, set the following environment variable:
+Context tracking is disabled by default for optimal performance. However, enabling of context tracking can significantly improve performance
+in certain scenarios. To enable context tracking, set the following environment variable:
 
 .. code-block:: shell
 
-   export RCCL_DISABLE_CONTEXT_TRACKING=1
+   export RCCL_ENABLE_CONTEXT_TRACKING=1

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -68,8 +68,6 @@ inline ncclResult_t getRandomData(void* buffer, size_t bytes) {
   return ret;
 }
 
-bool rcclNeedEnableContextTrack(int cuDeviceId);
-
 ////////////////////////////////////////////////////////////////////////////////
 
 template<typename Int>

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -68,6 +68,8 @@ inline ncclResult_t getRandomData(void* buffer, size_t bytes) {
   return ret;
 }
 
+bool rcclNeedEnableContextTrack(int cuDeviceId);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 template<typename Int>

--- a/src/init.cc
+++ b/src/init.cc
@@ -531,7 +531,12 @@ static ncclResult_t commFree(ncclComm_t comm) {
   NCCLCHECK(ncclProfilerPluginFinalize(comm));
   NCCLCHECK(ncclNetFinalize(comm));
   // Disable until we validate NCCL_LAUNCH_IMPLICIT_ORDER support.
-  //ncclCudaContextDrop(comm->context);
+  // but enable for Radeon due to big impact on performance
+  if (rcclNeedEnableContextTrack(comm->cudaDev)) {
+    ncclCudaContextDrop(comm->context);
+    INFO(NCCL_INIT, "cudaDev %d context tracking destroyed", comm->cudaDev);
+  }
+
   free(comm);
 
   return ncclSuccess;
@@ -627,7 +632,11 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   CUDACHECK(cudaGetDevice(&comm->cudaDev));
 
   // Disable until we validate NCCL_LAUNCH_IMPLICIT_ORDER support.
-  //NCCLCHECK(ncclCudaContextTrack(&comm->context));
+  // but enable for Radeon due to big impact on performance
+  if (rcclNeedEnableContextTrack(comm->cudaDev)) {
+    NCCLCHECK(ncclCudaContextTrack(&comm->context));
+    INFO(NCCL_INIT, "cudaDev %d context tracking created", comm->cudaDev);
+  }
 
   NCCLCHECK(getBusId(comm->cudaDev, &comm->busId));
   char busId[]="0000:00:00.0";

--- a/src/init.cc
+++ b/src/init.cc
@@ -245,6 +245,7 @@ RCCL_PARAM(EnableProxyTrace, "ENABLE_PROXY_TRACE", 0);
 
 RCCL_PARAM(KernelCollTraceEnable, "KERNEL_COLL_TRACE_ENABLE", 0);
 RCCL_PARAM(KernelCollTraceThreadEnable, "KERNEL_COLL_TRACE_THREAD_ENABLE", 0);
+RCCL_PARAM(EnableContextTracking, "ENABLE_CONTEXT_TRACKING", 0);
 
 #ifdef ENABLE_COLLTRACE
 // Should be in sync with 'ALL_COLLS' in Generator.cmake
@@ -531,8 +532,8 @@ static ncclResult_t commFree(ncclComm_t comm) {
   NCCLCHECK(ncclProfilerPluginFinalize(comm));
   NCCLCHECK(ncclNetFinalize(comm));
   // Disable until we validate NCCL_LAUNCH_IMPLICIT_ORDER support.
-  // but enable for Radeon due to big impact on performance
-  if (rcclNeedEnableContextTrack(comm->cudaDev)) {
+  // but can be enabled via environment variable
+  if (rcclParamEnableContextTracking() == 1) {
     ncclCudaContextDrop(comm->context);
     INFO(NCCL_INIT, "cudaDev %d context tracking destroyed", comm->cudaDev);
   }
@@ -632,8 +633,8 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   CUDACHECK(cudaGetDevice(&comm->cudaDev));
 
   // Disable until we validate NCCL_LAUNCH_IMPLICIT_ORDER support.
-  // but enable for Radeon due to big impact on performance
-  if (rcclNeedEnableContextTrack(comm->cudaDev)) {
+  // but can be enabled via environment variable
+  if (rcclParamEnableContextTracking() == 1) {
     NCCLCHECK(ncclCudaContextTrack(&comm->context));
     INFO(NCCL_INIT, "cudaDev %d context tracking created", comm->cudaDev);
   }

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -8,7 +8,6 @@
 #include "core.h"
 
 #include "nvmlwrap.h"
-#include "archinfo.h"
 
 #include <unistd.h>
 #include <stdlib.h>
@@ -191,18 +190,6 @@ bool matchIfList(const char* string, int port, struct netIf* ifList, int listSiz
     }
   }
   return false;
-}
-
-RCCL_PARAM(DisableContextTracking, "DISABLE_CONTEXT_TRACKING", 0);
-bool rcclNeedEnableContextTrack(int cuDeviceId) {
-  hipDeviceProp_t devProp;
-  if (rcclParamDisableContextTracking() == 1)
-    return false;
-  if (hipGetDeviceProperties(&devProp, cuDeviceId) != 0)
-    return false;
-  return IsArchMatch(devProp.gcnArchName,"gfx11")
-         || IsArchMatch(devProp.gcnArchName,"gfx12")
-         || IsArchMatch(devProp.gcnArchName,"gfx10");
 }
 
 __thread struct ncclThreadSignal ncclThreadSignalLocalInstance = ncclThreadSignalStaticInitializer();

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -8,6 +8,8 @@
 #include "core.h"
 
 #include "nvmlwrap.h"
+#include "archinfo.h"
+
 #include <unistd.h>
 #include <stdlib.h>
 
@@ -189,6 +191,18 @@ bool matchIfList(const char* string, int port, struct netIf* ifList, int listSiz
     }
   }
   return false;
+}
+
+RCCL_PARAM(DisableContextTracking, "DISABLE_CONTEXT_TRACKING", 0);
+bool rcclNeedEnableContextTrack(int cuDeviceId) {
+  hipDeviceProp_t devProp;
+  if (rcclParamDisableContextTracking() == 1)
+    return false;
+  if (hipGetDeviceProperties(&devProp, cuDeviceId) != 0)
+    return false;
+  return IsArchMatch(devProp.gcnArchName,"gfx11")
+         || IsArchMatch(devProp.gcnArchName,"gfx12")
+         || IsArchMatch(devProp.gcnArchName,"gfx10");
 }
 
 __thread struct ncclThreadSignal ncclThreadSignalLocalInstance = ncclThreadSignalStaticInitializer();


### PR DESCRIPTION
Cherry-pick of #1927 for ROCm 7.1 and reverted logic of enabling:
Context tracking is disabled by default for both (CDNA and RDNA) and can be enabled via `RCCL_ENABLE_CONTEXT_TRACKING=1`

* Revert disabling of context tracking for Radeon

Original commit 6fc228e2
 `Disable context tracking for the current version. (#1839)`

* Add env variable for disabling of context tracking for Radeon

~`export NCCL_DISABLE_CONTEXT_TRACKING=1` to force disable of context tracking~

* Update docs/how-to/rccl-usage-tips.rst

Fix grammar, thanks @amd-jnovotny



~* Rename NCCL_DISABLE_CONTEXT_TRACKING -> RCCL_DISABLE_CONTEXT_TRACKING~

* Revert changes in includes and rename util function

---------

(cherry picked from commit 07925ec027404198d9264cfefaf3a074595d376c)

Reverse logic is merged into `develop` branch -> https://github.com/ROCm/rccl/pull/1971
