### PR TITLE
[RcclReplayer] Compile without the need for RCCL to be compiled

### DIFF
--- a/src/include/recorder.h
+++ b/src/include/recorder.h
@@ -5,7 +5,6 @@
 #include <vector>
 #include <mutex>
 #include <chrono>
-#include "debug.h"
 
 namespace rccl
 {

--- a/src/misc/recorder.cc
+++ b/src/misc/recorder.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <iomanip>
 #include <sys/syscall.h>
+#include "debug.h"
  
 using namespace std::chrono;
 

--- a/tools/RcclReplayer/Makefile
+++ b/tools/RcclReplayer/Makefile
@@ -2,7 +2,7 @@ ROCM_DIR ?= /opt/rocm
 RCCL_DIR ?= ../../build/release
 MPI_DIR  ?= /opt/ompi
 
-INCLUDES = -I$(MPI_DIR)/include -I$(RCCL_DIR)/include -I$(RCCL_DIR)/hipify/src/include
+INCLUDES = -I$(MPI_DIR)/include -I$(RCCL_DIR)/include -I../../src/include
 LDFLAGS  = -L$(MPI_DIR)/lib -L$(RCCL_DIR) -lmpi -lrccl
 
 main: rcclReplayer.cpp

--- a/tools/RcclReplayer/README.md
+++ b/tools/RcclReplayer/README.md
@@ -73,7 +73,7 @@ Replayer is a separate tool which aims to re-run the same set of RCCL calls as r
 ## Installation
 * Replayer relies on MPI for out of band communication.
 * Under `rccl/tools/RcclReplayer`, run `MPI_DIR=${MPI_PATH} make`
-*  Replayer has to be built from RCCL source. Furthermore, it requires RCCL library to be built from the same source in `../../build/release`. For compatibility reason, it is recommended that the logs are collected using same RCCL library as well.
+*  Replayer can be built from RCCL source using internal headers directly. It links against a RCCL library specified by `RCCL_DIR` (defaults to `../../build/release`). For compatibility, it is recommended that logs are collected using the same RCCL library version.
 ## Running
 * Replayer requires the exact same number of processes and processes per node as the recorded job. And all log files must be accessible by all processes in Replayer, either through shared filesystem or copies.
 * To run Replayer, simply call `mpirun -np ${np} ./rcclReplayer ${filename}.${extension}` 


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _LWPCLPAT-617_

**What were the changes?**  
Simplified RcclReplayer build to directly include RCCL source headers `rccl/src/include`

**Why were the changes made?**  
RcclReplayer only needs `rcclApiCall, rcclCallStr, rcclCall_t` from `recorder.h` to format and parse logs, and function `ncclTypeSize()` from `collectives.h`. Including full internal headers previously required rccl to be built into `../build/release`

**How was the outcome achieved?**  
- Moved `#include "debug.h"` from `recorder.h` to `recorder.cc` to reduce dependencies
- Added forward declaration of `ncclInfo` in `rcclReplayer.hpp` to break dependency on `info.h`
- Extracted `ncclTypeSize()` function directly into header to avoid including `collectives.h`
- Updated Makefile to include `../../src/include`

**Additional Documentation:**  

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
