### PR TITLE
Fix segmentation fault related to ext-profiler plugin

### DIFF
--- a/ext-profiler/example/event.h
+++ b/ext-profiler/example/event.h
@@ -12,7 +12,7 @@
 #include <unistd.h>
 #include "profiler.h"
 
-#define MAX_CHANNELS                     32
+#define MAX_CHANNELS                     128 // Match RCCL's MAXCHANNELS
 #define MAX_STEPS                        16
 #define MAX_OPS                          16 // Up to 64K ranks for PAT
 #define MAX_EVENTS_PER_REQ               (8)


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal"_

**What were the changes?**  
Increased `MAX_CHANNELS` from `32` to `128` to prevent segmentation faults during **Multi Node** detailed profiling.

**Why were the changes made?**  
The profiler plugin `librccl-profiler.so` crashes with a segmentation fault when detailed profiling `NCCL_PROFILE_EVENT_MASK=31` or higher is enabled during multi-node collective runs.

The root cause was a hardcoded `MAX_CHANNELS` limit of `32`, which was insufficient for RCCL's usage of up to 128 channels.

**How was the outcome achieved?**  
The crash occurs in the below line of code in `plugin.c`, for `channelId > 31`
```
line 335: struct proxyOp* event = &parent->op[channelId][parent->nProxyOps[channelId]++];
```

To fix this, `MAX_CHANNELS` was updated to `128`, aligning it with RCCL’s `MAXCHANNELS` definition from `src/include/device.h`.

**Additional Documentation:**  
Affected benchmarks
- all_reduce_perf
- broadcast_perf
- reduce_perf
- all_gather_perf - Failed for `NCCL_PROFILE_EVENT_MASK=255` (Include complete profiling)
- reduce_scatter_perf

Verified fix on 2 MI300X nodes.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
