### PR TITLE
Add <chrono> to rccl_prim_test

### DIFF
--- a/tools/rccl-prim-test/rccl_prim_test.cpp
+++ b/tools/rccl-prim-test/rccl_prim_test.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <iostream> //cerr
 #include <unistd.h> //usleep
 #include <cstring>
+#include <chrono>
 #include <hip/hip_runtime_api.h>
 #include <hip/hip_runtime.h>
 #include "copy_kernel.h"


### PR DESCRIPTION
Added missing header <chrono> in rccl_prim_test.cpp to fix compilation error
