### PR TITLE
Updated troubleshooting-rccl.rst to change rocm-smi to amd-smi

### DIFF
--- a/docs/how-to/troubleshooting-rccl.rst
+++ b/docs/how-to/troubleshooting-rccl.rst
@@ -45,6 +45,8 @@ Collect this information about the ROCm version, GPU/accelerator, platform, and 
       amd-smi
       amd-smi topology
       amd-smi static --driver
+      amd-smi firmware
+      amd-smi xgmi
 
 *  Determine the values of the ``PATH`` and ``LD_LIBRARY_PATH`` environment variables.
 

--- a/docs/how-to/troubleshooting-rccl.rst
+++ b/docs/how-to/troubleshooting-rccl.rst
@@ -38,13 +38,12 @@ Collect this information about the ROCm version, GPU/accelerator, platform, and 
 
       rocminfo
 
-*  Run these ``rocm-smi`` commands to display the system topology.
+*  Run these ``amd-smi`` commands to display the system topology.
 
    .. code:: shell
 
-      rocm-smi
-      rocm-smi --showtopo
-      rocm-smi --showdriverversion
+      amd-smi
+      amd-smi topology
 
 *  Determine the values of the ``PATH`` and ``LD_LIBRARY_PATH`` environment variables.
 

--- a/docs/how-to/troubleshooting-rccl.rst
+++ b/docs/how-to/troubleshooting-rccl.rst
@@ -44,6 +44,7 @@ Collect this information about the ROCm version, GPU/accelerator, platform, and 
 
       amd-smi
       amd-smi topology
+      amd-smi static --driver
 
 *  Determine the values of the ``PATH`` and ``LD_LIBRARY_PATH`` environment variables.
 


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**What were the changes?**  
Changed troubleshooting docs to refer to `amd-smi` instead of `rocm-smi`.

**Why were the changes made?**  
`rocm-smi` is now deprecated.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
