### PR TITLE
Missing ROCm 7.0 & 7.1.0 Changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * The MSCCL++ feature is now disabled by default. The `--disable-mscclpp` build flag is replaced with `--enable-mscclpp` in the `rccl/install.sh` script.
 * Compatibility with NCCL 2.27.7
 
-### Optimizations
+### Optimized
 * Improve small message performance for alltoall by enabling and optimizing batched P2P operations.
 
 ### Known issues
@@ -55,7 +55,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Compatibility with NCCL 2.25.1
 * Compatibility with NCCL 2.26.6
 
-### Optimizations
+### Optimized
 * Improved the performance of the `FP8` Sum operation by upcasting to `FP16`.
 
 ### Known Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Compatibility with NCCL 2.27.7
 
 ### Optimized
-* Improve small message performance for alltoall by enabling and optimizing batched P2P operations.
+* Enabled and optimized batched P2P operations to improve small message performance for AllToAll and AllGather.
+* Optimized channel count selection to improve efficiency for small to medium message sizes in ReduceScatter.
+* Changed code inlining to improve latency for small message sizes for AllReduce, AllGather, and ReduceScatter.
 
 ### Known issues
 * Symmetric memory kernels are currently disabled due to ongoing CUMEM enablement work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,9 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 * The MSCCL++ feature is now disabled by default. The `--disable-mscclpp` build flag is replaced with `--enable-mscclpp` in the `rccl/install.sh` script.
 * Compatibility with NCCL 2.27.7
-* Improved the performance of the `FP8` Sum operation by upcasting to `FP16`.
 
-### Resolved issues
+### Optimizations
 * Improve small message performance for alltoall by enabling and optimizing batched P2P operations.
-* Fixed broken functionality within the LL protocol on gfx950 by disabling inlining of LLGenericOp kernels.
 
 ### Known issues
 * Symmetric memory kernels are currently disabled due to ongoing CUMEM enablement work.
@@ -33,6 +31,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Fixed unit test failures in tests ending with `ManagedMem` and `ManagedMemGraph` suffixes.
 * Suboptimal algorithmic switching point for AllReduce on MI300x.
 * Fixed the known issue "When splitting a communicator using `ncclCommSplit` in some GPU configurations, MSCCL initialization can cause a segmentation fault." with a design change to use `comm` instead of `rank` for `mscclStatus`. The Global map for `comm` to `mscclStatus` is still not thread safe but should be explicitly handled by mutexes for read writes. This is tested for correctness, but there is a plan to use a thread-safe map data structure in upcoming changes.
+* Fixed broken functionality within the LL protocol on gfx950 by disabling inlining of LLGenericOp kernels.
 
 ### Added
 
@@ -55,6 +54,12 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Compatibility with NCCL 2.24.3
 * Compatibility with NCCL 2.25.1
 * Compatibility with NCCL 2.26.6
+
+### Optimizations
+* Improved the performance of the `FP8` Sum operation by upcasting to `FP16`.
+
+### Known Issues
+* When running this version of RCCL using ROCm versions earlier than 6.4.0, the user must set the environment flag `HSA_NO_SCRATCH_RECLAIM=1`.
 
 ## RCCL 2.22.3 for ROCm 6.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 Full documentation for RCCL is available at [https://rccl.readthedocs.io](https://rccl.readthedocs.io)
 
-## Unreleased - RCCL 2.27.7 for ROCm 7.1.0
+## Unreleased - RCCL 2.27.7 for ROCm 7.1.1
+
+
+## RCCL 2.27.7 for ROCm 7.1.0
 
 ### Added
 * Added `RCCL_P2P_BATCH_THRESHOLD` to set the message size limit for batching P2P operations. This mainly affects small message performance for alltoall at a large scale but also applies to alltoallv.
@@ -12,9 +15,11 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 * The MSCCL++ feature is now disabled by default. The `--disable-mscclpp` build flag is replaced with `--enable-mscclpp` in the `rccl/install.sh` script.
 * Compatibility with NCCL 2.27.7
+* Improved performance of FP8 Sum operation by upcasting to FP16.
 
 ### Resolved issues
-* Improve small message performance for alltoall by enabling and optimizing batched P2P operations. 
+* Improve small message performance for alltoall by enabling and optimizing batched P2P operations.
+* Fixed broken functionality within LL protocol on gfx950 by disabling inlining of LLGenericOp kernels.
 
 ### Known issues
 * Symmetric memory kernels are currently disabled due to ongoing CUMEM enablement work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 ### Known issues
 * Symmetric memory kernels are currently disabled due to ongoing CUMEM enablement work.
+* When running this version of RCCL using ROCm versions earlier than 6.4.0, the user must set the environment flag `HSA_NO_SCRATCH_RECLAIM=1`.
 
 ## RCCL 2.26.6 for ROCm 7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 * The MSCCL++ feature is now disabled by default. The `--disable-mscclpp` build flag is replaced with `--enable-mscclpp` in the `rccl/install.sh` script.
 * Compatibility with NCCL 2.27.7
-* Improved performance of FP8 Sum operation by upcasting to FP16.
+* Improved the performance of the `FP8` Sum operation by upcasting to `FP16`.
 
 ### Resolved issues
 * Improve small message performance for alltoall by enabling and optimizing batched P2P operations.
-* Fixed broken functionality within LL protocol on gfx950 by disabling inlining of LLGenericOp kernels.
+* Fixed broken functionality within the LL protocol on gfx950 by disabling inlining of LLGenericOp kernels.
 
 ### Known issues
 * Symmetric memory kernels are currently disabled due to ongoing CUMEM enablement work.


### PR DESCRIPTION
Added missing items to 7.1.0 changelog, stubbed in 7.1.1 section.