### PR TITLE
Update gfx950 tuner conf to include broadcast

### DIFF
--- a/ext-tuner/example/rccl_tuner_gfx950.conf
+++ b/ext-tuner/example/rccl_tuner_gfx950.conf
@@ -2,6 +2,7 @@
 # Optimization metric: latency_us
 # Format: collective_type,min_bytes,max_bytes,algorithm,protocol,channels,nNodes,nRanks,numPipeOps,regBuff
 # This file contains configurations for allgather, allreduce, and reducescatter on gfx950 with 2,4,8 nodes.
+# Also, this file contains configurations for broadcast on gfx950 with 2,4,8,16 nodes.
 # The config for allgather upto 4MB will be bypassed by rccl as rccl runtime
 # forced direct implementation for msgs upto 4MB
 allgather,0,1536,ring,ll128,32,2,16,-1,-1
@@ -130,3 +131,51 @@ reducescatter,201326593,402653184,ring,ll128,56,8,64,-1,-1
 reducescatter,402653185,805306368,ring,simple,40,8,64,-1,-1
 reducescatter,805306369,1610612736,ring,simple,56,8,64,-1,-1
 reducescatter,1610612737,17179869184,ring,simple,64,8,64,-1,-1
+broadcast,0,1536,ring,ll,56,2,16,-1,-1
+broadcast,1537,3072,ring,ll,1,2,16,-1,-1
+broadcast,3073,6144,ring,ll,56,2,16,-1,-1
+broadcast,6145,12288,ring,ll,1,2,16,-1,-1
+broadcast,12289,24576,ring,ll128,16,2,16,-1,-1
+broadcast,24577,393216,ring,ll128,1,2,16,-1,-1
+broadcast,393217,786432,ring,ll128,32,2,16,-1,-1
+broadcast,786433,6291456,ring,ll128,64,2,16,-1,-1
+broadcast,6291457,25165824,ring,ll128,56,2,16,-1,-1
+broadcast,25165825,805306368,ring,ll128,64,2,16,-1,-1
+broadcast,805306369,1610612736,ring,simple,48,2,16,-1,-1
+broadcast,1610612737,17179869184,ring,simple,32,2,16,-1,-1
+broadcast,0,1536,ring,ll,8,4,32,-1,-1
+broadcast,1537,3072,ring,ll,32,4,32,-1,-1
+broadcast,3073,12288,ring,ll,1,4,32,-1,-1
+broadcast,12289,24576,ring,ll128,2,4,32,-1,-1
+broadcast,24577,786432,ring,ll128,1,4,32,-1,-1
+broadcast,786433,6291456,ring,ll128,64,4,32,-1,-1
+broadcast,6291457,25165824,ring,ll128,48,4,32,-1,-1
+broadcast,25165825,50331648,ring,ll128,64,4,32,-1,-1
+broadcast,50331649,100663296,ring,ll128,56,4,32,-1,-1
+broadcast,100663297,3221225472,ring,ll128,64,4,32,-1,-1
+broadcast,3221225473,17179869184,ring,simple,32,4,32,-1,-1
+broadcast,0,3072,ring,ll,16,8,64,-1,-1
+broadcast,3073,6144,ring,ll,32,8,64,-1,-1
+broadcast,6145,12288,ring,ll128,2,8,64,-1,-1
+broadcast,12289,24576,ring,ll128,16,8,64,-1,-1
+broadcast,24577,1572864,ring,ll128,1,8,64,-1,-1
+broadcast,1572865,3145728,ring,simple,1,8,64,-1,-1
+broadcast,3145729,6291456,ring,ll,32,8,64,-1,-1
+broadcast,6291457,12582912,ring,ll128,32,8,64,-1,-1
+broadcast,12582913,25165824,ring,ll128,40,8,64,-1,-1
+broadcast,25165825,50331648,ring,ll128,56,8,64,-1,-1
+broadcast,50331649,6442450944,ring,ll128,64,8,64,-1,-1
+broadcast,6442450945,17179869184,ring,simple,32,8,64,-1,-1
+broadcast,0,1536,ring,ll,24,16,128,-1,-1
+broadcast,1537,3072,ring,ll,64,16,128,-1,-1
+broadcast,3073,6144,ring,ll,24,16,128,-1,-1
+broadcast,6145,12288,ring,ll128,16,16,128,-1,-1
+broadcast,12289,24576,ring,ll128,56,16,128,-1,-1
+broadcast,24577,1572864,ring,ll128,1,16,128,-1,-1
+broadcast,1572865,6291456,ring,simple,1,16,128,-1,-1
+broadcast,6291457,12582912,ring,ll,56,16,128,-1,-1
+broadcast,12582913,25165824,ring,ll128,32,16,128,-1,-1
+broadcast,25165825,50331648,ring,ll128,48,16,128,-1,-1
+broadcast,50331649,100663296,ring,ll128,56,16,128,-1,-1
+broadcast,100663297,12884901888,ring,ll128,64,16,128,-1,-1
+broadcast,12884901889,17179869184,ring,simple,32,16,128,-1,-1


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** LWPCLPAT-634

Follow up PR to #2012 

**What were the changes?**  
Update tuner configuration file for gfx950 with broadcast for 2, 4, 8, and 16 nodes.

**Why were the changes made?**  
Improve tuner plugin for gfx950

**How was the outcome achieved?**  
Ran rccl-tests for broadcast with different number of nodes, algorithms, protocols, and channel counts. Generated a csv file from the performance data and passed the csv to /ext-tuner/example/scripts/optimize_config.py to generate an optimized config for rccl.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
