### PR TITLE
Removed RCCL_EXPOSE_STATIC duplicate definition.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -760,8 +760,6 @@ add_custom_target(hipify_all DEPENDS ${HIP_SOURCES})
 
 if (BUILD_TESTS)
   if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
-    ## Set definition for exposing rccl static function
-    add_definitions(-DRCCL_EXPOSE_STATIC)
 
     set(HIPIFY_SRC_DIR "${PROJECT_BINARY_DIR}/hipify/src")
     set(REPLACE_SCRIPT "${CMAKE_SOURCE_DIR}/tools/scripts/replace_static.sh")


### PR DESCRIPTION
## Details
**Work item:** Internal

**What were the changes?**  
Fixed below warning:
```
rccl/build_debug_cov_on_tests_on/hipify/src/include/rccl_vars.h:30:9: warning: 'RCCL_EXPOSE_STATIC' macro redefined [-Wmacro-redefined]
   30 | #define RCCL_EXPOSE_STATIC // Expose needed static functions for rccl-tests (or unit-testing in future)
      |         ^
<command line>:10:9: note: previous definition is here
   10 | #define RCCL_EXPOSE_STATIC 1
      |         ^
```

**Why were the changes made?**  
Quality improvements.

**How was the outcome achieved?**  
Removed definition from CMakeLists.txt file since it is now enabled for all build types.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
