### PR TITLE
[AzureCI] Add RcclReplayer to CI

### DIFF
--- a/.azuredevops/slurm/build.sh
+++ b/.azuredevops/slurm/build.sh
@@ -41,7 +41,7 @@ cmake --build . --target install
 
 # Building RCCL Replayer
 cd ../tools/RcclReplayer 2>/dev/null || cd ../RcclReplayer
-ROCM_DIR="$ROCM_PATH" MPI_DIR="$MPI_HOME" make
+RCCL_DIR="../../build" ROCM_DIR="$ROCM_PATH" MPI_DIR="$MPI_HOME" make
 
 cd "${SLURM_SUBMIT_DIR:-$PWD}"
 ## Building RCCL-Tests

--- a/.azuredevops/slurm/build.sh
+++ b/.azuredevops/slurm/build.sh
@@ -41,7 +41,7 @@ cmake --build . --target install
 
 # Building RCCL Replayer
 cd ../tools/RcclReplayer 2>/dev/null || cd ../RcclReplayer
-MPI_DIR="$MPI_HOME" make
+ROCM_DIR="$ROCM_PATH" MPI_DIR="$MPI_HOME/install" make
 
 cd "${SLURM_SUBMIT_DIR:-$PWD}"
 ## Building RCCL-Tests

--- a/.azuredevops/slurm/build.sh
+++ b/.azuredevops/slurm/build.sh
@@ -41,7 +41,7 @@ cmake --build . --target install
 
 # Building RCCL Replayer
 cd ../tools/RcclReplayer 2>/dev/null || cd ../RcclReplayer
-ROCM_DIR="$ROCM_PATH" MPI_DIR="$MPI_HOME/install" make
+ROCM_DIR="$ROCM_PATH" MPI_DIR="$MPI_HOME" make
 
 cd "${SLURM_SUBMIT_DIR:-$PWD}"
 ## Building RCCL-Tests

--- a/.azuredevops/slurm/build.sh
+++ b/.azuredevops/slurm/build.sh
@@ -39,6 +39,9 @@ cmake -G Ninja -DCMAKE_INSTALL_PREFIX="$BINARIES_DIR" -DCMAKE_BUILD_TYPE=Release
 cmake --build .
 cmake --build . --target install
 
+# Building RCCL Replayer
+cd ../tools/RcclReplayer 2>/dev/null || cd ../RcclReplayer
+MPI_DIR="$MPI_HOME" make
 
 cd "${SLURM_SUBMIT_DIR:-$PWD}"
 ## Building RCCL-Tests


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _LWPCLPAT-627_

**What were the changes?**  
_Add `rccl/tools/RcclReplayer` build as part of AzureCI pipeline._

**Why were the changes made?**  
_We have some dependencies on RCCL so it's good to add Replayer to CI so that nothing breaks when RCCL breaks._

**How was the outcome achieved?**  

**Additional Documentation:**  
_Added fallback `cd ../RcclReplayer` in case PR-1897 is merged._

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
