### PR TITLE
Add ProxyTrace struct for tracking all completed operations for active collectives

### DIFF
--- a/src/include/proxy_trace/.clang-format
+++ b/src/include/proxy_trace/.clang-format
@@ -1,0 +1,126 @@
+# The canary clang-format config file.
+#
+# Changes from head:
+# - AllowAllParametersOfDeclarationOnNextLine: Safe
+# - AllowShortFunctionsOnASingleLine: Safe
+# - IncludeIsMainRegex: May cause errors, as it may reorder includes.
+# - IncludeCategories: May cause errors, as it may reorder includes.
+---
+AccessModifierOffset: -1
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: DontAlign
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit: 80
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat: false
+FixNamespaceComments: true
+ForEachMacros:
+  - FOR_EACH
+  - FOR_EACH_R
+  - FOR_EACH_RANGE
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^<(sodium|Python)\.h>$'
+    Priority:        3
+  - Regex:           '^<((arpa|net|netinet|sys|linux)\/)?[-_[:alnum:]]+\.h>$'
+    Priority:        1
+  - Regex:           '^<[\/-_[:alnum:]]+>$'
+    Priority:        2
+  - Regex:           '^<((bistro|caffe2|cachelib|fatal|fb303|faiss|fbmeshd|fboss|fbzmq|fizz|folly|gloo|hphp|logdevice|magma|mcrouter|openr|proxygen|quic|rsocket|scape|squangle|tensorpipe|thrift|wangle|wdt|yarpl)\/).*>$'
+    Priority:        4
+  - Regex:           '^<.*>$'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        5
+IncludeIsMainRegex: '((Test|Tests|_test|Bench|Benchmark|Performance)[0-9]*)?$'
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 10
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard: Latest
+TabWidth: 8
+UseCRLF: false
+UseTab: Never
+...

--- a/src/include/proxy_trace/proxy_trace.h
+++ b/src/include/proxy_trace/proxy_trace.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
- 
+
 #pragma once
 
 #include <chrono>
@@ -13,9 +13,9 @@
 #ifndef FMT_HEADER_ONLY
 #define FMT_HEADER_ONLY 1
 #endif
-#include <fmt/format.h>
 #include <memory>
 #include <unordered_map>
+#include <fmt/format.h>
 namespace facebook_rccl {
 
 enum class ProxyOpStepStatus {
@@ -58,13 +58,13 @@ enum class ProxyOpType { SEND, RECV };
 // proxy thread (see ncclProxyOp and ncclProxySubArgs in proxy.h)
 struct ProxyTraceRecordKey {
   uint64_t commHash{0};
-  int64_t opCount{-1};   // opCount is a unique id for a given collective/p2p
+  int64_t opCount{-1}; // opCount is a unique id for a given collective/p2p
   int64_t proxyOpId{-1}; // id of a proxyOp in an given comm and grouped
                          // collective/p2p (identified as commHash:opCount),
                          // assigned when creating ProxyTraceOp entry
   inline std::string str() const {
     return "<" + std::to_string(commHash) + ":" + std::to_string(opCount) +
-           ":" + std::to_string(proxyOpId) + ">";
+        ":" + std::to_string(proxyOpId) + ">";
   }
 };
 
@@ -75,8 +75,13 @@ struct ProxyTraceExtraInfo {
   uint32_t totalBytes{0};
   uint32_t chunkSize{0};
   inline std::string str() const {
-    return fmt::format("[fu,pr,pa,tb,ck]:{},{},{},{},{}", funcIdx, protocol,
-                       pattern, totalBytes, chunkSize);
+    return fmt::format(
+        "[fu,pr,pa,tb,ck]:{},{},{},{},{}",
+        funcIdx,
+        protocol,
+        pattern,
+        totalBytes,
+        chunkSize);
   }
 };
 
@@ -114,26 +119,31 @@ struct ProxyTraceOp {
 
 using ProxyActiveOpMap = std::unordered_map<
     uint64_t /* commHash*/,
-    std::unordered_map<int64_t /* opCount*/,
-                       /* proxyOpId : op */
-                       std::unordered_map<int64_t, ProxyTraceOp>>>;
+    std::unordered_map<
+        int64_t /* opCount*/,
+        /* proxyOpId : op */
+        std::unordered_map<int64_t, ProxyTraceOp>>>;
 
-using ProxyActiveOpIdTracker =
-    std::unordered_map<uint64_t /* commHash*/,
-                       std::unordered_map<int64_t /* opCount*/, int64_t>>;
+using ProxyActiveOpIdTracker = std::unordered_map<
+    uint64_t /* commHash*/,
+    std::unordered_map<int64_t /* opCount*/, int64_t>>;
 
 class ProxyTrace {
-public:
+ public:
   ProxyTrace(int32_t rank) : myRank(rank) {}
-  ProxyTrace(const ProxyTrace &) = delete;
-  ProxyTrace &operator=(const ProxyTrace &) = delete;
+  ProxyTrace(const ProxyTrace&) = delete;
+  ProxyTrace& operator=(const ProxyTrace&) = delete;
   bool initialized{false};
-  void checkOpCompleted(const ProxyTraceRecordKey &key);
+  void checkOpCompleted(const ProxyTraceRecordKey& key);
 
-  void addNewProxyTraceOpImpl(const ProxyTraceRecordKey &key,
-                              const ProxyTraceExtraInfo &extraInfo,
-                              ProxyOpType opType, int channelId, int nSteps,
-                              uint32_t nbytes, int peerRank);
+  void addNewProxyTraceOpImpl(
+      const ProxyTraceRecordKey& key,
+      const ProxyTraceExtraInfo& extraInfo,
+      ProxyOpType opType,
+      int channelId,
+      int nSteps,
+      uint32_t nbytes,
+      int peerRank);
 
   // Get a unique proxyOpId for a given commHash:opCount
   // If the opCount is not found, create a new entry for it and return 0
@@ -146,14 +156,14 @@ public:
   std::string dump();
 
   // check if an active send/recv operation exists for a given commHash:opCount
-  bool checkActiveOpExist(uint64_t commHash, uint64_t opCount,
-                          uint32_t proxyOpId) const;
+  bool checkActiveOpExist(
+      uint64_t commHash, uint64_t opCount, uint32_t proxyOpId) const;
 
-  ProxyTraceOp *getProxyTraceOpPtr(const ProxyTraceRecordKey &traceKey);
+  ProxyTraceOp* getProxyTraceOpPtr(const ProxyTraceRecordKey& traceKey);
   float getMapSizeMB() const;
   void resetAll();
 
-private:
+ private:
   int myRank{-1};
 
   // Current active send/recv operations.
@@ -170,15 +180,22 @@ private:
   std::deque<std::pair<std::string, std::string>> finishedOps;
 };
 struct ncclProxySubArgs;
-void proxyTraceInit(std::unique_ptr<ProxyTrace> &proxyTrace,
-                            int32_t rank, uint64_t commHash);
+void proxyTraceInit(
+    std::unique_ptr<ProxyTrace>& proxyTrace, int32_t rank, uint64_t commHash);
 
-void updateProxyOpCounter(std::unique_ptr<ProxyTrace> &proxyTraceObj,
-                                  const ProxyTraceRecordKey &traceKey,
-                                  ProxyCounterTypes counter, int64_t val);
+void updateProxyOpCounter(
+    std::unique_ptr<ProxyTrace>& proxyTraceObj,
+    const ProxyTraceRecordKey& traceKey,
+    ProxyCounterTypes counter,
+    int64_t val);
 
 void addNewProxyOp(
-    std::unique_ptr<ProxyTrace> &proxyTraceObj, ProxyTraceRecordKey &key,
-    const ProxyTraceExtraInfo &extraInfo, ProxyOpType opType, int channelId,
-    int nSteps, uint32_t nbytes, int peerRank);
+    std::unique_ptr<ProxyTrace>& proxyTraceObj,
+    ProxyTraceRecordKey& key,
+    const ProxyTraceExtraInfo& extraInfo,
+    ProxyOpType opType,
+    int channelId,
+    int nSteps,
+    uint32_t nbytes,
+    int peerRank);
 } // namespace facebook_rccl

--- a/src/include/proxy_trace/proxy_trace.h
+++ b/src/include/proxy_trace/proxy_trace.h
@@ -128,6 +128,13 @@ using ProxyActiveOpIdTracker = std::unordered_map<
     uint64_t /* commHash*/,
     std::unordered_map<int64_t /* opCount*/, int64_t>>;
 
+using ProxyActiveCollFinishedOpMap = std::unordered_map<
+    uint64_t /* commHash*/,
+    std::unordered_map<
+        uint64_t /* opCount*/,
+        /* list of past ops of current active collective in completion order */
+        std::deque<ProxyTraceOp>>>;
+
 class ProxyTrace {
  public:
   ProxyTrace(int32_t rank) : myRank(rank) {}
@@ -175,9 +182,12 @@ class ProxyTrace {
   ProxyActiveOpMap activeOps;
   ProxyActiveOpIdTracker activeOpIdTracker;
 
-  // keep track of the recent completed ops;
-  // A record is a pair of traceKey.str() and ProxyTraceOp.str()
+  // Keep track of the recent completed ops, across all collectives.
+  // A record is a pair of traceKey.str() and ProxyTraceOp.str().
   std::deque<std::pair<std::string, std::string>> finishedOps;
+
+  // Keep more detailed records for the finished ops of active collectives.
+  ProxyActiveCollFinishedOpMap activeCollFinishedOps;
 };
 struct ncclProxySubArgs;
 void proxyTraceInit(

--- a/src/misc/proxy_trace/.clang-format
+++ b/src/misc/proxy_trace/.clang-format
@@ -1,0 +1,126 @@
+# The canary clang-format config file.
+#
+# Changes from head:
+# - AllowAllParametersOfDeclarationOnNextLine: Safe
+# - AllowShortFunctionsOnASingleLine: Safe
+# - IncludeIsMainRegex: May cause errors, as it may reorder includes.
+# - IncludeCategories: May cause errors, as it may reorder includes.
+---
+AccessModifierOffset: -1
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: DontAlign
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit: 80
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat: false
+FixNamespaceComments: true
+ForEachMacros:
+  - FOR_EACH
+  - FOR_EACH_R
+  - FOR_EACH_RANGE
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^<(sodium|Python)\.h>$'
+    Priority:        3
+  - Regex:           '^<((arpa|net|netinet|sys|linux)\/)?[-_[:alnum:]]+\.h>$'
+    Priority:        1
+  - Regex:           '^<[\/-_[:alnum:]]+>$'
+    Priority:        2
+  - Regex:           '^<((bistro|caffe2|cachelib|fatal|fb303|faiss|fbmeshd|fboss|fbzmq|fizz|folly|gloo|hphp|logdevice|magma|mcrouter|openr|proxygen|quic|rsocket|scape|squangle|tensorpipe|thrift|wangle|wdt|yarpl)\/).*>$'
+    Priority:        4
+  - Regex:           '^<.*>$'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        5
+IncludeIsMainRegex: '((Test|Tests|_test|Bench|Benchmark|Performance)[0-9]*)?$'
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 10
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard: Latest
+TabWidth: 8
+UseCRLF: false
+UseTab: Never
+...

--- a/src/misc/proxy_trace/proxy_trace.cc
+++ b/src/misc/proxy_trace/proxy_trace.cc
@@ -6,10 +6,10 @@
  */
 
 #include "proxy_trace/proxy_trace.h"
+#include <map>
 #include "debug.h"
 #include "device.h"
 #include "proxy.h"
-#include <map>
 
 constexpr int32_t kFinishedProxyOpItems = 32;
 static std::unordered_map<facebook_rccl::ProxyOpStepStatus, std::string>
@@ -31,25 +31,24 @@ void facebook_rccl::ProxyTrace::resetAll() {
   initialized = false;
 }
 
-bool facebook_rccl::ProxyTrace::checkActiveOpExist(uint64_t commHash,
-                                                   uint64_t opCount,
-                                                   uint32_t proxyOpId) const {
-  return (activeOps.find(commHash) != activeOps.end() &&
-          activeOps.at(commHash).find(opCount) !=
-              activeOps.at(commHash).end() &&
-          activeOps.at(commHash).at(opCount).find(proxyOpId) !=
-              activeOps.at(commHash).at(opCount).end());
+bool facebook_rccl::ProxyTrace::checkActiveOpExist(
+    uint64_t commHash, uint64_t opCount, uint32_t proxyOpId) const {
+  return (
+      activeOps.find(commHash) != activeOps.end() &&
+      activeOps.at(commHash).find(opCount) != activeOps.at(commHash).end() &&
+      activeOps.at(commHash).at(opCount).find(proxyOpId) !=
+          activeOps.at(commHash).at(opCount).end());
 }
 
 // Get a unique proxyOpId for a given commHash:opCount
 // If the opCount is not found, create a new entry for it and return 0
-int64_t facebook_rccl::ProxyTrace::getOrCreateProxyOpId(uint64_t commHash,
-                                                        uint64_t opCount) {
+int64_t facebook_rccl::ProxyTrace::getOrCreateProxyOpId(
+    uint64_t commHash, uint64_t opCount) {
   return activeOpIdTracker[commHash][opCount];
 }
 
-facebook_rccl::ProxyTraceOp *
-facebook_rccl::ProxyTrace::getProxyTraceOpPtr(const ProxyTraceRecordKey &key) {
+facebook_rccl::ProxyTraceOp* facebook_rccl::ProxyTrace::getProxyTraceOpPtr(
+    const ProxyTraceRecordKey& key) {
   if (checkActiveOpExist(key.commHash, key.opCount, key.proxyOpId)) {
     return &(activeOps.at(key.commHash).at(key.opCount).at(key.proxyOpId));
   }
@@ -57,9 +56,9 @@ facebook_rccl::ProxyTrace::getProxyTraceOpPtr(const ProxyTraceRecordKey &key) {
 }
 
 void facebook_rccl::ProxyTrace::checkOpCompleted(
-    const ProxyTraceRecordKey &key) {
+    const ProxyTraceRecordKey& key) {
   if (checkActiveOpExist(key.commHash, key.opCount, key.proxyOpId)) {
-    auto &traceOp = activeOps[key.commHash][key.opCount][key.proxyOpId];
+    auto& traceOp = activeOps[key.commHash][key.opCount][key.proxyOpId];
     // Remove finished proxyOp or colls to avoid memory leak
     if (traceOp.counters[facebook_rccl::ProxyCounterTypes::DONE] ==
         traceOp.nSteps) {
@@ -80,8 +79,12 @@ void facebook_rccl::ProxyTrace::checkOpCompleted(
 }
 
 void facebook_rccl::ProxyTrace::addNewProxyTraceOpImpl(
-    const ProxyTraceRecordKey &key, const ProxyTraceExtraInfo &extraInfo,
-    ProxyOpType opType, int channelId, int nSteps, uint32_t nbytes,
+    const ProxyTraceRecordKey& key,
+    const ProxyTraceExtraInfo& extraInfo,
+    ProxyOpType opType,
+    int channelId,
+    int nSteps,
+    uint32_t nbytes,
     int peerRank) {
   if (nSteps > 0 &&
       !checkActiveOpExist(key.commHash, key.opCount, key.proxyOpId)) {
@@ -97,8 +100,8 @@ void facebook_rccl::ProxyTrace::addNewProxyTraceOpImpl(
     traceOp.startTs = std::chrono::high_resolution_clock::now();
     traceOp.status = ProxyOpStepStatus::INIT;
     activeOpIdTracker[key.commHash][key.opCount]++;
-    activeOps[key.commHash][key.opCount].emplace(key.proxyOpId,
-                                                 std::move(traceOp));
+    activeOps[key.commHash][key.opCount].emplace(
+        key.proxyOpId, std::move(traceOp));
   } else if (nSteps == 0) {
     INFO(NCCL_PROXY, "nSteps is 0, ignored %s", key.str().c_str());
   }
@@ -139,16 +142,16 @@ void facebook_rccl::ProxyTraceOp::computeStatus() {
 std::string facebook_rccl::ProxyTrace::dump(uint64_t commHash) {
   std::string result = fmt::format("commDump for commHash:{}\n", commHash);
   std::map<std::string, std::string> sortedDumpStrMap;
-  for (auto &opCountMap : activeOps.at(commHash)) {
-    for (auto &proxyOpMap : opCountMap.second) {
-      ProxyTraceRecordKey traceKey = {commHash, opCountMap.first,
-                                      proxyOpMap.first};
+  for (auto& opCountMap : activeOps.at(commHash)) {
+    for (auto& proxyOpMap : opCountMap.second) {
+      ProxyTraceRecordKey traceKey = {
+          commHash, opCountMap.first, proxyOpMap.first};
       proxyOpMap.second.computeStatus();
       sortedDumpStrMap[traceKey.str()] = proxyOpMap.second.str();
     }
   }
-  for (const auto &pair : sortedDumpStrMap) {
-    result += pair.second; //proxyOpStr
+  for (const auto& pair : sortedDumpStrMap) {
+    result += pair.second; // proxyOpStr
   }
   return result;
 }
@@ -159,10 +162,13 @@ std::string facebook_rccl::ProxyTrace::dump() {
 
   // maps serialized key to serliazed proxyOp; sorted by key
   std::map<std::string, std::string> sortedDumpStrMap;
-  for (auto &commHash_opCountMap : activeOps) {
-    for (auto &opCount_proxyOpMap : commHash_opCountMap.second /*opCountMap*/) {
-      for (auto &opId_opEntry : opCount_proxyOpMap.second/*proxyOpMap*/) {
-        ProxyTraceRecordKey traceKey = {commHash_opCountMap.first, opCount_proxyOpMap.first, opId_opEntry.first};
+  for (auto& commHash_opCountMap : activeOps) {
+    for (auto& opCount_proxyOpMap : commHash_opCountMap.second /*opCountMap*/) {
+      for (auto& opId_opEntry : opCount_proxyOpMap.second /*proxyOpMap*/) {
+        ProxyTraceRecordKey traceKey = {
+            commHash_opCountMap.first,
+            opCount_proxyOpMap.first,
+            opId_opEntry.first};
         opId_opEntry.second.computeStatus();
         sortedDumpStrMap[traceKey.str()] = opId_opEntry.second.str();
       }
@@ -170,10 +176,10 @@ std::string facebook_rccl::ProxyTrace::dump() {
   }
 
   // add the recent finished ops as well
-  for (const auto &keyStr_proxyOpStr : finishedOps) {
+  for (const auto& keyStr_proxyOpStr : finishedOps) {
     sortedDumpStrMap[keyStr_proxyOpStr.first] = keyStr_proxyOpStr.second;
   }
-  for (const auto &keyStr_proxyOpStr : sortedDumpStrMap) {
+  for (const auto& keyStr_proxyOpStr : sortedDumpStrMap) {
     result += keyStr_proxyOpStr.second;
   }
   return result;
@@ -191,9 +197,16 @@ std::string facebook_rccl::ProxyTraceOp::str() {
       std::chrono::duration_cast<std::chrono::milliseconds>(
           lastUpdateTs.time_since_epoch())
           .count(),
-      static_cast<int>(lastUpdatingCounter), traceKey.str(), extraInfo.str(),
-      myRank, peerRank, opType == ProxyOpType::SEND ? "S" : "R", channelId,
-      proxyStepStatusStrMap[status], nSteps, nbytes,
+      static_cast<int>(lastUpdatingCounter),
+      traceKey.str(),
+      extraInfo.str(),
+      myRank,
+      peerRank,
+      opType == ProxyOpType::SEND ? "S" : "R",
+      channelId,
+      proxyStepStatusStrMap[status],
+      nSteps,
+      nbytes,
       counters[ProxyCounterTypes::POSTED],
       counters[ProxyCounterTypes::KERNEL_COPY_READY],
       counters[ProxyCounterTypes::TAIL_OR_HEAD],
@@ -201,42 +214,49 @@ std::string facebook_rccl::ProxyTraceOp::str() {
       counters[ProxyCounterTypes::FIFO_SZ_OR_HEAD_CACHE],
       counters[ProxyCounterTypes::TRANSMITTED],
       counters[ProxyCounterTypes::FLUSHED],
-      counters[ProxyCounterTypes::RECEIVED], counters[ProxyCounterTypes::DONE]);
+      counters[ProxyCounterTypes::RECEIVED],
+      counters[ProxyCounterTypes::DONE]);
   return ret;
 }
 
 float facebook_rccl::ProxyTrace::getMapSizeMB() const {
   float size = 0;
-  for (const auto &commHash_opCountMap : activeOps) {
-    for (const auto &opCount_proxyOpMap : commHash_opCountMap.second) {
+  for (const auto& commHash_opCountMap : activeOps) {
+    for (const auto& opCount_proxyOpMap : commHash_opCountMap.second) {
       size += opCount_proxyOpMap.second.size() *
-              (sizeof(ProxyTraceOp) +
-               sizeof(std::unique_ptr<facebook_rccl::ProxyTraceOp>));
+          (sizeof(ProxyTraceOp) +
+           sizeof(std::unique_ptr<facebook_rccl::ProxyTraceOp>));
     }
   }
-  for (const auto &keyStr_proxyOpStr : finishedOps) {
+  for (const auto& keyStr_proxyOpStr : finishedOps) {
     size += keyStr_proxyOpStr.first.size() + keyStr_proxyOpStr.second.size();
   }
   return size / 1024.0 / 1024.0;
 }
 
-void facebook_rccl::proxyTraceInit(std::unique_ptr<ProxyTrace> &proxyTrace,
-                                   int32_t rank, uint64_t commHash) {
+void facebook_rccl::proxyTraceInit(
+    std::unique_ptr<ProxyTrace>& proxyTrace, int32_t rank, uint64_t commHash) {
   if (proxyTrace) {
-    WARN("[proxyTrace] Initializing non-empty proxyTrace! rank: %d, commHash: "
-         "%lu",
-         rank, commHash);
+    WARN(
+        "[proxyTrace] Initializing non-empty proxyTrace! rank: %d, commHash: "
+        "%lu",
+        rank,
+        commHash);
     return;
   }
-  INFO(NCCL_PROXY, "Initializing ProxyTrace, rank: %d, commHash: %lu", rank,
-       commHash);
+  INFO(
+      NCCL_PROXY,
+      "Initializing ProxyTrace, rank: %d, commHash: %lu",
+      rank,
+      commHash);
   proxyTrace = std::make_unique<facebook_rccl::ProxyTrace>(rank);
   proxyTrace->initialized = true;
 }
 
 void facebook_rccl::updateProxyOpCounter(
-    std::unique_ptr<ProxyTrace> &proxyTraceObj,
-    const ProxyTraceRecordKey &traceKey, ProxyCounterTypes counter,
+    std::unique_ptr<ProxyTrace>& proxyTraceObj,
+    const ProxyTraceRecordKey& traceKey,
+    ProxyCounterTypes counter,
     int64_t val) {
   if (proxyTraceObj) {
     auto traceOpPtr = proxyTraceObj->getProxyTraceOpPtr(traceKey);
@@ -249,15 +269,19 @@ void facebook_rccl::updateProxyOpCounter(
   }
 }
 
-void facebook_rccl::addNewProxyOp(std::unique_ptr<ProxyTrace> &proxyTraceObj,
-                                  ProxyTraceRecordKey &key,
-                                  const ProxyTraceExtraInfo &extraInfo,
-                                  ProxyOpType opType, int channelId, int nSteps,
-                                  uint32_t nbytes, int peerRank) {
+void facebook_rccl::addNewProxyOp(
+    std::unique_ptr<ProxyTrace>& proxyTraceObj,
+    ProxyTraceRecordKey& key,
+    const ProxyTraceExtraInfo& extraInfo,
+    ProxyOpType opType,
+    int channelId,
+    int nSteps,
+    uint32_t nbytes,
+    int peerRank) {
   if (proxyTraceObj) {
     auto opId = proxyTraceObj->getOrCreateProxyOpId(key.commHash, key.opCount);
     key.proxyOpId = opId;
-    proxyTraceObj->addNewProxyTraceOpImpl(key, extraInfo, opType, channelId,
-                                          nSteps, nbytes, peerRank);
+    proxyTraceObj->addNewProxyTraceOpImpl(
+        key, extraInfo, opType, channelId, nSteps, nbytes, peerRank);
   }
 }

--- a/src/misc/proxy_trace/proxy_trace.cc
+++ b/src/misc/proxy_trace/proxy_trace.cc
@@ -67,10 +67,14 @@ void facebook_rccl::ProxyTrace::checkOpCompleted(
         finishedOps.pop_front();
       }
       finishedOps.push_back({key.str(), traceOp.str()});
+      activeCollFinishedOps[key.commHash][key.opCount].push_back(
+          std::move(traceOp));
       activeOps[key.commHash][key.opCount].erase(key.proxyOpId);
       if (activeOps[key.commHash][key.opCount].empty()) {
         activeOps[key.commHash].erase(key.opCount);
         activeOpIdTracker[key.commHash].erase(key.opCount);
+        activeCollFinishedOps[key.commHash][key.opCount]
+            .clear(); // coll is no longer active
       }
     }
   } else {


### PR DESCRIPTION
This data is used for our Fault Analyzer tool. See section 7.3 of https://arxiv.org/pdf/2510.20171 for more details.