### PR TITLE
[Net plugin] Enable capping the number of QPs created for send/recv colls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 ## Unreleased - RCCL 2.27.7 for ROCm 7.1.0
 
 ### Added
+* Added `RCCL_IB_QPS_PER_P2P` to set the number of QPs per connection for P2P operations. When set (≥1), P2P operations (Send/Recv) use `RCCL_IB_QPS_PER_P2P`, while other collective operations continue to use `NCCL_IB_QPS_PER_CONNECTION`. When not set, `NCCL_IB_QPS_PER_CONNECTION` applies to all operations.
 * `RCCL_FORCE_ENABLE_DMABUF` added as a debugging feature if the user wants to explicitly enable DMABUF and forego system/kernel checks.
 * Added `RCCL_P2P_BATCH_THRESHOLD` to set the message size limit for batching P2P operations. This mainly affects small message performance for alltoall at a large scale but also applies to alltoallv.
 * Added `RCCL_P2P_BATCH_ENABLE` to enable batching P2P operations to receive performance gains for smaller messages up to 4MB for alltoall when the workload requires it. This is to avoid performance dips for larger messages.

--- a/src/include/net.h
+++ b/src/include/net.h
@@ -23,4 +23,14 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport);
 extern ncclNet_t ncclNetIb;
 extern ncclNet_t ncclNetSocket;
 
+// Optional weak symbol for transport-specific policy encoding.
+// If defined by the plugin (e.g., IB), core will call it with the handle and isP2p flag.
+#ifdef __cplusplus
+extern "C" {
+#endif
+void ncclIbNetEncodeP2pPolicy(void* handle, int isP2p) __attribute__((weak));
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/src/include/net.h
+++ b/src/include/net.h
@@ -23,8 +23,8 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport);
 extern ncclNet_t ncclNetIb;
 extern ncclNet_t ncclNetSocket;
 
-// Optional weak symbol for transport-specific policy encoding.
+// Optional function for transport-specific policy encoding.
 // If defined by the plugin (e.g., IB), core will call it with the handle and isP2p flag.
-int ncclNetEncodeP2pPolicy(void* handle, int isP2p) __attribute__((weak));
+extern int ncclNetEncodeP2pPolicy(void* handle, int isP2p);
 
 #endif

--- a/src/include/net.h
+++ b/src/include/net.h
@@ -25,12 +25,6 @@ extern ncclNet_t ncclNetSocket;
 
 // Optional weak symbol for transport-specific policy encoding.
 // If defined by the plugin (e.g., IB), core will call it with the handle and isP2p flag.
-#ifdef __cplusplus
-extern "C" {
-#endif
-void ncclIbNetEncodeP2pPolicy(void* handle, int isP2p) __attribute__((weak));
-#ifdef __cplusplus
-}
-#endif
+int ncclNetEncodeP2pPolicy(void* handle, int isP2p) __attribute__((weak));
 
 #endif

--- a/src/include/net.h
+++ b/src/include/net.h
@@ -23,6 +23,6 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport);
 extern ncclNet_t ncclNetIb;
 extern ncclNet_t ncclNetSocket;
 
-extern int rcclNetP2pPolicy(void* handle, int isP2p);
+extern ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p);
 
 #endif

--- a/src/include/net.h
+++ b/src/include/net.h
@@ -23,8 +23,6 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport);
 extern ncclNet_t ncclNetIb;
 extern ncclNet_t ncclNetSocket;
 
-// Optional function for transport-specific policy encoding.
-// If defined by the plugin (e.g., IB), core will call it with the handle and isP2p flag.
-extern int ncclNetEncodeP2pPolicy(void* handle, int isP2p);
+extern int rcclNetP2pPolicy(void* handle, int isP2p);
 
 #endif

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -774,6 +774,11 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   commConfig.trafficClass = req->trafficClass == NCCL_CONFIG_UNDEF_INT ? NCCL_NET_TRAFFIC_CLASS_UNDEF : req->trafficClass;
   NCCLCHECK(ncclNetGetDeviceHandle(resources->netDeviceType, resources->netDeviceVersion, false /*isRecv*/, &resources->netDeviceHandle));
   bool rccl_anp = !(strcmp(proxyState->ncclNet->name, RCCL_ANP_PLUGIN_STR));
+  // Call plugin-specific hook to encode P2P policy into handle
+  if (ncclIbNetEncodeP2pPolicy) {
+    // IB plugin provides strong symbol implementation
+    ncclIbNetEncodeP2pPolicy(req->handle, resources->isP2p);
+  }
   if (resources->shared) {
     // Shared buffers
     struct ncclProxyProgressState* progressState = &proxyState->progressState;

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -30,6 +30,11 @@
 static_assert(sizeof(ncclNetHandle_t) <= CONNECT_SIZE, "NET Connect info is too large");
 
 #define RCCL_ANP_PLUGIN_STR  "RCCL-ANP"
+// Default weak implementation - no-op if no plugin provides strong symbol
+__attribute__((weak))
+int ncclNetEncodeP2pPolicy(void* handle, int isP2p) {
+  return 0;  // Not handled
+}
 
 #define NCCL_NET_MAP_HOSTMEM 0
 #define NCCL_NET_MAP_DEVMEM 1
@@ -775,9 +780,9 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   NCCLCHECK(ncclNetGetDeviceHandle(resources->netDeviceType, resources->netDeviceVersion, false /*isRecv*/, &resources->netDeviceHandle));
   bool rccl_anp = !(strcmp(proxyState->ncclNet->name, RCCL_ANP_PLUGIN_STR));
   // Call plugin-specific hook to encode P2P policy into handle
-  if (ncclIbNetEncodeP2pPolicy) {
+  if (ncclNetEncodeP2pPolicy) {
     // IB plugin provides strong symbol implementation
-    ncclIbNetEncodeP2pPolicy(req->handle, resources->isP2p);
+    ncclNetEncodeP2pPolicy(req->handle, resources->isP2p);
   }
   if (resources->shared) {
     // Shared buffers

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -224,6 +224,7 @@ static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   req.connIndex = connIndex;
   req.curr_hdp_reg = 0;
   req.netDev = -1;
+  // Determine if this is a P2P connection or not based on the graph pointer
   if(graph == NULL) {
     req.isP2p = 1;
   } else {

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -776,7 +776,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   bool rccl_anp = !(strcmp(proxyState->ncclNet->name, RCCL_ANP_PLUGIN_STR));
   
   if (rcclNetP2pPolicy) {
-    rcclNetP2pPolicy(req->handle, resources->isP2p);
+    NCCLCHECK(rcclNetP2pPolicy(req->handle, resources->isP2p));
   }
   
   if (resources->shared) {

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -122,6 +122,7 @@ struct sendNetResources {
   ncclNetDeviceHandle_t* netDeviceHandle;
   size_t maxP2pBytes;
   volatile uint32_t* curr_hdp_reg;  // Curr GPU in ring (for rdma transport use only)
+  int isP2p;
 };
 
 struct recvNetResources {
@@ -194,6 +195,7 @@ struct setupReq {
   int channelId;
   int connIndex;
   uint32_t* curr_hdp_reg;
+  int isP2p;
 };
 
 NCCL_PARAM(NetOptionalRecvCompletion, "NET_OPTIONAL_RECV_COMPLETION", 1);
@@ -222,6 +224,11 @@ static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   req.connIndex = connIndex;
   req.curr_hdp_reg = 0;
   req.netDev = -1;
+  if(graph == NULL) {
+    req.isP2p = 1;
+  } else {
+    req.isP2p = 0;
+  }
 
   int proxyRank = myInfo->rank;
   int64_t netId;
@@ -672,6 +679,7 @@ static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struc
   resources->channelId = req->channelId;
   resources->connIndex = req->connIndex;
   resources->curr_hdp_reg = req->curr_hdp_reg;
+  resources->isP2p = req->isP2p;
   ncclNetProperties_t props;
   NCCLCHECK(proxyState->ncclNet->getProperties(req->netDev, &props));
   /* DMA-BUF support */

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -30,11 +30,6 @@
 static_assert(sizeof(ncclNetHandle_t) <= CONNECT_SIZE, "NET Connect info is too large");
 
 #define RCCL_ANP_PLUGIN_STR  "RCCL-ANP"
-// Default weak implementation - no-op if no plugin provides strong symbol
-__attribute__((weak))
-int ncclNetEncodeP2pPolicy(void* handle, int isP2p) {
-  return 0;  // Not handled
-}
 
 #define NCCL_NET_MAP_HOSTMEM 0
 #define NCCL_NET_MAP_DEVMEM 1
@@ -779,11 +774,12 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   commConfig.trafficClass = req->trafficClass == NCCL_CONFIG_UNDEF_INT ? NCCL_NET_TRAFFIC_CLASS_UNDEF : req->trafficClass;
   NCCLCHECK(ncclNetGetDeviceHandle(resources->netDeviceType, resources->netDeviceVersion, false /*isRecv*/, &resources->netDeviceHandle));
   bool rccl_anp = !(strcmp(proxyState->ncclNet->name, RCCL_ANP_PLUGIN_STR));
-  // Call plugin-specific hook to encode P2P policy into handle
+  // Call plugin-specific hook to encode P2P policy into handle before connect
   if (ncclNetEncodeP2pPolicy) {
-    // IB plugin provides strong symbol implementation
     ncclNetEncodeP2pPolicy(req->handle, resources->isP2p);
+    //printf("NET: sendProxyConnect called ncclNetEncodeP2pPolicy isP2p=%d\n", resources->isP2p);
   }
+  
   if (resources->shared) {
     // Shared buffers
     struct ncclProxyProgressState* progressState = &proxyState->progressState;

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -774,10 +774,9 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   commConfig.trafficClass = req->trafficClass == NCCL_CONFIG_UNDEF_INT ? NCCL_NET_TRAFFIC_CLASS_UNDEF : req->trafficClass;
   NCCLCHECK(ncclNetGetDeviceHandle(resources->netDeviceType, resources->netDeviceVersion, false /*isRecv*/, &resources->netDeviceHandle));
   bool rccl_anp = !(strcmp(proxyState->ncclNet->name, RCCL_ANP_PLUGIN_STR));
-  // Call plugin-specific hook to encode P2P policy into handle before connect
-  if (ncclNetEncodeP2pPolicy) {
-    ncclNetEncodeP2pPolicy(req->handle, resources->isP2p);
-    //printf("NET: sendProxyConnect called ncclNetEncodeP2pPolicy isP2p=%d\n", resources->isP2p);
+  
+  if (rcclNetP2pPolicy) {
+    rcclNetP2pPolicy(req->handle, resources->isP2p);
   }
   
   if (resources->shared) {

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -1210,7 +1210,7 @@ struct ncclIbRecvComm {
 static_assert((offsetof(struct ncclIbRecvComm, remFifo) % 32) == 0, "ncclIbRecvComm fifo must be 32-byte aligned");
 
 NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
-RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 1);
+RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
 
 static void ncclIbAddEvent(struct ncclIbRequest* req, int devIndex, struct ncclIbNetCommDevBase* base) {
   req->events[devIndex]++;
@@ -1430,16 +1430,21 @@ ib_recv_dev_list:
   // Read isP2p from handle
   isP2p = handle->isP2p;
   INFO(NCCL_NET, "NET/IB: ncclIbConnect isP2p=%d", isP2p);
-  
-  if(isP2p) {
-    localNqps  = rcclParamIbQpsPerP2p() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
-    remoteNqps = rcclParamIbQpsPerP2p() * remoteVProps.ndevs;
+  if (rcclParamIbQpsPerP2p() > 0) {
+    if(isP2p) {
+      localNqps  = rcclParamIbQpsPerP2p() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
+      remoteNqps = rcclParamIbQpsPerP2p() * remoteVProps.ndevs;
+    } else {
+      localNqps  = ncclParamIbQpsPerConn() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
+      remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
+    }
   } else {
     localNqps  = ncclParamIbQpsPerConn() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
     remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
   }
   comm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps; // Select max nqps (local or remote)
   INFO(NCCL_NET, "NET/IB: Max Nqps=%d, localNqps=%d, remoteNqps=%d", comm->base.nqps, localNqps, remoteNqps);
+
   // Init PD, Ctx for each IB device
   comm->ar = 1; // Set to 1 for logic
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
@@ -1757,10 +1762,14 @@ ib_recv:
 
   mergedDev = ncclIbMergedDevs + lComm->dev;
   rComm->base.nRemDevs = remMeta.ndevs;
-  
-  if(remMeta.isP2p) {
-    localNqps  = rcclParamIbQpsPerP2p() * rComm->base.vProps.ndevs;
-    remoteNqps = rcclParamIbQpsPerP2p() * remMeta.ndevs;
+  if (rcclParamIbQpsPerP2p() > 0) {
+    if(remMeta.isP2p) {
+      localNqps  = rcclParamIbQpsPerP2p() * rComm->base.vProps.ndevs;
+      remoteNqps = rcclParamIbQpsPerP2p() * remMeta.ndevs;
+    } else {
+      localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs;
+      remoteNqps = ncclParamIbQpsPerConn() * remMeta.ndevs;
+    }
   } else {
     localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs;
     remoteNqps = ncclParamIbQpsPerConn() * remMeta.ndevs;

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -129,6 +129,8 @@ NCCL_PARAM(IbFifoTc, "IB_FIFO_TC", -1);
 NCCL_PARAM(IbAsyncEvents,"IB_RETURN_ASYNC_EVENTS",1);
 NCCL_PARAM(IbEceEnable,"IB_ECE_ENABLE",1);
 NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
+NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
+RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
 
 static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
   __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
@@ -151,6 +153,18 @@ static void ncclIbQpFatalError(struct ibv_qp* qp) {
 static void ncclIbCqFatalError(struct ibv_cq* cq) {
   ncclIbStatsFatalError((struct ncclIbStats*)cq->cq_context);
 }
+// Calculate number of QPs based on P2P flag and device counts
+static int ncclIbCalculateNqps(int isP2p, int localNdevs, int remoteNdevs, const char* funcName) {
+  auto qp_multiplier = (rcclParamIbQpsPerP2p() > 0 && isP2p) ? 
+                       rcclParamIbQpsPerP2p() : ncclParamIbQpsPerConn();
+  int localNqps = qp_multiplier * localNdevs;
+  int remoteNqps = qp_multiplier * remoteNdevs;
+  int maxNqps = (remoteNqps > localNqps) ? remoteNqps : localNqps;
+  INFO(NCCL_NET, "NET/IB: %s Max Nqps=%d, localNqps=%d, remoteNqps=%d", 
+       funcName, maxNqps, localNqps, remoteNqps);
+  return maxNqps;
+}
+
 static void ncclIbDevFatalError(struct ncclIbDev* dev) {
   ncclIbStatsFatalError(&dev->stats);
 }
@@ -1210,9 +1224,6 @@ struct ncclIbRecvComm {
 };
 static_assert((offsetof(struct ncclIbRecvComm, remFifo) % 32) == 0, "ncclIbRecvComm fifo must be 32-byte aligned");
 
-NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
-RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
-
 static void ncclIbAddEvent(struct ncclIbRequest* req, int devIndex, struct ncclIbNetCommDevBase* base) {
   req->events[devIndex]++;
   req->devBases[devIndex] = base;
@@ -1426,20 +1437,12 @@ ib_recv_dev_list:
   memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
   mergedDev = ncclIbMergedDevs + dev;
   comm->base.vProps = mergedDev->vProps;
-  int localNqps, remoteNqps;
 
   // Read isP2p from handle
   isP2p = handle->isP2p;
   INFO(NCCL_NET, "NET/IB: ncclIbConnect isP2p=%d", isP2p);
-  if (rcclParamIbQpsPerP2p() > 0 && isP2p) {
-    localNqps  = rcclParamIbQpsPerP2p() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
-    remoteNqps = rcclParamIbQpsPerP2p() * remoteVProps.ndevs;
-  } else {
-    localNqps  = ncclParamIbQpsPerConn() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
-    remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
-  }
-  comm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps; // Select max nqps (local or remote)
-  INFO(NCCL_NET, "NET/IB: Max Nqps=%d, localNqps=%d, remoteNqps=%d", comm->base.nqps, localNqps, remoteNqps);
+  comm->base.nqps = ncclIbCalculateNqps(isP2p, comm->base.vProps.ndevs, 
+                                         remoteVProps.ndevs, __func__);
 
   // Init PD, Ctx for each IB device
   comm->ar = 1; // Set to 1 for logic
@@ -1753,20 +1756,12 @@ ib_recv:
   struct ncclIbRecvCommDev* rCommDev;
   struct ncclIbDevInfo* remDevInfo;
   struct ncclIbQp* qp;
-  bool useDmaBuf; 
-  int localNqps, remoteNqps;
+  bool useDmaBuf;
 
   mergedDev = ncclIbMergedDevs + lComm->dev;
   rComm->base.nRemDevs = remMeta.ndevs;
-  if (rcclParamIbQpsPerP2p() > 0 && remMeta.isP2p) {
-    localNqps  = rcclParamIbQpsPerP2p() * rComm->base.vProps.ndevs;
-    remoteNqps = rcclParamIbQpsPerP2p() * remMeta.ndevs;
-  } else {
-    localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs;
-    remoteNqps = ncclParamIbQpsPerConn() * remMeta.ndevs;
-  }
-  rComm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps;  
-  INFO(NCCL_NET, "NET/IB: IbAccept Max Nqps=%d, localNqps=%d, remoteNqps=%d",rComm->base.nqps, localNqps, remoteNqps);
+  rComm->base.nqps = ncclIbCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, 
+                                          remMeta.ndevs, __func__);
   if (rComm->base.nRemDevs != rComm->base.vProps.ndevs) {
     INFO(NCCL_NET, "NET/IB : Local mergedDev %s has a different number of devices=%d as remote %s %d",
       mergedDev->devName, rComm->base.vProps.ndevs, remMeta.devName, rComm->base.nRemDevs);

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -1383,6 +1383,7 @@ ncclResult_t ncclIbConnect(int dev, ncclNetCommConfig_t* config, void* opaqueHan
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)stage->comm;
   int ready;
   uint8_t link_layer = IBV_LINK_LAYER_UNSPECIFIED;
+  int isP2p = 0; 
   *sendComm = NULL;
 
   if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
@@ -1442,9 +1443,23 @@ ib_recv_dev_list:
   mergedDev = ncclIbMergedDevs + dev;
   comm->base.vProps = mergedDev->vProps;
   int localNqps, remoteNqps;
-  localNqps  = ncclParamIbQpsPerConn() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
-  remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
+
+  // Validate isP2p signature and extract flag from single uint32_t field
+  // Upper 31 bits contain signature, LSB contains P2P flag
+  if (ncclIbValidateP2pSignature(handle->isP2pFlags)) {
+    // Signature valid by extracting P2P flag from LSB
+    isP2p = ncclIbExtractP2pFlag(handle->isP2pFlags);
+  } 
+  
+  if(isP2p) {
+    localNqps  = P2P_MAX_QPS * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
+    remoteNqps = P2P_MAX_QPS * remoteVProps.ndevs;
+  } else {
+    localNqps  = ncclParamIbQpsPerConn() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
+    remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
+  }
   comm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps; // Select max nqps (local or remote)
+  INFO(NCCL_NET, "NET/IB: Max Nqps=%d, localNqps=%d, remoteNqps=%d", comm->base.nqps, localNqps, remoteNqps);
 
   // Init PD, Ctx for each IB device
   comm->ar = 1; // Set to 1 for logic
@@ -1456,7 +1471,7 @@ ib_recv_dev_list:
 
   memset(&meta, 0, sizeof(meta));
   meta.ndevs = comm->base.vProps.ndevs;
-
+  meta.isP2p = isP2p;
   // Alternate QPs between devices
   int devIndex;
   devIndex = 0;
@@ -1735,9 +1750,16 @@ ib_recv_dev_list:
   memcpy(stage->buffer, &rComm->base.vProps, sizeof(ncclNetVDeviceProps_t));
   rComm->base.isSend = false;
   int localNqps, remoteNqps;
-  localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs; // We must have at least 1 qp per-device
-  remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
-  rComm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps; // Select max nqps (local or remote)
+  // Recalculate nqps based on isP2p from remote metadata
+  if(remMeta.isP2p) {
+    localNqps  = P2P_MAX_QPS * rComm->base.vProps.ndevs;
+    remoteNqps = P2P_MAX_QPS * remMeta.ndevs;
+  } else {
+    localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs;
+    remoteNqps = ncclParamIbQpsPerConn() * remMeta.ndevs;
+  }
+  rComm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps;
+  INFO(NCCL_NET, "NET/IB: ibAccept Max Nqps=%d, localNqps=%d, remoteNqps=%d", rComm->base.nqps, localNqps, remoteNqps);
 
   stage->offset = 0;
   stage->state = ncclIbCommStateSendDevList;
@@ -1926,6 +1948,7 @@ ib_recv:
     meta.qpInfo[q].devIndex = rComm->base.qps[q].devIndex;
   }
   meta.ndevs = rComm->base.vProps.ndevs;
+  meta.isP2p = remMeta.isP2p;
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
   rComm->base.nDataQps = std::max(rComm->base.vProps.ndevs, rComm->base.nRemDevs);
 

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -969,6 +969,24 @@ ncclResult_t ncclIbGetProperties(int dev, ncclNetProperties_t* props) {
 static_assert(MAX_REQUESTS <= 256, "request id are encoded in wr_id and we need up to 8 requests ids per completion");
 
 #define NCCL_IB_MAX_QPS 128
+#define P2P_MAX_QPS 1
+
+// P2P Signature Helpers for IB transport
+// Upper 31 bits = signature, LSB = isP2p flag.
+#define NCCL_IB_ISP2P_SIGNATURE_BASE  0x49420000u  // "IB" 
+#define NCCL_IB_ISP2P_SIGNATURE_MASK  0xFFFFFFFEu
+#define NCCL_IB_ISP2P_FLAG_MASK       0x00000001u
+static inline uint32_t ncclIbPackP2pFlags(int isP2p) {
+ return (NCCL_IB_ISP2P_SIGNATURE_BASE & NCCL_IB_ISP2P_SIGNATURE_MASK) |
+        (isP2p & NCCL_IB_ISP2P_FLAG_MASK);
+}
+static inline int ncclIbExtractP2pFlag(uint32_t flags) {
+ return (int)(flags & NCCL_IB_ISP2P_FLAG_MASK);
+}
+static inline int ncclIbValidateP2pSignature(uint32_t flags) {
+ return ((flags & NCCL_IB_ISP2P_SIGNATURE_MASK) ==
+         (NCCL_IB_ISP2P_SIGNATURE_BASE & NCCL_IB_ISP2P_SIGNATURE_MASK));
+}
 
 // Per-QP connection metatdata
 struct ncclIbQpInfo {
@@ -1008,6 +1026,7 @@ struct ncclIbConnectionMetadata {
   int ndevs;
   int tc;
   int sl;
+  int isP2p;
 };
 
 enum ncclIbCommState {
@@ -1033,6 +1052,7 @@ struct ncclIbCommStage {
 struct ncclIbHandle {
   union ncclSocketAddress connectAddr; // Filled by the target
   uint64_t magic; // random number to help debugging
+  uint32_t isP2pFlags; // Upper 31 bits: signature (0x49420000u), bit 0: isP2p flag
   struct ncclIbCommStage stage; // Used by the other side when connecting
 };
 
@@ -2715,6 +2735,15 @@ ncclResult_t ncclIbCloseListen(void* listenComm) {
     free(comm);
   }
   return ncclSuccess;
+}
+
+extern "C" __attribute__((visibility("default")))
+void ncclIbNetEncodeP2pPolicy(void* handle, int isP2p) {
+ if (!handle) return;
+ ncclIbHandle* h = (ncclIbHandle*)handle;
+ h->isP2pFlags = ncclIbPackP2pFlags(isP2p);
+ INFO(NCCL_NET, "NET/IB: Encoded policy into handle: isP2p=%d flags=0x%x",
+      isP2p, h->isP2pFlags);
 }
 
 ncclNet_t ncclNetIb = {

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -969,7 +969,6 @@ ncclResult_t ncclIbGetProperties(int dev, ncclNetProperties_t* props) {
 static_assert(MAX_REQUESTS <= 256, "request id are encoded in wr_id and we need up to 8 requests ids per completion");
 
 #define NCCL_IB_MAX_QPS 128
-#define P2P_MAX_QPS 1
 
 // Per-QP connection metatdata
 struct ncclIbQpInfo {
@@ -1211,6 +1210,7 @@ struct ncclIbRecvComm {
 static_assert((offsetof(struct ncclIbRecvComm, remFifo) % 32) == 0, "ncclIbRecvComm fifo must be 32-byte aligned");
 
 NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
+RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 1);
 
 static void ncclIbAddEvent(struct ncclIbRequest* req, int devIndex, struct ncclIbNetCommDevBase* base) {
   req->events[devIndex]++;
@@ -1432,8 +1432,8 @@ ib_recv_dev_list:
   INFO(NCCL_NET, "NET/IB: ncclIbConnect isP2p=%d", isP2p);
   
   if(isP2p) {
-    localNqps  = P2P_MAX_QPS * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
-    remoteNqps = P2P_MAX_QPS * remoteVProps.ndevs;
+    localNqps  = rcclParamIbQpsPerP2p() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
+    remoteNqps = rcclParamIbQpsPerP2p() * remoteVProps.ndevs;
   } else {
     localNqps  = ncclParamIbQpsPerConn() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
     remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
@@ -1759,8 +1759,8 @@ ib_recv:
   rComm->base.nRemDevs = remMeta.ndevs;
   
   if(remMeta.isP2p) {
-    localNqps  = P2P_MAX_QPS * rComm->base.vProps.ndevs;
-    remoteNqps = P2P_MAX_QPS * remMeta.ndevs;
+    localNqps  = rcclParamIbQpsPerP2p() * rComm->base.vProps.ndevs;
+    remoteNqps = rcclParamIbQpsPerP2p() * remMeta.ndevs;
   } else {
     localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs;
     remoteNqps = ncclParamIbQpsPerConn() * remMeta.ndevs;

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -1430,14 +1430,9 @@ ib_recv_dev_list:
   // Read isP2p from handle
   isP2p = handle->isP2p;
   INFO(NCCL_NET, "NET/IB: ncclIbConnect isP2p=%d", isP2p);
-  if (rcclParamIbQpsPerP2p() > 0) {
-    if(isP2p) {
-      localNqps  = rcclParamIbQpsPerP2p() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
-      remoteNqps = rcclParamIbQpsPerP2p() * remoteVProps.ndevs;
-    } else {
-      localNqps  = ncclParamIbQpsPerConn() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
-      remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
-    }
+  if (rcclParamIbQpsPerP2p() > 0 && isP2p) {
+    localNqps  = rcclParamIbQpsPerP2p() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
+    remoteNqps = rcclParamIbQpsPerP2p() * remoteVProps.ndevs;
   } else {
     localNqps  = ncclParamIbQpsPerConn() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
     remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
@@ -1762,14 +1757,9 @@ ib_recv:
 
   mergedDev = ncclIbMergedDevs + lComm->dev;
   rComm->base.nRemDevs = remMeta.ndevs;
-  if (rcclParamIbQpsPerP2p() > 0) {
-    if(remMeta.isP2p) {
-      localNqps  = rcclParamIbQpsPerP2p() * rComm->base.vProps.ndevs;
-      remoteNqps = rcclParamIbQpsPerP2p() * remMeta.ndevs;
-    } else {
-      localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs;
-      remoteNqps = ncclParamIbQpsPerConn() * remMeta.ndevs;
-    }
+  if (rcclParamIbQpsPerP2p() > 0 && remMeta.isP2p) {
+    localNqps  = rcclParamIbQpsPerP2p() * rComm->base.vProps.ndevs;
+    remoteNqps = rcclParamIbQpsPerP2p() * remMeta.ndevs;
   } else {
     localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs;
     remoteNqps = ncclParamIbQpsPerConn() * remMeta.ndevs;
@@ -2747,10 +2737,12 @@ ncclResult_t ncclIbCloseListen(void* listenComm) {
   return ncclSuccess;
 }
 
-int rcclNetP2pPolicy(void* handle, int isP2p) {
+ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p) {
+  if (!handle) return ncclInvalidArgument;
   struct ncclIbHandle* ibHandle = (struct ncclIbHandle*)handle;
+  if (ibHandle->magic != NCCL_SOCKET_MAGIC) return ncclInvalidArgument;
   ibHandle->isP2p = isP2p;
-  return 1;  // Handled
+  return ncclSuccess;
 }
 
 ncclNet_t ncclNetIb = {

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -971,25 +971,6 @@ static_assert(MAX_REQUESTS <= 256, "request id are encoded in wr_id and we need 
 #define NCCL_IB_MAX_QPS 128
 #define P2P_MAX_QPS 1
 
-// P2P Signature Helpers for IB transport
-#define NCCL_IB_ISP2P_SIGNATURE_BASE  0x49420000u    // 'IB' in hex
-#define NCCL_IB_ISP2P_SIGNATURE_MASK  0xFFFFFFFEu  // Upper 31 bits for signature
-#define NCCL_IB_ISP2P_FLAG_MASK       0x00000001u  // LSB for P2P flag
-
-static inline uint32_t ncclIbPackP2pFlags(int isP2p) {
-  return (NCCL_IB_ISP2P_SIGNATURE_BASE & NCCL_IB_ISP2P_SIGNATURE_MASK) |
-         (isP2p & NCCL_IB_ISP2P_FLAG_MASK);
-}
-
-static inline int ncclIbExtractP2pFlag(uint32_t flags) {
-  return (int)(flags & NCCL_IB_ISP2P_FLAG_MASK);
-}
-
-static inline int ncclIbValidateP2pSignature(uint32_t flags) {
-  return ((flags & NCCL_IB_ISP2P_SIGNATURE_MASK) ==
-          (NCCL_IB_ISP2P_SIGNATURE_BASE & NCCL_IB_ISP2P_SIGNATURE_MASK));
-}
-
 // Per-QP connection metatdata
 struct ncclIbQpInfo {
   uint32_t qpn;
@@ -1054,7 +1035,7 @@ struct ncclIbCommStage {
 struct ncclIbHandle {
   union ncclSocketAddress connectAddr; // Filled by the target
   uint64_t magic; // random number to help debugging
-  uint32_t isP2pFlags; // Upper 31 bits: signature (0x50325032), bit 0: isP2p flag
+  int isP2p; // P2P flag
   struct ncclIbCommStage stage; // Used by the other side when connecting
 };
 
@@ -1446,13 +1427,9 @@ ib_recv_dev_list:
   comm->base.vProps = mergedDev->vProps;
   int localNqps, remoteNqps;
 
-  // Validate isP2p signature and extract flag from single uint32_t field
-  // Upper 31 bits contain signature, LSB contains P2P flag
-  INFO(NCCL_NET, "NET/IB: ncclIbConnect reading isP2pFlags=0x%x", handle->isP2pFlags);
-  if (ncclIbValidateP2pSignature(handle->isP2pFlags)) {
-    // Signature valid by extracting P2P flag from LSB
-    isP2p = ncclIbExtractP2pFlag(handle->isP2pFlags);
-  }
+  // Read isP2p from handle
+  isP2p = handle->isP2p;
+  INFO(NCCL_NET, "NET/IB: ncclIbConnect isP2p=%d", isP2p);
   
   if(isP2p) {
     localNqps  = P2P_MAX_QPS * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
@@ -1790,8 +1767,8 @@ ib_recv:
     localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs;
     remoteNqps = ncclParamIbQpsPerConn() * remMeta.ndevs;
   }
-  rComm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps;
-  INFO(NCCL_NET, "NET/IB: ibAccept Max Nqps=%d, localNqps=%d, remoteNqps=%d", rComm->base.nqps, localNqps, remoteNqps);
+  rComm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps;  
+  INFO(NCCL_NET, "NET/IB: IbAccept Max Nqps=%d, localNqps=%d, remoteNqps=%d",rComm->base.nqps, localNqps, remoteNqps);
   if (rComm->base.nRemDevs != rComm->base.vProps.ndevs) {
     INFO(NCCL_NET, "NET/IB : Local mergedDev %s has a different number of devices=%d as remote %s %d",
       mergedDev->devName, rComm->base.vProps.ndevs, remMeta.devName, rComm->base.nRemDevs);
@@ -2765,9 +2742,9 @@ ncclResult_t ncclIbCloseListen(void* listenComm) {
 
 // Strong symbol implementation of P2P policy encoding hook
 int ncclNetEncodeP2pPolicy(void* handle, int isP2p) {
-  // Encode P2P policy: isP2pFlags at offset after connectAddr and magic
-  uint32_t* flagsPtr = (uint32_t*)((char*)handle + sizeof(union ncclSocketAddress) + sizeof(uint64_t));
-  *flagsPtr = ncclIbPackP2pFlags(isP2p);
+  // Encode P2P policy: isP2p at offset after connectAddr and magic
+  struct ncclIbHandle* ibHandle = (struct ncclIbHandle*)handle;
+  ibHandle->isP2p = isP2p;
   return 1;  // Handled
 }
 

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -1758,8 +1758,6 @@ ib_recv:
   mergedDev = ncclIbMergedDevs + lComm->dev;
   rComm->base.nRemDevs = remMeta.ndevs;
   
-  // NOW we can safely use remMeta.isP2p and remMeta.ndevs (they've been received!)
-  // Recalculate nqps based on isP2p from remote metadata
   if(remMeta.isP2p) {
     localNqps  = P2P_MAX_QPS * rComm->base.vProps.ndevs;
     remoteNqps = P2P_MAX_QPS * remMeta.ndevs;
@@ -2740,9 +2738,7 @@ ncclResult_t ncclIbCloseListen(void* listenComm) {
   return ncclSuccess;
 }
 
-// Strong symbol implementation of P2P policy encoding hook
-int ncclNetEncodeP2pPolicy(void* handle, int isP2p) {
-  // Encode P2P policy: isP2p at offset after connectAddr and magic
+int rcclNetP2pPolicy(void* handle, int isP2p) {
   struct ncclIbHandle* ibHandle = (struct ncclIbHandle*)handle;
   ibHandle->isP2p = isP2p;
   return 1;  // Handled

--- a/src/transport/net_ib.cc
+++ b/src/transport/net_ib.cc
@@ -972,20 +972,22 @@ static_assert(MAX_REQUESTS <= 256, "request id are encoded in wr_id and we need 
 #define P2P_MAX_QPS 1
 
 // P2P Signature Helpers for IB transport
-// Upper 31 bits = signature, LSB = isP2p flag.
-#define NCCL_IB_ISP2P_SIGNATURE_BASE  0x49420000u  // "IB" 
-#define NCCL_IB_ISP2P_SIGNATURE_MASK  0xFFFFFFFEu
-#define NCCL_IB_ISP2P_FLAG_MASK       0x00000001u
+#define NCCL_IB_ISP2P_SIGNATURE_BASE  0x49420000u    // 'IB' in hex
+#define NCCL_IB_ISP2P_SIGNATURE_MASK  0xFFFFFFFEu  // Upper 31 bits for signature
+#define NCCL_IB_ISP2P_FLAG_MASK       0x00000001u  // LSB for P2P flag
+
 static inline uint32_t ncclIbPackP2pFlags(int isP2p) {
- return (NCCL_IB_ISP2P_SIGNATURE_BASE & NCCL_IB_ISP2P_SIGNATURE_MASK) |
-        (isP2p & NCCL_IB_ISP2P_FLAG_MASK);
+  return (NCCL_IB_ISP2P_SIGNATURE_BASE & NCCL_IB_ISP2P_SIGNATURE_MASK) |
+         (isP2p & NCCL_IB_ISP2P_FLAG_MASK);
 }
+
 static inline int ncclIbExtractP2pFlag(uint32_t flags) {
- return (int)(flags & NCCL_IB_ISP2P_FLAG_MASK);
+  return (int)(flags & NCCL_IB_ISP2P_FLAG_MASK);
 }
+
 static inline int ncclIbValidateP2pSignature(uint32_t flags) {
- return ((flags & NCCL_IB_ISP2P_SIGNATURE_MASK) ==
-         (NCCL_IB_ISP2P_SIGNATURE_BASE & NCCL_IB_ISP2P_SIGNATURE_MASK));
+  return ((flags & NCCL_IB_ISP2P_SIGNATURE_MASK) ==
+          (NCCL_IB_ISP2P_SIGNATURE_BASE & NCCL_IB_ISP2P_SIGNATURE_MASK));
 }
 
 // Per-QP connection metatdata
@@ -1052,7 +1054,7 @@ struct ncclIbCommStage {
 struct ncclIbHandle {
   union ncclSocketAddress connectAddr; // Filled by the target
   uint64_t magic; // random number to help debugging
-  uint32_t isP2pFlags; // Upper 31 bits: signature (0x49420000u), bit 0: isP2p flag
+  uint32_t isP2pFlags; // Upper 31 bits: signature (0x50325032), bit 0: isP2p flag
   struct ncclIbCommStage stage; // Used by the other side when connecting
 };
 
@@ -1446,10 +1448,11 @@ ib_recv_dev_list:
 
   // Validate isP2p signature and extract flag from single uint32_t field
   // Upper 31 bits contain signature, LSB contains P2P flag
+  INFO(NCCL_NET, "NET/IB: ncclIbConnect reading isP2pFlags=0x%x", handle->isP2pFlags);
   if (ncclIbValidateP2pSignature(handle->isP2pFlags)) {
     // Signature valid by extracting P2P flag from LSB
     isP2p = ncclIbExtractP2pFlag(handle->isP2pFlags);
-  } 
+  }
   
   if(isP2p) {
     localNqps  = P2P_MAX_QPS * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
@@ -1460,7 +1463,6 @@ ib_recv_dev_list:
   }
   comm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps; // Select max nqps (local or remote)
   INFO(NCCL_NET, "NET/IB: Max Nqps=%d, localNqps=%d, remoteNqps=%d", comm->base.nqps, localNqps, remoteNqps);
-
   // Init PD, Ctx for each IB device
   comm->ar = 1; // Set to 1 for logic
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
@@ -1749,18 +1751,6 @@ ib_recv_dev_list:
   rComm->base.vProps = mergedDev->vProps;
   memcpy(stage->buffer, &rComm->base.vProps, sizeof(ncclNetVDeviceProps_t));
   rComm->base.isSend = false;
-  int localNqps, remoteNqps;
-  // Recalculate nqps based on isP2p from remote metadata
-  if(remMeta.isP2p) {
-    localNqps  = P2P_MAX_QPS * rComm->base.vProps.ndevs;
-    remoteNqps = P2P_MAX_QPS * remMeta.ndevs;
-  } else {
-    localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs;
-    remoteNqps = ncclParamIbQpsPerConn() * remMeta.ndevs;
-  }
-  rComm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps;
-  INFO(NCCL_NET, "NET/IB: ibAccept Max Nqps=%d, localNqps=%d, remoteNqps=%d", rComm->base.nqps, localNqps, remoteNqps);
-
   stage->offset = 0;
   stage->state = ncclIbCommStateSendDevList;
 
@@ -1786,9 +1776,22 @@ ib_recv:
   struct ncclIbDevInfo* remDevInfo;
   struct ncclIbQp* qp;
   bool useDmaBuf; 
+  int localNqps, remoteNqps;
 
   mergedDev = ncclIbMergedDevs + lComm->dev;
   rComm->base.nRemDevs = remMeta.ndevs;
+  
+  // NOW we can safely use remMeta.isP2p and remMeta.ndevs (they've been received!)
+  // Recalculate nqps based on isP2p from remote metadata
+  if(remMeta.isP2p) {
+    localNqps  = P2P_MAX_QPS * rComm->base.vProps.ndevs;
+    remoteNqps = P2P_MAX_QPS * remMeta.ndevs;
+  } else {
+    localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs;
+    remoteNqps = ncclParamIbQpsPerConn() * remMeta.ndevs;
+  }
+  rComm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps;
+  INFO(NCCL_NET, "NET/IB: ibAccept Max Nqps=%d, localNqps=%d, remoteNqps=%d", rComm->base.nqps, localNqps, remoteNqps);
   if (rComm->base.nRemDevs != rComm->base.vProps.ndevs) {
     INFO(NCCL_NET, "NET/IB : Local mergedDev %s has a different number of devices=%d as remote %s %d",
       mergedDev->devName, rComm->base.vProps.ndevs, remMeta.devName, rComm->base.nRemDevs);
@@ -2760,13 +2763,12 @@ ncclResult_t ncclIbCloseListen(void* listenComm) {
   return ncclSuccess;
 }
 
-extern "C" __attribute__((visibility("default")))
-void ncclIbNetEncodeP2pPolicy(void* handle, int isP2p) {
- if (!handle) return;
- ncclIbHandle* h = (ncclIbHandle*)handle;
- h->isP2pFlags = ncclIbPackP2pFlags(isP2p);
- INFO(NCCL_NET, "NET/IB: Encoded policy into handle: isP2p=%d flags=0x%x",
-      isP2p, h->isP2pFlags);
+// Strong symbol implementation of P2P policy encoding hook
+int ncclNetEncodeP2pPolicy(void* handle, int isP2p) {
+  // Encode P2P policy: isP2pFlags at offset after connectAddr and magic
+  uint32_t* flagsPtr = (uint32_t*)((char*)handle + sizeof(union ncclSocketAddress) + sizeof(uint64_t));
+  *flagsPtr = ncclIbPackP2pFlags(isP2p);
+  return 1;  // Handled
 }
 
 ncclNet_t ncclNetIb = {


### PR DESCRIPTION
Work item:
Internal, LWPCLPAT-594

What were the changes?
This work introduces selective QP-per-connection tuning for P2P collectives versus non-P2P collectives. This approach allows using a higher or customized number of QPs for non-P2P collectives and making more effective use of NCCL_IB_QPS_PER_CONNECTION.

Why were the changes made?
Transport layer 

How was the outcome achieved?
More information about the code design -> LWPCLPAT-594

Additional Information
RCCL_IB_QPS_PER_P2P enables separate QP control: When set (≥1), P2P operations (Send/Recv) use RCCL_IB_QPS_PER_P2P while collectives (AllReduce/AllGather/etc.) use NCCL_IB_QPS_PER_CONNECTION. When not set: NCCL_IB_QPS_PER_CONNECTION controls all operations QPs (P2P and collectives), maintaining NCCL original behavior where one parameter applies to everything including P2P operations. 
## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
