### PR TITLE
Add S3 upload support for Perf and test reports by run ID and architecture

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -124,6 +124,9 @@ jobs:
   therock-test-linux-multi-node:
     name: "Test multi-node"
     if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
+    permissions:
+      contents: read
+      id-token: write
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-test-packages-multi-node.yml
     with:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -5,6 +5,8 @@ on:
     inputs:
       amdgpu_families:
         type: string
+      artifact_group:
+        type: string
       extra_cmake_options:
         type: string
 
@@ -32,7 +34,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: aa315ec2801ff6772a6c9ca6799669395630c45c
+          ref: 6ecc2af91fc8a4271a949005d7404bd13278c005
 
       - name: Checkout rccl repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -126,6 +128,7 @@ jobs:
     uses: ./.github/workflows/therock-test-packages-multi-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
+      artifact_group: ${{ inputs.artifact_group }}
       test_runs_on: nova-linux-slurm-scale-runner
       artifact_run_id: ${{ github.run_id }}
 

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 6ecc2af91fc8a4271a949005d7404bd13278c005
+          ref: aa315ec2801ff6772a6c9ca6799669395630c45c
 
       - name: Checkout rccl repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -57,6 +57,7 @@ jobs:
     secrets: inherit
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
+      artifact_group: ${{ matrix.amdgpu_family }}
       extra_cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -68,6 +68,25 @@ jobs:
               --cluster_file ./input/cluster.json \
               --config_file ./input/mi350_config.json \
               --log-file=/tmp/rccl_log.log \
-              --html=/home/arravikum/cvs/ci_test_report.html \
+              --html=/home/arravikum/cvs/test_reports/ci_test_report.html \
               --capture=tee-sys \
               --self-contained-html"
+              
+      - name: Configure AWS Credentials for non-forked repos
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts-external
+
+      - name: Post test report upload
+        if: always()
+        working-directory: ${{ github.workspace }}
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${{ github.workspace }}/build_tools"
+          python3 build_tools/github_actions/upload_test_report_script.py \
+            --run-id "${{ github.run_id }}" \
+            --amdgpu-family "${{ inputs.amdgpu_families }}" \
+            --report-path "/home/arravikum/cvs/test_reports" \
+            --log-destination "/logs/gfx950-dcgpu" \
+            --index-file-name "index_rccl_test_report.html"

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -5,6 +5,8 @@ on:
     inputs:
       amdgpu_families:
         type: string
+      artifact_group:
+        type: string
       test_runs_on:
         type: string
       artifact_run_id:
@@ -12,6 +14,8 @@ on:
   workflow_dispatch:
     inputs:
       amdgpu_families:
+        type: string
+      artifact_group:
         type: string
       test_runs_on:
         type: string
@@ -38,13 +42,14 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 890c856134d955441790c8ed2d60ad4fb027f4e5
+          ref: 6ecc2af91fc8a4271a949005d7404bd13278c005
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+          ARTIFACT_GROUP: ${{ inputs.artifact_group }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
           FETCH_ARTIFACT_ARGS: "--rccl"

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -52,7 +52,7 @@ jobs:
           ARTIFACT_GROUP: ${{ inputs.artifact_group }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
-          FETCH_ARTIFACT_ARGS: "--rccl"
+          FETCH_ARTIFACT_ARGS: "--rccl --tests"
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
       # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
@@ -71,7 +71,7 @@ jobs:
               --html=/home/arravikum/cvs/test_reports/ci_test_report.html \
               --capture=tee-sys \
               --self-contained-html"
-              
+
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -21,9 +21,10 @@ on:
         type: string
       artifact_run_id:
         type: string
-
+        
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test_rccl_multi_node:
@@ -32,6 +33,9 @@ jobs:
     defaults:
       run:
         shell: bash
+    permissions:
+      contents: read
+      id-token: write
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 6ecc2af91fc8a4271a949005d7404bd13278c005
+          ref: 6ecc2af91fc8a4271a949005d7404bd13278c005 # 2025-10-23 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'


### PR DESCRIPTION
Summary

This PR adds support for automatically uploading performance bandwidth and test reports to the S3 build artifacts bucket, organized by workflow run ID and GPU architecture type.

Details

Enhanced reporting workflow:

Moves the pytest test report and HTML performance metrics for each run to their respective directories in S3, categorized by GPU architecture and workflow run ID.

New script added:

Introduced test_reporting_script.py to handle copying of test and performance reports to the build artifacts S3 bucket.

Reference commit: 

https://github.com/ROCm/TheRock/commit/6ecc2af91fc8a4271a949005d7404bd13278c005

Validation

✅ Verified successful workflow execution with the new reporting flow:
Passing workflow run

https://github.com/ROCm/rccl/actions/runs/18917095004/job/54006232489#step:6:35