### PR TITLE
Fix git version fetching logic.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -889,16 +889,19 @@ endforeach()
 
 # Create an initial git_version.cpp file (that will be updated with latest git version)
 #==================================================================================================
+# Create initial empty file at configure time
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp "")
-list(APPEND HIP_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp)
 
-# Create a custom target that updates git_version.cpp and executes whenever rccl is built
-add_custom_target(git_version_check
-  COMMENT "Updating git_version.cpp if necessary"
-  COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/scripts/git_version.cmake
+# Add a custom target that always runs at build time to update git version
+add_custom_target(update_git_version
+  ALL
+  COMMAND ${CMAKE_COMMAND} -DRCCL_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR} -DRCCL_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/scripts/git_version.cmake
+  BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp
+  COMMENT "Updating git version information"
   VERBATIM
 )
 
+list(APPEND HIP_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp)
 
 # Set up RCCL library
 #==================================================================================================
@@ -906,7 +909,8 @@ add_custom_target(git_version_check
 add_library(rccl ${HIP_SOURCES})
 
 ## Set RCCL dependencies
-add_dependencies(rccl git_version_check)                                      # Execute git_version_check during build
+## Ensure git version is updated before building rccl
+add_dependencies(rccl update_git_version)
 
 if (BUILD_TESTS AND ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
   ## Set static replacement dependency for fixture unit tests

--- a/cmake/scripts/git_version.cmake
+++ b/cmake/scripts/git_version.cmake
@@ -19,8 +19,16 @@
 # SOFTWARE.
 
 # Attempt to collect the latest git hash
-set(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+# Use RCCL_SOURCE_DIR if passed, otherwise fallback to CMAKE_CURRENT_SOURCE_DIR
+if(NOT DEFINED RCCL_SOURCE_DIR)
+  set(RCCL_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+if(NOT DEFINED RCCL_BINARY_DIR)
+  set(RCCL_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
 execute_process(COMMAND git log --pretty=format:'%h' -n 1
+                WORKING_DIRECTORY ${RCCL_SOURCE_DIR}
                 OUTPUT_VARIABLE GIT_REV
                 ERROR_QUIET)
 
@@ -31,10 +39,12 @@ else()
   # Check for changes (denote with a '+') after hash
   execute_process(
     COMMAND bash -c "git diff --quiet --exit-code || echo +"
+    WORKING_DIRECTORY ${RCCL_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_DIFF)
   # Collect branch information
   execute_process(
     COMMAND git rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY ${RCCL_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_BRANCH)
 
   string(STRIP "${GIT_REV}" GIT_REV)
@@ -46,18 +56,18 @@ else()
 endif()
 
 # Compare file with older git version file (git_version.cpp)
-if (EXISTS ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp)
-  #MESSAGE(STATUS "Found ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp")
-  file(READ ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp PREV_GIT_VERSION)
+if (EXISTS ${RCCL_BINARY_DIR}/git_version.cpp)
+  #MESSAGE(STATUS "Found ${RCCL_BINARY_DIR}/git_version.cpp")
+  file(READ ${RCCL_BINARY_DIR}/git_version.cpp PREV_GIT_VERSION)
   #message(STATUS "CURR GIT version: ${CURR_GIT_VERSION}")
   #message(STATUS "PREV GIT version: ${PREV_GIT_VERSION}")
   if (NOT "${CURR_GIT_VERSION}" STREQUAL "${PREV_GIT_VERSION}")
     message(STATUS "Updating git_version.cpp")
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp "${CURR_GIT_VERSION}")
+    file(WRITE ${RCCL_BINARY_DIR}/git_version.cpp "${CURR_GIT_VERSION}")
   else()
     message(STATUS "No changes to git_version.cpp required")
   endif()
 else()
   # Create git_version.cpp if it doesn't exist yet
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/git_version.cpp "${CURR_GIT_VERSION}")
+  file(WRITE ${RCCL_BINARY_DIR}/git_version.cpp "${CURR_GIT_VERSION}")
 endif()


### PR DESCRIPTION
## Details
Fix a bug where if the build directory is not RCCL source directory, the version info printout will be the git information of current build directory instead, as seen in mainline builds. We are currently taking git hash of CQE build script, resulting in mismatch and difficulties in debugging issues.

This has been attempted in #1910  but that is not sufficient.

**What were the changes?**  
Change CMake script to pass actual source directory and use git info from that directory.

**Why were the changes made?**  
Wrong version printout in staging/mainline/release build.

**How was the outcome achieved?**  
CMake passing directory as parameter.

Tested with custom cmake build directory and it prints correct version info:
```
RCCL version : 2.27.7-bugfix/git_version:7e287c5
HIP version  : 7.0.51831-a3e329ad8
ROCm version : 7.0.1.0-42-9428210
Hostname     : banff-pla-r27-14
Librccl path : /nfs/users/apatinya/build/librccl.so.1
```

## Approval Checklist
___Do not approve until these items are satisfied.___
- [x] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
