### PR TITLE
Disable Bfloatf16 pipelining for reduction collectives for gfx950

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 ### Changed
 
 * RCCL error messages have been made more verbose in several cases. RCCL now prints out fatal error messages by default. Fatal error messages can be suppressed by setting `NCCL_DEBUG=NONE`.
+* Disabled `reduceCopyPacks` pipelining for `gfx950`.
 
 ## Unreleased - RCCL 2.27.7 for ROCm 7.1.1
 

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -170,9 +170,9 @@ class Fn:
   def __iter__(self):
     return iter((self.coll, self.algo, self.proto, self.redop, self.ty, self.acc, self.pipeline, self.unroll))
 
-def calc_unroll_for_local_arch():
+def calc_unroll_and_pipeline_for_local_arch():
   if not is_local_arch_only:
-    return all_unrolls
+    return (all_unrolls, all_pipelines)
 
   rocminfo_path = os.environ.get('ROCM_PATH') + "/bin/rocminfo"
 
@@ -202,52 +202,17 @@ def calc_unroll_for_local_arch():
   if len(gfx_targets) == 1:
     gfx_name, cu_count = gfx_targets[0]
     if "gfx950" == gfx_name:
-      return ["1", "2"]
+      return (["1", "2"], ["0"])  # Disable pipelining for gfx950
     elif "gfx908" == gfx_name or ("gfx942" == gfx_name and cu_count > 80):
-      return ["2"]
+      return (["2"], all_pipelines)
     else:
-      return ["4"]
+      return (["4"], all_pipelines)
   else:
-    return all_unrolls
+    return (all_unrolls, all_pipelines)
 
 # if building for local arch only, we only need to build for 1 variant of unroll for most gfx targets,
-# except for gfx950
-local_unroll = calc_unroll_for_local_arch()
-
-def calc_pipeline_for_local_arch():
-  # Default: pipelining enabled
-  default_pipeline = ["0", "1"]
-  
-  if not is_local_arch_only:
-    return default_pipeline
-
-  rocminfo_path = os.environ.get('ROCM_PATH') + "/bin/rocminfo"
-
-  res = subprocess.run([rocminfo_path], stdout=subprocess.PIPE, universal_newlines=True)
-  rocminfo_output = res.stdout
-
-  # Parse rocminfo binary output to detect GPU architecture
-  gfx_targets = set()
-  curr_name = None
-  for line in rocminfo_output.splitlines():
-    line = line.strip()
-
-    if line.startswith("Name:"):
-      name = line.split(':')[-1].strip()
-      if "gfx" in name:
-        curr_name = name
-    if line.startswith("Compute Unit:") and curr_name:
-      gfx_targets.add(curr_name)
-      curr_name = None
-
-  # Disable pipelining for MI350 (gfx950)
-  if "gfx950" in gfx_targets:
-    return ["0"]  # Disable pipelining
-  
-  return default_pipeline
-
-# if building for gfx950, we need to disable pipelining
-local_pipeline = calc_pipeline_for_local_arch()
+# except for gfx950. For gfx950, we also disable pipelining.
+local_unroll, local_pipeline = calc_unroll_and_pipeline_for_local_arch()
 
 # Helper function to check if the conditions for the collective is being met
 def func_validate(coll, algo, proto, redop, ty, acc,  pipeline, unroll):

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -171,8 +171,6 @@ class Fn:
     return iter((self.coll, self.algo, self.proto, self.redop, self.ty, self.acc, self.pipeline, self.unroll))
 
 def calc_unroll_and_pipeline_for_local_arch():
-  if not is_local_arch_only:
-    return (all_unrolls, all_pipelines)
 
   rocminfo_path = os.environ.get('ROCM_PATH') + "/bin/rocminfo"
 
@@ -197,6 +195,12 @@ def calc_unroll_and_pipeline_for_local_arch():
   # We want to remove duplicates but cannot use a dictionary since same gfx name can have different cu counts
   # Use (gfx_name, cu_count) as key for dictionary and convert it to list here
   gfx_targets = list(gfx_targets.keys())
+  
+  has_gfx950 = any(gfx_name == "gfx950" for gfx_name, _ in gfx_targets)
+  pipeline = ["0"] if has_gfx950 else all_pipelines
+ 
+  if not is_local_arch_only:
+    return (all_unrolls, pipeline)
 
   # Homogeneous system is required to build for only 1 variant of unroll factor (except for gfx950)
   if len(gfx_targets) == 1:

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -214,6 +214,41 @@ def calc_unroll_for_local_arch():
 # except for gfx950
 local_unroll = calc_unroll_for_local_arch()
 
+def calc_pipeline_for_local_arch():
+  # Default: pipelining enabled
+  default_pipeline = ["0", "1"]
+  
+  if not is_local_arch_only:
+    return default_pipeline
+
+  rocminfo_path = os.environ.get('ROCM_PATH') + "/bin/rocminfo"
+
+  res = subprocess.run([rocminfo_path], stdout=subprocess.PIPE, universal_newlines=True)
+  rocminfo_output = res.stdout
+
+  # Parse rocminfo binary output to detect GPU architecture
+  gfx_targets = set()
+  curr_name = None
+  for line in rocminfo_output.splitlines():
+    line = line.strip()
+
+    if line.startswith("Name:"):
+      name = line.split(':')[-1].strip()
+      if "gfx" in name:
+        curr_name = name
+    if line.startswith("Compute Unit:") and curr_name:
+      gfx_targets.add(curr_name)
+      curr_name = None
+
+  # Disable pipelining for MI350 (gfx950)
+  if "gfx950" in gfx_targets:
+    return ["0"]  # Disable pipelining
+  
+  return default_pipeline
+
+# if building for gfx950, we need to disable pipelining
+local_pipeline = calc_pipeline_for_local_arch()
+
 # Helper function to check if the conditions for the collective is being met
 def func_validate(coll, algo, proto, redop, ty, acc,  pipeline, unroll):
   if redop == "SumPostDiv" and ty[0] not in ("i","u"):
@@ -226,6 +261,7 @@ def func_validate(coll, algo, proto, redop, ty, acc,  pipeline, unroll):
       ty not in tys_of_coll[coll] or
       acc not in acc_of_coll[coll] or
       pipeline not in pipelines_of_coll[coll] or (pipeline in ["1"] and ty not in pipelined_types) or
+      pipeline not in local_pipeline or
       unroll not in local_unroll):
     return False
   return True
@@ -318,7 +354,7 @@ def enumerate_func_rows():
           for redop in all_redops:
             for ty in all_tys:
               for acc in all_accs:
-                for pipeline in all_pipelines:
+                for pipeline in local_pipeline:
                   if func_validate(coll, algo, proto, redop, ty, acc, pipeline, unroll):
                     yield (coll, algo, proto, redop, ty, acc, pipeline, unroll)
 
@@ -332,7 +368,7 @@ def custom_sort_key(fn: Fn):
         all_redops.index(fn.redop),
         all_tys.index(fn.ty),
         all_accs.index(fn.acc),
-        all_pipelines.index(fn.pipeline)
+        local_pipeline.index(fn.pipeline)
     )
 
 def get_arch_guard(fn):

--- a/src/device/generate.py
+++ b/src/device/generate.py
@@ -172,6 +172,9 @@ class Fn:
 
 def calc_unroll_and_pipeline_for_local_arch():
 
+  if not is_local_arch_only:
+    return (all_unrolls, all_pipelines)
+
   rocminfo_path = os.environ.get('ROCM_PATH') + "/bin/rocminfo"
 
   res = subprocess.run([rocminfo_path], stdout=subprocess.PIPE, universal_newlines=True)
@@ -196,12 +199,6 @@ def calc_unroll_and_pipeline_for_local_arch():
   # Use (gfx_name, cu_count) as key for dictionary and convert it to list here
   gfx_targets = list(gfx_targets.keys())
   
-  has_gfx950 = any(gfx_name == "gfx950" for gfx_name, _ in gfx_targets)
-  pipeline = ["0"] if has_gfx950 else all_pipelines
- 
-  if not is_local_arch_only:
-    return (all_unrolls, pipeline)
-
   # Homogeneous system is required to build for only 1 variant of unroll factor (except for gfx950)
   if len(gfx_targets) == 1:
     gfx_name, cu_count = gfx_targets[0]

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -239,7 +239,7 @@ void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, stru
 
 void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info) {
   info->pipeline = 0; // Default to no pipelining
-  if (rcclParamdisableReduceCopyPipelining()) {
+  if (rcclParamdisableReduceCopyPipelining() || IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
     return;
   }
   const bool dtypeOK = (info->datatype == ncclBfloat16) || rcclParamPipelineAllDTypes();

--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -244,22 +244,6 @@ void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclT
   }
   const bool dtypeOK = (info->datatype == ncclBfloat16) || rcclParamPipelineAllDTypes();
 
-  if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && dtypeOK) {
-    if (comm->nNodes > 1) {
-      switch (info->func) {
-        case ncclFuncAllReduce:
-        case ncclFuncReduceScatter:
-        case ncclFuncReduce:
-          // Enable for multi-node
-          info->pipeline = 1;
-          break;
-        default:
-          break;
-      }
-    }
-    return;
-  }
-
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") && dtypeOK) {
     switch (info->func) {
       // For multi-node case, we check if the number of bytes (`nBytes`) satisfies


### PR DESCRIPTION
**What were the changes?**  
Disable Bfloatf16 pipelining for reduction collectives for gfx950 in generate.py

**Why were the changes made?**  
Based on current testing and the performance uplift observed from the new __bf16 intrinsic https://github.com/ROCm/rccl/pull/2037, we are no longer observing significant uplift from the pipelining in gfx950. 

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
