### PR TITLE
Using hip_bf16.h instead of hip_bfloat16.h for the __bf16 intrinsic

### DIFF
--- a/src/device/reduce_kernel.h
+++ b/src/device/reduce_kernel.h
@@ -415,9 +415,9 @@ SPECIALIZE_REDUCE(FuncMinMax, half, 1, half, fn.isMinNotMax ? __hmin(x, y) : __h
   // coverity[copy_constructor_call]
   SPECIALIZE_REDUCE(FuncMinMax, __nv_bfloat16, 2, __nv_bfloat162, fn.isMinNotMax ? __hmin2(x, y) : __hmax2(x, y))
 #else
-  SPECIALIZE_REDUCE(FuncSum, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) + (float)(y)))
-  SPECIALIZE_REDUCE(FuncProd, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) * (float)(y)))
-  SPECIALIZE_REDUCE(FuncMinMax, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)(fn.isMinNotMax ? fminf((float)(x), (float)(y)) : fmaxf((float)(x), (float)(y))))
+  // SPECIALIZE_REDUCE(FuncSum, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) + (float)(y)))
+  // SPECIALIZE_REDUCE(FuncProd, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) * (float)(y)))
+  // SPECIALIZE_REDUCE(FuncMinMax, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)(fn.isMinNotMax ? fminf((float)(x), (float)(y)) : fmaxf((float)(x), (float)(y))))
 #endif
 #endif
 

--- a/src/device/reduce_kernel.h
+++ b/src/device/reduce_kernel.h
@@ -414,10 +414,10 @@ SPECIALIZE_REDUCE(FuncMinMax, half, 1, half, fn.isMinNotMax ? __hmin(x, y) : __h
   SPECIALIZE_REDUCE(FuncMinMax, __nv_bfloat16, 1, __nv_bfloat16, fn.isMinNotMax ? __hmin(x, y) : __hmax(x, y))
   // coverity[copy_constructor_call]
   SPECIALIZE_REDUCE(FuncMinMax, __nv_bfloat16, 2, __nv_bfloat162, fn.isMinNotMax ? __hmin2(x, y) : __hmax2(x, y))
-#else
-  // SPECIALIZE_REDUCE(FuncSum, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) + (float)(y)))
-  // SPECIALIZE_REDUCE(FuncProd, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) * (float)(y)))
-  // SPECIALIZE_REDUCE(FuncMinMax, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)(fn.isMinNotMax ? fminf((float)(x), (float)(y)) : fmaxf((float)(x), (float)(y))))
+#elif ROCM_VERSION < 60000
+  SPECIALIZE_REDUCE(FuncSum, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) + (float)(y)))
+  SPECIALIZE_REDUCE(FuncProd, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) * (float)(y)))
+  SPECIALIZE_REDUCE(FuncMinMax, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)(fn.isMinNotMax ? fminf((float)(x), (float)(y)) : fmaxf((float)(x), (float)(y))))
 #endif
 #endif
 

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -11,9 +11,13 @@
 
 #include "nccl.h"
 #include "rccl_float8.h"
-// #include <hip/hip_bfloat16.h>
-#include <hip/hip_bf16.h>
-typedef __hip_bfloat16 hip_bfloat16;
+#if ROCM_VERSION >= 60000
+   // hip_bf16.h should be used from ROCm 6.0
+  #include <hip/hip_bf16.h>
+  typedef __hip_bfloat16 hip_bfloat16;
+#else
+  #include <hip/hip_bfloat16.h>
+#endif
 #include "nccl_common.h"
 #include "bitops.h"
 #include "symmetric.h"

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -11,7 +11,9 @@
 
 #include "nccl.h"
 #include "rccl_float8.h"
-#include <hip/hip_bfloat16.h>
+// #include <hip/hip_bfloat16.h>
+#include <hip/hip_bf16.h>
+typedef __hip_bfloat16 hip_bfloat16;
 #include "nccl_common.h"
 #include "bitops.h"
 #include "symmetric.h"


### PR DESCRIPTION
## Details
**Work item:** _"Internal", or link to GitHub issue (if applicable)._
LWPCLPAT-588
**What were the changes?**  
Switching to the hip_bf16.h implementation with the new __hip_bfloat16 datatype

**Why were the changes made?**  
To observe the performance gain for bf16 datatype through __bf16 intrinsic on MI350

**How was the outcome achieved?**  
By switching to the hip_bf16.h implementation with the new __hip_bfloat16 datatype

**Additional Documentation:**  

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
