### PR TITLE
Add timeout duration for Slurm salloc reservations in CI

### DIFF
--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          salloc -N 4 -p meta64 --exclusive bash -c "
+          salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
           source /home/arravikum/TheRock/.venv/bin/activate &&
           cd /home/arravikum/cvs &&
           python input/setup.py &&


### PR DESCRIPTION
This PR introduces a reservation timeout for salloc allocations in CI workflows that use the Slurm cluster.
The -t (time limit) option ensures that allocated nodes are automatically released after a specified duration, even if CI runs become stalled or fail to release resources properly.

Example usage in CI:

salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "<job_command>"


This helps prevent long-running or failed jobs from holding onto nodes indefinitely, improving cluster resource availability and fairness for subsequent CI jobs or general use.