### PR TITLE
Disable graph mode memory registration and UBR as unsupported feature.

### DIFF
--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -319,7 +319,7 @@ static void finishPlan(struct ncclComm* comm, struct ncclKernelPlan* plan) {
   }
 }
 
-NCCL_PARAM(GraphRegister, "GRAPH_REGISTER", 1);
+NCCL_PARAM(GraphRegister, "GRAPH_REGISTER", 0); // LWPCOMMLIBS-632: off by default for RCCL as unsupported feature.
 
 static ncclResult_t getCollNetSupport(struct ncclComm* comm, struct ncclTaskColl* task, int* collNetSupport);
 rccl_static ncclResult_t getAlgoInfo(

--- a/src/register/register.cc
+++ b/src/register/register.cc
@@ -18,7 +18,7 @@
 
 using namespace rccl;
 
-NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 1);
+NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 0); // LWPCOMMLIBS-632: off by default for RCCL as unsupported feature.
 
 static ncclResult_t regFindHandleFromSymAddr(struct ncclComm* comm, void* baseSymPtr, struct ncclReg** handle) {
   struct ncclRegCache* cache = &comm->regCache;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** LWPCOMMLIBS-632

**What were the changes?**  
Disable graph mode memory registration and UBR for p2p

**Why were the changes made?**  
The feature is currently unsupported and need to be turned off by default.

**How was the outcome achieved?**  
Changing default environment variable value.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
