### PR TITLE
Fix broken Clang formatting by removing duplicate rule

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -95,7 +95,6 @@ IndentPPDirectives: BeforeHash
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 LambdaBodyIndentation: Signature
-MaxEmptyLinesToKeep: 1
 MacroBlockBegin: ''
 MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1


### PR DESCRIPTION
Clang formatting is currently broken in the repo.
```
$ clang-format -i src/include/proxy_trace/proxy_trace.h 
/data/users/ahmedkkhan/rccl/.clang-format:101:1: error: duplicated mapping key 'MaxEmptyLinesToKeep'
MaxEmptyLinesToKeep: 1
^~~~~~~~~~~~~~~~~~~
Error reading /data/users/ahmedkkhan/rccl/.clang-format: Invalid argument
```

This is because there are two lines settings `MaxEmptyLinesToKeep: 1`

This branch removes one of the calls, and now clang formatting works again
```
$ clang-format -i src/include/proxy_trace/proxy_trace.h 
$
```