### PR TITLE
Enable NIC config based multinode script run and s3 report uploads for PR runs from forks

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       TEATIME_FORCE_INTERACTIVE: 0
-      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      AWS_SHARED_CREDENTIALS_FILE: /apps/cvs/awsconfig/credentials.ini
       CACHE_DIR: ${{ github.workspace }}/.container-cache
       # The ccache.conf will be written by setup_ccache.py before this gets used.
       CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       TEATIME_FORCE_INTERACTIVE: 0
-      AWS_SHARED_CREDENTIALS_FILE: /apps/cvs/awsconfig/credentials.ini
+      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
       CACHE_DIR: ${{ github.workspace }}/.container-cache
       # The ccache.conf will be written by setup_ccache.py before this gets used.
       CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -9,6 +9,9 @@ on:
         type: string
       extra_cmake_options:
         type: string
+      enabled_nics:
+        type: string
+        default: "8nic"
 
 permissions:
   contents: read
@@ -132,6 +135,7 @@ jobs:
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
+      enabled_nics: ${{ inputs.enabled_nics }}
       test_runs_on: nova-linux-slurm-scale-runner
       artifact_run_id: ${{ github.run_id }}
 

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -9,7 +9,7 @@ on:
         type: string
       extra_cmake_options:
         type: string
-      enabled_nics:
+      nic_config:
         type: string
         default: "8nic"
 
@@ -135,7 +135,7 @@ jobs:
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
-      enabled_nics: ${{ inputs.enabled_nics }}
+      nic_config: ${{ inputs.nic_config }}
       test_runs_on: nova-linux-slurm-scale-runner
       artifact_run_id: ${{ github.run_id }}
 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -67,8 +67,6 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
-      # Pass nic_config *only* for workflow_dispatch runs
-      nic_config: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.nic_config }}
       extra_cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -66,6 +66,7 @@ jobs:
     secrets: inherit
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
+      nic_config: ${{ github.event.inputs.nic_config != '' && github.event.inputs.nic_config || '8nic' }}
       artifact_group: ${{ matrix.amdgpu_family }}
       extra_cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -10,6 +10,15 @@ on:
       - opened
       - synchronize
   workflow_dispatch:
+    inputs:
+      enabled_nics:
+        description: "Select NIC configuration to run tests"
+        required: true
+        default: "8nic"
+        type: choice
+        options:
+          - "4nic"
+          - "8nic"
 
 permissions:
   contents: read
@@ -58,6 +67,7 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
+      enabled_nics: ${{ github.event.inputs.enabled_nics }}
       extra_cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -11,7 +11,7 @@ on:
       - synchronize
   workflow_dispatch:
     inputs:
-      enabled_nics:
+      nic_config:
         description: "Select NIC configuration to run tests"
         required: true
         default: "8nic"
@@ -67,8 +67,8 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
-      # Pass enabled_nics *only* for workflow_dispatch runs
-      enabled_nics: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enabled_nics || '' }}
+      # Pass nic_config *only* for workflow_dispatch runs
+      nic_config: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.nic_config }}
       extra_cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -67,7 +67,8 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
-      enabled_nics: ${{ github.event.inputs.enabled_nics }}
+      # Pass enabled_nics *only* for workflow_dispatch runs
+      enabled_nics: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.enabled_nics || '' }}
       extra_cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -78,7 +78,7 @@ jobs:
           echo "Using config file: $CONFIG_FILE"
 
           salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
-          source /home/arravikum/TheRock/.venv/bin/activate &&
+          source /apps/TheRock/.venv/bin/activate &&
           cd /apps/cvs &&
           python input/setup.py --rccl_file $CONFIG_FILE &&
           pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -11,6 +11,9 @@ on:
         type: string
       artifact_run_id:
         type: string
+      enabled_nics:
+        type: string
+        default: "8nic"
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -21,6 +24,9 @@ on:
         type: string
       artifact_run_id:
         type: string
+      enabled_nics:
+        type: string
+        default: "8nic"
         
 permissions:
   contents: read
@@ -42,6 +48,7 @@ jobs:
       OUTPUT_ARTIFACTS_DIR: /home/arravikum/dist_new/dist/rocm
       THEROCK_BIN_DIR: "./build/bin"
       AWS_SHARED_CREDENTIALS_FILE: /home/arravikum/awsconfig/credentials.ini
+      ENABLED_NICS: ${{ inputs.enabled_nics }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -60,29 +67,38 @@ jobs:
           FETCH_ARTIFACT_ARGS: "--rccl --tests"
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
-      # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
-      # salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
-      # - name: Test gfx950
-      #   if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
-      #   run: |
-      #     salloc -N 4 --nodelist="cv350-zts-gtu-h32-08, cv350-zts-gtu-h32-18, cv350-zts-gtu-h32b-08, cv350-zts-gtu-h32b-18" -p meta64 -t 04:00:00 --exclusive bash -c "
-      #     source /home/arravikum/TheRock/.venv/bin/activate &&
-      #     cd /home/arravikum/cvs &&
-      #     python input/setup.py &&
-      #     pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
-      #         --cluster_file ./input/cluster.json \
-      #         --config_file ./input/mi350_config.json \
-      #         --log-file=/tmp/rccl_log.log \
-      #         --html=/home/arravikum/cvs/test_reports/ci_test_report.html \
-      #         --capture=tee-sys \
-      #         --self-contained-html"
+      The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
+      salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
+      - name: Test gfx950
+        if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
+        run: |
+          # Determine config file based on NIC count
+          if [[ "${ENABLED_NICS}" == "8nic" ]]; then
+            CONFIG_FILE="./input/mi350_8nic_config.json"
+          else
+            CONFIG_FILE="./input/mi350_4nic_config.json"
+          fi
 
-      # - name: Configure AWS Credentials for non-forked repos
-      #   if: ${{ always() && !github.event.pull_request.head.repo.fork }}
-      #   uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-      #   with:
-      #     aws-region: us-east-2
-      #     role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts-external
+          echo "Using config file: $CONFIG_FILE"
+
+          salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
+          source /home/arravikum/TheRock/.venv/bin/activate &&
+          cd /home/arravikum/cvs &&
+          python input/setup.py &&
+          pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
+              --cluster_file ./input/cluster.json \
+              --config_file $CONFIG_FILE \
+              --log-file=/tmp/rccl_log.log \
+              --html=/home/arravikum/cvs/test_reports/ci_test_report.html \
+              --capture=tee-sys \
+              --self-contained-html"
+
+      - name: Configure AWS Credentials for non-forked repos
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts-external
 
       - name: Post test report upload
         if: always()

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -104,6 +104,6 @@ jobs:
           python3 build_tools/github_actions/upload_test_report_script.py \
             --run-id "${{ github.run_id }}" \
             --amdgpu-family "${{ inputs.amdgpu_families }}" \
-            --report-path "/apps/cvs/test_reports/test_reports" \
+            --report-path "/apps/cvs/test_reports/" \
             --log-destination "/logs/gfx950-dcgpu" \
             --index-file-name "index_rccl_test_report.html"

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           # Determine config file based on NIC_CONFIG,
           # the NIC_CONFIG signifies the number of NICs used in the node to run Bandwidth tests for rccl_multinode_cvs.py
-          CONFIG_FILE = "./input/mi350_${NIC_CONFIG}_config.json"
+          CONFIG_FILE="./input/mi350_${NIC_CONFIG}_config.json"
           echo "Using config file: $CONFIG_FILE"
 
           salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -84,7 +84,7 @@ jobs:
           salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
           source /home/arravikum/TheRock/.venv/bin/activate &&
           cd /home/arravikum/cvs &&
-          python input/setup.py &&
+          python input/setup.py --rccl_file $CONFIG_FILE &&
           pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
               --cluster_file ./input/cluster.json \
               --config_file $CONFIG_FILE \

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -25,8 +25,13 @@ on:
       artifact_run_id:
         type: string
       nic_config:
-        type: string
+        description: "Select NIC configuration to run tests"
+        required: true
         default: "8nic"
+        type: choice
+        options:
+          - "4nic"
+          - "8nic"
         
 permissions:
   contents: read

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -67,29 +67,25 @@ jobs:
           FETCH_ARTIFACT_ARGS: "--rccl --tests"
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
-      ## The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
-      ## salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
+      # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
+      # salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          # Determine config file based on NIC count
-          if [[ "${ENABLED_NICS}" == "8nic" ]]; then
-            CONFIG_FILE="./input/mi350_8nic_config.json"
-          else
-            CONFIG_FILE="./input/mi350_4nic_config.json"
-          fi
-
+          # Determine config file based on NIC count,
+          # the NIC count signifies the number of NICs used in the node to run BW tests
+          CONFIG_FILE = "./input/mi350_${ENABLED_NICS}_config.json"
           echo "Using config file: $CONFIG_FILE"
 
           salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
           source /home/arravikum/TheRock/.venv/bin/activate &&
-          cd /home/arravikum/cvs &&
+          cd /apps/cvs &&
           python input/setup.py --rccl_file $CONFIG_FILE &&
           pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
               --cluster_file ./input/cluster.json \
               --config_file $CONFIG_FILE \
               --log-file=/tmp/rccl_log.log \
-              --html=/home/arravikum/cvs/test_reports/ci_test_report.html \
+              --html=/apps/cvs/test_reports/ci_test_report.html \
               --capture=tee-sys \
               --self-contained-html"
 
@@ -108,6 +104,6 @@ jobs:
           python3 build_tools/github_actions/upload_test_report_script.py \
             --run-id "${{ github.run_id }}" \
             --amdgpu-family "${{ inputs.amdgpu_families }}" \
-            --report-path "/home/arravikum/cvs/test_reports" \
+            --report-path "/apps/cvs/test_reports/test_reports" \
             --log-destination "/logs/gfx950-dcgpu" \
             --index-file-name "index_rccl_test_report.html"

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -11,7 +11,7 @@ on:
         type: string
       artifact_run_id:
         type: string
-      enabled_nics:
+      nic_config:
         type: string
         default: "8nic"
   workflow_dispatch:
@@ -24,7 +24,7 @@ on:
         type: string
       artifact_run_id:
         type: string
-      enabled_nics:
+      nic_config:
         type: string
         default: "8nic"
         
@@ -48,7 +48,7 @@ jobs:
       OUTPUT_ARTIFACTS_DIR: /home/arravikum/dist_new/dist/rocm
       THEROCK_BIN_DIR: "./build/bin"
       AWS_SHARED_CREDENTIALS_FILE: /apps/cvs/awsconfig/credentials.ini
-      ENABLED_NICS: ${{ inputs.enabled_nics }}
+      NIC_CONFIG: ${{ inputs.nic_config }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -72,9 +72,9 @@ jobs:
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          # Determine config file based on NIC count,
-          # the NIC count signifies the number of NICs used in the node to run BW tests
-          CONFIG_FILE = "./input/mi350_${ENABLED_NICS}_config.json"
+          # Determine config file based on NIC_CONFIG,
+          # the NIC_CONFIG signifies the number of NICs used in the node to run Bandwidth tests for rccl_multinode_cvs.py
+          CONFIG_FILE = "./input/mi350_${NIC_CONFIG}_config.json"
           echo "Using config file: $CONFIG_FILE"
 
           salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -41,6 +41,7 @@ jobs:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
       OUTPUT_ARTIFACTS_DIR: /home/arravikum/dist_new/dist/rocm
       THEROCK_BIN_DIR: "./build/bin"
+      AWS_SHARED_CREDENTIALS_FILE: /home/arravikum/awsconfig/credentials.ini
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -61,27 +62,27 @@ jobs:
 
       # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
       # salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
-      - name: Test gfx950
-        if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
-        run: |
-          salloc -N 4 --nodelist="cv350-zts-gtu-h32-08, cv350-zts-gtu-h32-18, cv350-zts-gtu-h32b-08, cv350-zts-gtu-h32b-18" -p meta64 -t 04:00:00 --exclusive bash -c "
-          source /home/arravikum/TheRock/.venv/bin/activate &&
-          cd /home/arravikum/cvs &&
-          python input/setup.py &&
-          pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
-              --cluster_file ./input/cluster.json \
-              --config_file ./input/mi350_config.json \
-              --log-file=/tmp/rccl_log.log \
-              --html=/home/arravikum/cvs/test_reports/ci_test_report.html \
-              --capture=tee-sys \
-              --self-contained-html"
+      # - name: Test gfx950
+      #   if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
+      #   run: |
+      #     salloc -N 4 --nodelist="cv350-zts-gtu-h32-08, cv350-zts-gtu-h32-18, cv350-zts-gtu-h32b-08, cv350-zts-gtu-h32b-18" -p meta64 -t 04:00:00 --exclusive bash -c "
+      #     source /home/arravikum/TheRock/.venv/bin/activate &&
+      #     cd /home/arravikum/cvs &&
+      #     python input/setup.py &&
+      #     pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
+      #         --cluster_file ./input/cluster.json \
+      #         --config_file ./input/mi350_config.json \
+      #         --log-file=/tmp/rccl_log.log \
+      #         --html=/home/arravikum/cvs/test_reports/ci_test_report.html \
+      #         --capture=tee-sys \
+      #         --self-contained-html"
 
-      - name: Configure AWS Credentials for non-forked repos
-        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-        with:
-          aws-region: us-east-2
-          role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts-external
+      # - name: Configure AWS Credentials for non-forked repos
+      #   if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+      #   uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+      #   with:
+      #     aws-region: us-east-2
+      #     role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts-external
 
       - name: Post test report upload
         if: always()

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -67,8 +67,8 @@ jobs:
           FETCH_ARTIFACT_ARGS: "--rccl --tests"
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
-      The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
-      salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
+      ## The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
+      ## salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
+          salloc -N 4 --nodelist="cv350-zts-gtu-h32-08, cv350-zts-gtu-h32-18, cv350-zts-gtu-h32b-08, cv350-zts-gtu-h32b-18" -p meta64 -t 04:00:00 --exclusive bash -c "
           source /home/arravikum/TheRock/.venv/bin/activate &&
           cd /home/arravikum/cvs &&
           python input/setup.py &&

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -47,7 +47,7 @@ jobs:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
       OUTPUT_ARTIFACTS_DIR: /home/arravikum/dist_new/dist/rocm
       THEROCK_BIN_DIR: "./build/bin"
-      AWS_SHARED_CREDENTIALS_FILE: /home/arravikum/awsconfig/credentials.ini
+      AWS_SHARED_CREDENTIALS_FILE: /apps/cvs/awsconfig/credentials.ini
       ENABLED_NICS: ${{ inputs.enabled_nics }}
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
This PR adds two improvements to the RCCL multi-node CI flow:

1. S3 Uploads for Forked PRs

Enables RCCL multi-node HTML test report uploads for PRs from forks by using a dedicated Slurm user with limited S3 access to the therock-artifacts-external bucket.

2. Support for 4-NIC Multi-Node Testing

Adds a new mi350_4nic_config.json and allows selecting between 4-NIC and 8-NIC configurations via the enabled_nics input.
The workflow now dynamically chooses the correct config file, with 8-NIC remaining the default.

3. Move CVS and TheRock repository to /apps as being a permanent direcotory instead of the cvs repo residing in user directory

As part of the last RCCL CI discussion call, there was a decision made to move the CVS repo to /apps directory which will be a permanent placeholder for the CVS scripts in the slurm cluster.  