### PR TITLE
Fix gating condition to match ROCm 7.0.2

### DIFF
--- a/src/device/prims_ll.h
+++ b/src/device/prims_ll.h
@@ -268,7 +268,7 @@ private:
     i4.flag2 = flag;
     __builtin_nontemporal_store(i4.v[0], dst->v);
     __builtin_nontemporal_store(i4.v[1], dst->v+1);
-#if defined(__gfx950__) && ROCM_VERSION < 70200
+#if defined(__gfx950__) && ROCM_VERSION < 70002
     __builtin_amdgcn_fence(__ATOMIC_RELEASE, ""); // flush cache
 #endif
 #else
@@ -344,7 +344,7 @@ private:
       __builtin_nontemporal_store(u4, (uint32_t*)dst);
     else
       __builtin_nontemporal_store(u8, (uint64_t*)dst);
-#if defined(__gfx950__) && ROCM_VERSION < 70200
+#if defined(__gfx950__) && ROCM_VERSION < 70002
     __builtin_amdgcn_fence(__ATOMIC_RELEASE, ""); // flush cache
 #endif
 #else

--- a/src/init.cc
+++ b/src/init.cc
@@ -1404,7 +1404,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       comm -> gfx9CheapFenceOff = 0;
     }
     else if(IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")){
-      comm -> gfx9CheapFenceOff = ROCM_VERSION < 70200 && nNodes > 1; // Enable for single node only prior to ROCm 7.0.2
+      comm -> gfx9CheapFenceOff = ROCM_VERSION < 70002 && nNodes > 1; // Enable for single node only prior to ROCm 7.0.2
     }
   }
   INFO(NCCL_INIT, "GFX9 cheap fence is %s", comm -> gfx9CheapFenceOff ? "OFF" : "ON");


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Fixed the gating condition for disabling threadfence in:
- LL protocol
- multi-node Simple protocol

if run on gfx950 using ROCm 7.0.2 or newer.

**Why were the changes made?**  
Original PR https://github.com/ROCm/rccl/pull/1945 had incorrect `ROCM_VERSION` check, which translated to ROCm 7.2.0 instead of ROCm 7.0.2

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
