### PR TITLE
Add ncclCommDump API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,7 @@ set(SRC_FILES
   src/bootstrap.cc
   src/channel.cc
   src/collectives.cc
+  src/commDump.cc
   src/debug.cc
   src/enqueue.cc
   src/group.cc

--- a/src/commDump.cc
+++ b/src/commDump.cc
@@ -1,0 +1,26 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "nccl.h"
+#include <cstring>
+#include "comm.h"
+#include "device.h"
+#include "archinfo.h"
+
+__attribute__ ((visibility("default")))
+ncclResult_t ncclCommDump(
+    const ncclComm_t comm,
+    std::unordered_map<std::string, std::string>& map) {
+  if (comm == nullptr) {
+    WARN("ncclCommDump comm is null");
+    return ncclSuccess;
+  }
+  if (comm->proxyState->proxyTrace == nullptr) {
+    WARN("ncclCommDump comm->proxyState->proxyTrace is null");
+    return ncclSuccess;
+  }
+
+  WARN("ncclCommDump() ProxyTrace:");
+  WARN("%s", comm->proxyState->proxyTrace->dump().c_str());
+
+  return ncclSuccess;
+}

--- a/src/include/proxy_trace/proxy_trace.h
+++ b/src/include/proxy_trace/proxy_trace.h
@@ -127,11 +127,12 @@ using ProxyActiveOpIdTracker =
                        std::unordered_map<int64_t /* opCount*/, int64_t>>;
 
 class ProxyTrace {
-public:
-  ProxyTrace(int32_t rank) : myRank(rank) {}
+ public:
+  ProxyTrace(int32_t rank) : myRank(rank) {}; 
+  
+  ProxyTrace() = delete;
   ProxyTrace(const ProxyTrace &) = delete;
   ProxyTrace &operator=(const ProxyTrace &) = delete;
-  bool initialized{false};
   void checkOpCompleted(const ProxyTraceRecordKey &key);
 
   void addNewProxyTraceOpImpl(const ProxyTraceRecordKey &key,
@@ -174,8 +175,6 @@ private:
   std::deque<std::pair<std::string, std::string>> finishedOps;
 };
 struct ncclProxySubArgs;
-void proxyTraceInit(std::unique_ptr<ProxyTrace> &proxyTrace,
-                            int32_t rank, uint64_t commHash);
 
 void updateProxyOpCounter(std::unique_ptr<ProxyTrace> &proxyTraceObj,
                                   const ProxyTraceRecordKey &traceKey,

--- a/src/include/proxy_trace/proxy_trace.h
+++ b/src/include/proxy_trace/proxy_trace.h
@@ -152,6 +152,13 @@ class ProxyTrace {
       uint32_t nbytes,
       int peerRank);
 
+  // Dump all trace for a given communicator
+  std::string dump(uint64_t commHash);
+
+  // Dump all active ops
+  std::string dump();
+
+private:
   void checkOpCompleted(const ProxyTraceRecordKey &key);
 
   void addNewProxyTraceOpImpl(const ProxyTraceRecordKey &key,
@@ -163,12 +170,6 @@ class ProxyTrace {
   // If the opCount is not found, create a new entry for it and return 0
   int64_t getOrCreateProxyOpId(uint64_t commHash, uint64_t opCount);
 
-  // Dump all trace for a given communicator
-  std::string dump(uint64_t commHash);
-
-  // Dump all active ops
-  std::string dump();
-
   // check if an active send/recv operation exists for a given commHash:opCount
   bool checkActiveOpExist(uint64_t commHash, uint64_t opCount,
                           uint32_t proxyOpId) const;
@@ -177,7 +178,6 @@ class ProxyTrace {
   float getMapSizeMB() const;
   void resetAll();
 
-private:
   int myRank{-1};
 
   // Current active send/recv operations.

--- a/src/include/proxy_trace/proxy_trace.h
+++ b/src/include/proxy_trace/proxy_trace.h
@@ -135,6 +135,11 @@ class ProxyTrace {
   ProxyTrace(const ProxyTrace &) = delete;
   ProxyTrace &operator=(const ProxyTrace &) = delete;
 
+  //
+  // Public APIs called by the proxy thread and ncclCommDump().
+  // All these APIs lock the same shared mutex before executing.
+  //
+
   void updateProxyOpCounter(
       const ProxyTraceRecordKey& traceKey,
       ProxyCounterTypes counter,
@@ -159,6 +164,14 @@ class ProxyTrace {
   // Dump all active ops
   std::string dump();
 
+  //
+  // Getters called by public APIs as well as unit tests.
+  // These are not thread-safe unless called by the public APIs above.
+  // 
+
+  ProxyTraceOp *getProxyTraceOpPtr(const ProxyTraceRecordKey &traceKey);
+  float getMapSizeMB() const;
+
 private:
   void checkOpCompleted(const ProxyTraceRecordKey &key);
 
@@ -174,10 +187,6 @@ private:
   // check if an active send/recv operation exists for a given commHash:opCount
   bool checkActiveOpExist(uint64_t commHash, uint64_t opCount,
                           uint32_t proxyOpId) const;
-
-  ProxyTraceOp *getProxyTraceOpPtr(const ProxyTraceRecordKey &traceKey);
-  float getMapSizeMB() const;
-  void resetAll();
 
   mutable std::mutex mutex_;
   int myRank{-1};

--- a/src/include/proxy_trace/proxy_trace.h
+++ b/src/include/proxy_trace/proxy_trace.h
@@ -139,6 +139,10 @@ class ProxyTrace {
       ProxyCounterTypes counter,
       int64_t val);
 
+  void setProxyOpTimestamp(
+      const ProxyTraceRecordKey& traceKey,
+      ProxyCounterTypes counter);
+
   void checkOpCompleted(const ProxyTraceRecordKey &key);
 
   void addNewProxyTraceOpImpl(const ProxyTraceRecordKey &key,
@@ -181,11 +185,6 @@ private:
   std::deque<std::pair<std::string, std::string>> finishedOps;
 };
 struct ncclProxySubArgs;
-
-void setProxyOpTimestamp(
-    std::unique_ptr<ProxyTrace>& proxyTraceObj,
-    const ProxyTraceRecordKey& traceKey,
-    ProxyCounterTypes counter);
 
 void addNewProxyOp(
     std::unique_ptr<ProxyTrace> &proxyTraceObj, ProxyTraceRecordKey &key,

--- a/src/include/proxy_trace/proxy_trace.h
+++ b/src/include/proxy_trace/proxy_trace.h
@@ -107,6 +107,10 @@ struct ProxyTraceOp {
   ProxyOpStepStatus status{ProxyOpStepStatus::UNINITIALIZED};
   std::chrono::time_point<std::chrono::high_resolution_clock> startTs{};
   std::chrono::time_point<std::chrono::high_resolution_clock> lastUpdateTs{};
+  std::unordered_map<ProxyCounterTypes, std::chrono::time_point<std::chrono::high_resolution_clock>> timestamps{
+      {ProxyCounterTypes::POSTED, {}},
+      {ProxyCounterTypes::KERNEL_COPY_READY, {}},
+  };
   void computeStatus();
   // str the entry to a string
   std::string str();
@@ -176,6 +180,11 @@ void proxyTraceInit(std::unique_ptr<ProxyTrace> &proxyTrace,
 void updateProxyOpCounter(std::unique_ptr<ProxyTrace> &proxyTraceObj,
                                   const ProxyTraceRecordKey &traceKey,
                                   ProxyCounterTypes counter, int64_t val);
+
+void setProxyOpTimestamp(
+    std::unique_ptr<ProxyTrace>& proxyTraceObj,
+    const ProxyTraceRecordKey& traceKey,
+    ProxyCounterTypes counter);
 
 void addNewProxyOp(
     std::unique_ptr<ProxyTrace> &proxyTraceObj, ProxyTraceRecordKey &key,

--- a/src/include/proxy_trace/proxy_trace.h
+++ b/src/include/proxy_trace/proxy_trace.h
@@ -133,6 +133,12 @@ class ProxyTrace {
   ProxyTrace() = delete;
   ProxyTrace(const ProxyTrace &) = delete;
   ProxyTrace &operator=(const ProxyTrace &) = delete;
+
+  void updateProxyOpCounter(
+      const ProxyTraceRecordKey& traceKey,
+      ProxyCounterTypes counter,
+      int64_t val);
+
   void checkOpCompleted(const ProxyTraceRecordKey &key);
 
   void addNewProxyTraceOpImpl(const ProxyTraceRecordKey &key,
@@ -175,10 +181,6 @@ private:
   std::deque<std::pair<std::string, std::string>> finishedOps;
 };
 struct ncclProxySubArgs;
-
-void updateProxyOpCounter(std::unique_ptr<ProxyTrace> &proxyTraceObj,
-                                  const ProxyTraceRecordKey &traceKey,
-                                  ProxyCounterTypes counter, int64_t val);
 
 void setProxyOpTimestamp(
     std::unique_ptr<ProxyTrace>& proxyTraceObj,

--- a/src/include/proxy_trace/proxy_trace.h
+++ b/src/include/proxy_trace/proxy_trace.h
@@ -143,6 +143,15 @@ class ProxyTrace {
       const ProxyTraceRecordKey& traceKey,
       ProxyCounterTypes counter);
 
+  void addNewProxyOp(
+      ProxyTraceRecordKey& key,
+      const ProxyTraceExtraInfo& extraInfo,
+      ProxyOpType opType,
+      int channelId,
+      int nSteps,
+      uint32_t nbytes,
+      int peerRank);
+
   void checkOpCompleted(const ProxyTraceRecordKey &key);
 
   void addNewProxyTraceOpImpl(const ProxyTraceRecordKey &key,
@@ -185,9 +194,4 @@ private:
   std::deque<std::pair<std::string, std::string>> finishedOps;
 };
 struct ncclProxySubArgs;
-
-void addNewProxyOp(
-    std::unique_ptr<ProxyTrace> &proxyTraceObj, ProxyTraceRecordKey &key,
-    const ProxyTraceExtraInfo &extraInfo, ProxyOpType opType, int channelId,
-    int nSteps, uint32_t nbytes, int peerRank);
 } // namespace facebook_rccl

--- a/src/include/proxy_trace/proxy_trace.h
+++ b/src/include/proxy_trace/proxy_trace.h
@@ -15,6 +15,7 @@
 #endif
 #include <fmt/format.h>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 namespace facebook_rccl {
 
@@ -178,6 +179,7 @@ private:
   float getMapSizeMB() const;
   void resetAll();
 
+  mutable std::mutex mutex_;
   int myRank{-1};
 
   // Current active send/recv operations.

--- a/src/init.cc
+++ b/src/init.cc
@@ -168,7 +168,7 @@ ncclResult_t checkHostUncacheMemSetting(struct ncclComm* comm) {
     else {
       return ncclSuccess;
     }
-  #endif
+  #endif   
 }
 
 static void initOnceFunc() {
@@ -1454,7 +1454,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     }
   }
   // For single node communicators that do not uses the full xgmi links per gpu, i.e., nranks < 8
-  // Inflate the nChannels a bit to achieve higher b/w.
+  // Inflate the nChannels a bit to achieve higher b/w. 
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")) {
     if (nranks == 2 && nNodes == 1){
       allGather3Data[rank].nc = 16;
@@ -1817,8 +1817,8 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   // Compute time models for algorithm and protocol combinations
   NCCLCHECKGOTO(ncclTopoTuneModel(comm, comm->minCompCap, comm->maxCompCap, graphs), ret, fail);
 
-  INFO(NCCL_INIT, "comm:%p, nRanks:%d, nNodes:%d, coll channels:%d collnet channels:%d, nvls channels:%d, p2p channels:%d, p2p channels per peer:%d", comm, comm->nRanks, comm->nNodes, comm->nChannels, comm->nChannels, comm->nvlsChannels, comm->p2pnChannels, comm->p2pnChannelsPerPeer);
-
+  INFO(NCCL_INIT, "comm:%p, nRanks:%d, nNodes:%d, coll channels:%d collnet channels:%d, nvls channels:%d, p2p channels:%d, p2p channels per peer:%d", comm, comm->nRanks, comm->nNodes, comm->nChannels, comm->nChannels, comm->nvlsChannels, comm->p2pnChannels, comm->p2pnChannelsPerPeer);  
+  
   if (comm->intraRank == 0) { // Load ncclParamLaunchMode
     const char* str = ncclGetEnv("NCCL_LAUNCH_MODE");
     enum ncclLaunchMode mode, modeOld;
@@ -2075,10 +2075,10 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   comm->cuCount = cuCount;
 
   NCCLCHECKGOTO(initTransportsRank(comm, job->parent, timers), res, fail);
-
+  
     // Check if using host uncached mem correctly
   NCCLCHECK(checkHostUncacheMemSetting(comm));
-
+  
   // RCCL: determine and set unroll factor for comm
   NCCLCHECK(commSetUnrollFactor(comm));
 

--- a/src/init.cc
+++ b/src/init.cc
@@ -168,7 +168,7 @@ ncclResult_t checkHostUncacheMemSetting(struct ncclComm* comm) {
     else {
       return ncclSuccess;
     }
-  #endif   
+  #endif
 }
 
 static void initOnceFunc() {
@@ -439,7 +439,7 @@ static ncclResult_t commFree(ncclComm_t comm) {
   free(comm->connectRecv);
 
   if (rcclParamEnableProxyTrace()) {
-    WARN("ProxyTrace:");
+    WARN("commFree() ProxyTrace:");
     if (comm->proxyState && comm->proxyState->proxyTrace){
       WARN("%s", comm->proxyState->proxyTrace->dump().c_str());
     }
@@ -1454,7 +1454,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     }
   }
   // For single node communicators that do not uses the full xgmi links per gpu, i.e., nranks < 8
-  // Inflate the nChannels a bit to achieve higher b/w. 
+  // Inflate the nChannels a bit to achieve higher b/w.
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")) {
     if (nranks == 2 && nNodes == 1){
       allGather3Data[rank].nc = 16;
@@ -1817,8 +1817,8 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   // Compute time models for algorithm and protocol combinations
   NCCLCHECKGOTO(ncclTopoTuneModel(comm, comm->minCompCap, comm->maxCompCap, graphs), ret, fail);
 
-  INFO(NCCL_INIT, "comm:%p, nRanks:%d, nNodes:%d, coll channels:%d collnet channels:%d, nvls channels:%d, p2p channels:%d, p2p channels per peer:%d", comm, comm->nRanks, comm->nNodes, comm->nChannels, comm->nChannels, comm->nvlsChannels, comm->p2pnChannels, comm->p2pnChannelsPerPeer);  
-  
+  INFO(NCCL_INIT, "comm:%p, nRanks:%d, nNodes:%d, coll channels:%d collnet channels:%d, nvls channels:%d, p2p channels:%d, p2p channels per peer:%d", comm, comm->nRanks, comm->nNodes, comm->nChannels, comm->nChannels, comm->nvlsChannels, comm->p2pnChannels, comm->p2pnChannelsPerPeer);
+
   if (comm->intraRank == 0) { // Load ncclParamLaunchMode
     const char* str = ncclGetEnv("NCCL_LAUNCH_MODE");
     enum ncclLaunchMode mode, modeOld;
@@ -2075,10 +2075,10 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   comm->cuCount = cuCount;
 
   NCCLCHECKGOTO(initTransportsRank(comm, job->parent, timers), res, fail);
-  
+
     // Check if using host uncached mem correctly
   NCCLCHECK(checkHostUncacheMemSetting(comm));
-  
+
   // RCCL: determine and set unroll factor for comm
   NCCLCHECK(commSetUnrollFactor(comm));
 

--- a/src/misc/proxy_trace/proxy_trace.cc
+++ b/src/misc/proxy_trace/proxy_trace.cc
@@ -24,12 +24,6 @@ static std::unordered_map<facebook_rccl::ProxyOpStepStatus, std::string>
         {facebook_rccl::ProxyOpStepStatus::UNINITIALIZED, "ILLEGAL"},
 };
 
-void facebook_rccl::ProxyTrace::resetAll() {
-  activeOps.clear();
-  activeOpIdTracker.clear();
-  myRank = -1;
-}
-
 bool facebook_rccl::ProxyTrace::checkActiveOpExist(uint64_t commHash,
                                                    uint64_t opCount,
                                                    uint32_t proxyOpId) const {

--- a/src/misc/proxy_trace/proxy_trace.cc
+++ b/src/misc/proxy_trace/proxy_trace.cc
@@ -28,7 +28,6 @@ void facebook_rccl::ProxyTrace::resetAll() {
   activeOps.clear();
   activeOpIdTracker.clear();
   myRank = -1;
-  initialized = false;
 }
 
 bool facebook_rccl::ProxyTrace::checkActiveOpExist(uint64_t commHash,
@@ -224,20 +223,6 @@ float facebook_rccl::ProxyTrace::getMapSizeMB() const {
     size += keyStr_proxyOpStr.first.size() + keyStr_proxyOpStr.second.size();
   }
   return size / 1024.0 / 1024.0;
-}
-
-void facebook_rccl::proxyTraceInit(std::unique_ptr<ProxyTrace> &proxyTrace,
-                                   int32_t rank, uint64_t commHash) {
-  if (proxyTrace) {
-    WARN("[proxyTrace] Initializing non-empty proxyTrace! rank: %d, commHash: "
-         "%lu",
-         rank, commHash);
-    return;
-  }
-  INFO(NCCL_PROXY, "Initializing ProxyTrace, rank: %d, commHash: %lu", rank,
-       commHash);
-  proxyTrace = std::make_unique<facebook_rccl::ProxyTrace>(rank);
-  proxyTrace->initialized = true;
 }
 
 void facebook_rccl::updateProxyOpCounter(

--- a/src/misc/proxy_trace/proxy_trace.cc
+++ b/src/misc/proxy_trace/proxy_trace.cc
@@ -182,7 +182,7 @@ std::string facebook_rccl::ProxyTrace::dump() {
 std::string facebook_rccl::ProxyTraceOp::str() {
   computeStatus();
   std::string ret = fmt::format(
-      "createT:{}, lastT:{}, cntNm:{}, {}, {}, {}->{}({}), "
+      "createT:{}, lastT:{}, postT:{}, sendT:{}, cntNm:{}, {}, {}, {}->{}({}), "
       "chan:{}, status:{}, ns:{}, nb:{}, po:{}, ke:{}, tail/h:{}, recvT:{}, "
       "connSz/h:{}, trans:{}, flushed:{}, recvd:{}, done:{}\n",
       std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -191,6 +191,12 @@ std::string facebook_rccl::ProxyTraceOp::str() {
       std::chrono::duration_cast<std::chrono::milliseconds>(
           lastUpdateTs.time_since_epoch())
           .count(),
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          timestamps[facebook_rccl::ProxyCounterTypes::POSTED].time_since_epoch())
+          .count(),
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          timestamps[facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY].time_since_epoch())
+          .count(),  
       static_cast<int>(lastUpdatingCounter), traceKey.str(), extraInfo.str(),
       myRank, peerRank, opType == ProxyOpType::SEND ? "S" : "R", channelId,
       proxyStepStatusStrMap[status], nSteps, nbytes,
@@ -247,6 +253,22 @@ void facebook_rccl::updateProxyOpCounter(
       proxyTraceObj->checkOpCompleted(traceKey);
     }
   }
+}
+
+void facebook_rccl::setProxyOpTimestamp(
+    std::unique_ptr<ProxyTrace>& proxyTraceObj,
+    const ProxyTraceRecordKey& traceKey,
+    ProxyCounterTypes counter) {
+  if (!proxyTraceObj) {
+    return;
+  }
+
+  auto traceOpPtr = proxyTraceObj->getProxyTraceOpPtr(traceKey);
+  if (!traceOpPtr || traceOpPtr->timestamps.find(counter) == traceOpPtr->timestamps.end()) {
+    return;
+  }
+
+  traceOpPtr->timestamps[counter] = std::chrono::high_resolution_clock::now();
 }
 
 void facebook_rccl::addNewProxyOp(std::unique_ptr<ProxyTrace> &proxyTraceObj,

--- a/src/misc/proxy_trace/proxy_trace.cc
+++ b/src/misc/proxy_trace/proxy_trace.cc
@@ -238,15 +238,11 @@ void facebook_rccl::ProxyTrace::updateProxyOpCounter(
   }
 }
 
-void facebook_rccl::setProxyOpTimestamp(
-    std::unique_ptr<ProxyTrace>& proxyTraceObj,
+void facebook_rccl::ProxyTrace::setProxyOpTimestamp(
     const ProxyTraceRecordKey& traceKey,
     ProxyCounterTypes counter) {
-  if (!proxyTraceObj) {
-    return;
-  }
 
-  auto traceOpPtr = proxyTraceObj->getProxyTraceOpPtr(traceKey);
+  auto traceOpPtr = getProxyTraceOpPtr(traceKey);
   if (!traceOpPtr || traceOpPtr->timestamps.find(counter) == traceOpPtr->timestamps.end()) {
     return;
   }

--- a/src/misc/proxy_trace/proxy_trace.cc
+++ b/src/misc/proxy_trace/proxy_trace.cc
@@ -136,6 +136,7 @@ void facebook_rccl::ProxyTraceOp::computeStatus() {
 }
 
 std::string facebook_rccl::ProxyTrace::dump(uint64_t commHash) {
+  std::lock_guard<std::mutex> lock(mutex_);
   std::string result = fmt::format("commDump for commHash:{}\n", commHash);
   std::map<std::string, std::string> sortedDumpStrMap;
   for (auto &opCountMap : activeOps.at(commHash)) {
@@ -153,6 +154,7 @@ std::string facebook_rccl::ProxyTrace::dump(uint64_t commHash) {
 }
 
 std::string facebook_rccl::ProxyTrace::dump() {
+  std::lock_guard<std::mutex> lock(mutex_);
   std::string result = "commDump for all active ops ";
   result += fmt::format("mapSizeMB:{:.2f}\n", getMapSizeMB());
 
@@ -229,6 +231,7 @@ void facebook_rccl::ProxyTrace::updateProxyOpCounter(
     const ProxyTraceRecordKey& traceKey,
     ProxyCounterTypes counter,
     int64_t val) {
+  std::lock_guard<std::mutex> lock(mutex_);
   auto traceOpPtr = getProxyTraceOpPtr(traceKey);
   if (traceOpPtr) {
     traceOpPtr->counters[counter] = val;
@@ -241,7 +244,7 @@ void facebook_rccl::ProxyTrace::updateProxyOpCounter(
 void facebook_rccl::ProxyTrace::setProxyOpTimestamp(
     const ProxyTraceRecordKey& traceKey,
     ProxyCounterTypes counter) {
-
+  std::lock_guard<std::mutex> lock(mutex_);
   auto traceOpPtr = getProxyTraceOpPtr(traceKey);
   if (!traceOpPtr || traceOpPtr->timestamps.find(counter) == traceOpPtr->timestamps.end()) {
     return;
@@ -258,6 +261,7 @@ void facebook_rccl::ProxyTrace::addNewProxyOp(
     int nSteps,
     uint32_t nbytes,
     int peerRank) {
+  std::lock_guard<std::mutex> lock(mutex_);
   auto opId = getOrCreateProxyOpId(key.commHash, key.opCount);
   key.proxyOpId = opId;
   addNewProxyTraceOpImpl(

--- a/src/misc/proxy_trace/proxy_trace.cc
+++ b/src/misc/proxy_trace/proxy_trace.cc
@@ -225,18 +225,16 @@ float facebook_rccl::ProxyTrace::getMapSizeMB() const {
   return size / 1024.0 / 1024.0;
 }
 
-void facebook_rccl::updateProxyOpCounter(
-    std::unique_ptr<ProxyTrace> &proxyTraceObj,
-    const ProxyTraceRecordKey &traceKey, ProxyCounterTypes counter,
+void facebook_rccl::ProxyTrace::updateProxyOpCounter(
+    const ProxyTraceRecordKey& traceKey,
+    ProxyCounterTypes counter,
     int64_t val) {
-  if (proxyTraceObj) {
-    auto traceOpPtr = proxyTraceObj->getProxyTraceOpPtr(traceKey);
-    if (traceOpPtr) {
-      traceOpPtr->counters[counter] = val;
-      traceOpPtr->lastUpdateTs = std::chrono::high_resolution_clock::now();
-      traceOpPtr->lastUpdatingCounter = counter;
-      proxyTraceObj->checkOpCompleted(traceKey);
-    }
+  auto traceOpPtr = getProxyTraceOpPtr(traceKey);
+  if (traceOpPtr) {
+    traceOpPtr->counters[counter] = val;
+    traceOpPtr->lastUpdateTs = std::chrono::high_resolution_clock::now();
+    traceOpPtr->lastUpdatingCounter = counter;
+    checkOpCompleted(traceKey);
   }
 }
 

--- a/src/misc/proxy_trace/proxy_trace.cc
+++ b/src/misc/proxy_trace/proxy_trace.cc
@@ -250,15 +250,16 @@ void facebook_rccl::ProxyTrace::setProxyOpTimestamp(
   traceOpPtr->timestamps[counter] = std::chrono::high_resolution_clock::now();
 }
 
-void facebook_rccl::addNewProxyOp(std::unique_ptr<ProxyTrace> &proxyTraceObj,
-                                  ProxyTraceRecordKey &key,
-                                  const ProxyTraceExtraInfo &extraInfo,
-                                  ProxyOpType opType, int channelId, int nSteps,
-                                  uint32_t nbytes, int peerRank) {
-  if (proxyTraceObj) {
-    auto opId = proxyTraceObj->getOrCreateProxyOpId(key.commHash, key.opCount);
-    key.proxyOpId = opId;
-    proxyTraceObj->addNewProxyTraceOpImpl(key, extraInfo, opType, channelId,
-                                          nSteps, nbytes, peerRank);
-  }
+void facebook_rccl::ProxyTrace::addNewProxyOp(
+    ProxyTraceRecordKey& key,
+    const ProxyTraceExtraInfo& extraInfo,
+    ProxyOpType opType,
+    int channelId,
+    int nSteps,
+    uint32_t nbytes,
+    int peerRank) {
+  auto opId = getOrCreateProxyOpId(key.commHash, key.opCount);
+  key.proxyOpId = opId;
+  addNewProxyTraceOpImpl(
+      key, extraInfo, opType, channelId, nSteps, nbytes, peerRank);
 }

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -949,4 +949,16 @@ ncclResult_t pncclGroupSimulateEnd(ncclSimInfo_t* simInfo);
 } // end extern "C"
 #endif
 
+#ifdef __cplusplus
+#define NCCL_COMM_DUMP
+
+#include <unordered_map>
+#include <string>
+/* Dump NCCL current internal state for a given communicator in a key-value store format.
+ * define outside extern "C"{} to pass C++ template */
+ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std::string>& map);
+#else
+#warning "NCCL C++ API is disabled because C compiler is being used. Please use a C++ compiler to build NCCL."
+#endif
+
 #endif // end include guard

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -1873,7 +1873,8 @@ ncclResult_t ncclProxyInit(struct ncclComm* comm, struct ncclSocket* sock, union
   comm->proxyState->peerAddresses = peerAddresses;
   comm->proxyState->peerAddressesUDS = peerAddressesUDS;
   if (rcclParamEnableProxyTrace()) {
-    facebook_rccl::proxyTraceInit(comm->proxyState->proxyTrace, comm->rank, comm->commHash);
+    INFO(NCCL_PROXY, "Initializing ProxyTrace, rank: %d, commHash: %lu", comm->rank, comm->commHash);
+    comm->proxyState->proxyTrace = std::make_unique<facebook_rccl::ProxyTrace>(comm->rank);
   }
 
   // UDS support

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1315,6 +1315,7 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
         }
         ncclProfilerRecordProxyStepEventState(s, args, postedStepId, ncclProfilerProxyStepSendGPUWait);
         facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED, sub->posted);
+        setProxyOpTimestamp(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED);        
         args->idle = 0;
         continue;
       }
@@ -1395,6 +1396,7 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
             if (ignoreCompletion) *requestPtr = (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION;
             NCCLCHECK(proxyState->ncclNet->isend(resources->netSendComm, buff, size, resources->tpRank, sub->sendMhandle, phandle, requestPtr));
             if (*requestPtr != NULL) {
+              setProxyOpTimestamp(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_NET_SEND_ENTRY) && defined(ENABLE_NPKIT_EVENT_NET_SEND_EXIT)
               NpKit::CollectCpuEvent(
                   NPKIT_EVENT_NET_SEND_ENTRY,

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1497,8 +1497,10 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
           TRACE(NCCL_NET, "sendProxy [%ld/%d/%d] request %p done", sub->done, buffSlot, sub->nsteps, sub->requests[buffSlot]);
           sub->done += args->sliceSteps;
           ncclProfilerStopProxyStepEvent(s, args, doneStepId);
-          facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, 
-            facebook_rccl::ProxyCounterTypes::DONE, sub->done);
+          if (proxyState->proxyTrace) {
+            proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey,
+              facebook_rccl::ProxyCounterTypes::DONE, sub->done);
+          }
           if (resources->shared == 0) {
             volatile uint64_t* sendHead = resources->gdcSync ? resources->gdcSync : &resources->sendMem->head;
             *sendHead = sub->base + sub->done;
@@ -1861,7 +1863,10 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
             int doneStepId = sub->done;
             sub->done += args->sliceSteps;
             ncclProfilerStopProxyStepEvent(s+i, args, doneStepId);
-            facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::DONE, sub->done);
+            if (proxyState->proxyTrace) {
+              proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey,
+                facebook_rccl::ProxyCounterTypes::DONE, sub->done);
+            }
             args->idle = 0;
             if (sub->done == sub->nsteps) {
               args->done++;

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1271,9 +1271,16 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
       resources->step = sub->base + sub->nsteps;
       sub->posted = sub->transmitted = sub->done = 0;
       ncclProfilerRecordProxyOpEventState(s, args, ncclProfilerProxyOpInProgress_v4);
-      facebook_rccl::addNewProxyOp(proxyState->proxyTrace, sub->traceKey, 
-        sub->traceInfo,  facebook_rccl::ProxyOpType::SEND,
-        sub->channelId, sub->nsteps, sub->nbytes, sub->peer);
+      if (proxyState->proxyTrace) {
+        proxyState->proxyTrace->addNewProxyOp(
+            sub->traceKey, 
+            sub->traceInfo,  
+            facebook_rccl::ProxyOpType::SEND,
+            sub->channelId, 
+            sub->nsteps, 
+            sub->nbytes, 
+            sub->peer);
+      }
       if (!sub->reg)
         sub->sendMhandle = resources->mhandles[args->protocol];
     }
@@ -1558,8 +1565,16 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
       sub->regBufferReady = 0;
       for (int i=0; i<groupSize; i++) sub[-i].groupSize = groupSize;
       ncclProfilerRecordProxyOpEventState(s, args, ncclProfilerProxyOpInProgress_v4);
-      facebook_rccl::addNewProxyOp(proxyState->proxyTrace, sub->traceKey, sub->traceInfo,  
-        facebook_rccl::ProxyOpType::RECV, sub->channelId, sub->nsteps, sub->nbytes, sub->peer);
+      if (proxyState->proxyTrace) {
+        proxyState->proxyTrace->addNewProxyOp(
+            sub->traceKey, 
+            sub->traceInfo,  
+            facebook_rccl::ProxyOpType::RECV,
+            sub->channelId, 
+            sub->nsteps, 
+            sub->nbytes, 
+            sub->peer);
+      }
       if (!sub->reg)
         sub->recvMhandle = resources->mhandles[args->protocol];
     }

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1315,7 +1315,7 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
         }
         ncclProfilerRecordProxyStepEventState(s, args, postedStepId, ncclProfilerProxyStepSendGPUWait);
         facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED, sub->posted);
-        setProxyOpTimestamp(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED);        
+        facebook_rccl::setProxyOpTimestamp(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED);        
         args->idle = 0;
         continue;
       }
@@ -1396,7 +1396,7 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
             if (ignoreCompletion) *requestPtr = (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION;
             NCCLCHECK(proxyState->ncclNet->isend(resources->netSendComm, buff, size, resources->tpRank, sub->sendMhandle, phandle, requestPtr));
             if (*requestPtr != NULL) {
-              setProxyOpTimestamp(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY);
+              facebook_rccl::setProxyOpTimestamp(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_NET_SEND_ENTRY) && defined(ENABLE_NPKIT_EVENT_NET_SEND_EXIT)
               NpKit::CollectCpuEvent(
                   NPKIT_EVENT_NET_SEND_ENTRY,

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1316,8 +1316,8 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
         ncclProfilerRecordProxyStepEventState(s, args, postedStepId, ncclProfilerProxyStepSendGPUWait);
         if (proxyState->proxyTrace) {
           proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED, sub->posted);
+          proxyState->proxyTrace->setProxyOpTimestamp(sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED);
         }
-        setProxyOpTimestamp(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED);
         args->idle = 0;
         continue;
       }
@@ -1399,7 +1399,9 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
             if (ignoreCompletion) *requestPtr = (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION;
             NCCLCHECK(proxyState->ncclNet->isend(resources->netSendComm, buff, size, resources->tpRank, sub->sendMhandle, phandle, requestPtr));
             if (*requestPtr != NULL) {
-              facebook_rccl::setProxyOpTimestamp(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY);
+              if (proxyState->proxyTrace) {
+                proxyState->proxyTrace->setProxyOpTimestamp(sub->traceKey, facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY);
+              }              
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_NET_SEND_ENTRY) && defined(ENABLE_NPKIT_EVENT_NET_SEND_EXIT)
               NpKit::CollectCpuEvent(
                   NPKIT_EVENT_NET_SEND_ENTRY,

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -1314,8 +1314,10 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
           sub->posted += args->sliceSteps;
         }
         ncclProfilerRecordProxyStepEventState(s, args, postedStepId, ncclProfilerProxyStepSendGPUWait);
-        facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED, sub->posted);
-        facebook_rccl::setProxyOpTimestamp(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED);        
+        if (proxyState->proxyTrace) {
+          proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED, sub->posted);
+        }
+        setProxyOpTimestamp(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED);
         args->idle = 0;
         continue;
       }
@@ -1324,15 +1326,14 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
         int buffSlot = (sub->base+sub->transmitted)%NCCL_STEPS;
         volatile uint64_t* recvTail = &resources->recvMem->tail;
         uint64_t tail = sub->base + sub->transmitted;
-        facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey,
-          facebook_rccl::ProxyCounterTypes::RECV_TAIL, *recvTail);
-
-        facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey,
-          facebook_rccl::ProxyCounterTypes::TAIL_OR_HEAD, tail);
-
-        facebook_rccl::updateProxyOpCounter(
-          proxyState->proxyTrace, sub->traceKey,
-          facebook_rccl::ProxyCounterTypes::FIFO_SZ_OR_HEAD_CACHE, connFifo[buffSlot].size);
+        if (proxyState->proxyTrace) {
+          proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey,
+            facebook_rccl::ProxyCounterTypes::RECV_TAIL, *recvTail);
+          proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey,
+            facebook_rccl::ProxyCounterTypes::TAIL_OR_HEAD, tail);
+          proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey,
+            facebook_rccl::ProxyCounterTypes::FIFO_SZ_OR_HEAD_CACHE, connFifo[buffSlot].size);
+        }
           
         if (connFifo[buffSlot].size != -1 && (*recvTail > tail || p == NCCL_PROTO_LL)) {
           // We have something to receive, let's check if it's completely ready.
@@ -1381,8 +1382,10 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
               *resources->curr_hdp_reg = 1;
             }
             ncclProfilerRecordProxyStepEventState(s, args, transmittedStepId, ncclProfilerProxyStepSendPeerWait_v4);
-            facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, 
-              facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY, sub->reg ? 1: sub->transmitted + args->sliceSteps);
+            if (proxyState->proxyTrace) {
+              proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey, 
+                facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY, sub->reg ? 1: sub->transmitted + args->sliceSteps);
+            }
             // Data is ready, try to send.
             // Coverity complains about the size here as pointing to an out-of-scope temporary.  Which is nonsense,
             // since size is a plain integer.
@@ -1416,8 +1419,10 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
               sub->transSize = size;
               sub->transmitted += args->sliceSteps;
               ncclProfilerRecordProxyStepEventState(s, args, transmittedStepId, ncclProfilerProxyStepSendWait);
-              facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, 
-                facebook_rccl::ProxyCounterTypes::TRANSMITTED, sub->transmitted);
+              if (proxyState->proxyTrace) {
+                proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey, 
+                  facebook_rccl::ProxyCounterTypes::TRANSMITTED, sub->transmitted);
+              }
               args->idle = 0;
               continue;
             }
@@ -1649,8 +1654,10 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
 
             sub->posted += args->sliceSteps;
             ncclProfilerRecordProxyStepEventState(s+i, args, postedStepId, ncclProfilerProxyStepRecvWait);
-            facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, 
-              sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED, sub->posted);
+            if (proxyState->proxyTrace) {
+              proxyState->proxyTrace->updateProxyOpCounter(
+                sub->traceKey, facebook_rccl::ProxyCounterTypes::POSTED, sub->posted);
+            }
           }
           args->idle = 0;
         }
@@ -1698,7 +1705,9 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
             sub->transSize = sizes[i];
             sub->received += args->sliceSteps;
             ncclProfilerRecordProxyStepEventState(s+i, args, receivedStepId, ncclProfilerProxyStepRecvFlushWait);
-            facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::RECEIVED, sub->received);
+            if (proxyState->proxyTrace) {
+              proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey, facebook_rccl::ProxyCounterTypes::RECEIVED, sub->received);
+            }
             if (step < sub->nsteps) {
               struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
               if (resources->useGdr) needFlush |= resources->needFlush;
@@ -1759,7 +1768,9 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
               if (subGroup->requests[step%NCCL_STEPS]){
                 for(int i=0; i<subGroup->groupSize; i++) {
                   struct ncclProxySubArgs* sub = subGroup + i;
-                  facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::FLUSHED, sub->received);
+                  if (proxyState->proxyTrace) {
+                    proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey, facebook_rccl::ProxyCounterTypes::FLUSHED, sub->received);
+                  }
                 }
               }
               if (once) {
@@ -1788,13 +1799,17 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
 
             sub->transmitted += args->sliceSteps;
             ncclProfilerRecordProxyStepEventState(s+i, args, transmittedStepId, ncclProfilerProxyStepRecvGPUWait);
-            facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::TRANSMITTED, sub->transmitted);
+            if (proxyState->proxyTrace) {
+              proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey, facebook_rccl::ProxyCounterTypes::TRANSMITTED, sub->transmitted);
+            }
             if (step < sub->nsteps) {
               __sync_synchronize();
               struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
               volatile uint64_t* recvTail = resources->gdcSync ? resources->gdcSync : &resources->recvMem->tail;
               *recvTail = sub->base + sub->transmitted;
-              facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::RECV_TAIL, *recvTail);
+              if (proxyState->proxyTrace) {
+                proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey, facebook_rccl::ProxyCounterTypes::RECV_TAIL, *recvTail);
+              }
               if (resources->gdcSync) wc_store_fence(); // Flush out WC write
             }
           }
@@ -1813,8 +1828,10 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
           struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
           volatile uint64_t* sendHead = &resources->sendMem->head;
           uint64_t done = *sendHead;
-          facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::TAIL_OR_HEAD, done);
-          facebook_rccl::updateProxyOpCounter(proxyState->proxyTrace, sub->traceKey, facebook_rccl::ProxyCounterTypes::FIFO_SZ_OR_HEAD_CACHE, sub->base + sub->done);
+          if (proxyState->proxyTrace) {
+            proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey, facebook_rccl::ProxyCounterTypes::TAIL_OR_HEAD, done);
+            proxyState->proxyTrace->updateProxyOpCounter(sub->traceKey, facebook_rccl::ProxyCounterTypes::FIFO_SZ_OR_HEAD_CACHE, sub->base + sub->done);
+          }
           while (done > sub->base + sub->done &&
               // LL and LL128 can acknowledge 0-bytes send before they even happen. Don't go past what we transmitted.
               sub->transmitted > sub->done) {

--- a/test/proxy_trace/ProxyTraceUnitTests.cpp
+++ b/test/proxy_trace/ProxyTraceUnitTests.cpp
@@ -9,6 +9,7 @@
 #include "proxy_trace/proxy_trace.h"
 #include <cstdint>
 #include <gtest/gtest.h>
+#include <memory>
 #include <unistd.h>
 namespace RcclUnitTesting {
 
@@ -21,7 +22,7 @@ public:
   int nSteps = 10;
   void SetUp() override {
     proxyState = new ncclProxyState();
-    facebook_rccl::proxyTraceInit(proxyState->proxyTrace, 0, commHash);
+    proxyState->proxyTrace = std::make_unique<facebook_rccl::ProxyTrace>(0);
     EXPECT_NE(proxyState->proxyTrace, nullptr);
     sub1 = new ncclProxySubArgs();
     sub2 = new ncclProxySubArgs();
@@ -36,9 +37,12 @@ public:
     delete proxyState;
   }
   void AddTraceOp(ncclProxySubArgs *sub, facebook_rccl::ProxyOpType opType) {
-    facebook_rccl::addNewProxyOp(proxyState->proxyTrace, sub->traceKey,
-                                 sub->traceInfo, opType, sub->channelId,
-                                 sub->nsteps, sub->nbytes, sub->peer);
+    proxyState->proxyTrace->addNewProxyOp(
+        sub->traceKey,
+        sub->traceInfo, 
+        opType, 
+        sub->channelId,
+        sub->nsteps, sub->nbytes, sub->peer);
   }
 };
 
@@ -49,16 +53,10 @@ TEST_F(ProxyTraceTestFixture, nonEmptySingleton) {
 
 TEST_F(ProxyTraceTestFixture, addTraceOp) {
   auto &tracer = proxyState->proxyTrace;
-  EXPECT_EQ(tracer->getOrCreateProxyOpId(sub1->traceKey.commHash,
-                                         sub1->traceKey.opCount),
-            0);
   AddTraceOp(sub1, facebook_rccl::ProxyOpType::SEND);
   EXPECT_EQ(sub1->traceKey.proxyOpId, 0);
   AddTraceOp(sub2, facebook_rccl::ProxyOpType::RECV);
   EXPECT_EQ(sub2->traceKey.proxyOpId, 1);
-  EXPECT_EQ(tracer->getOrCreateProxyOpId(sub1->traceKey.commHash,
-                                         sub1->traceKey.opCount),
-            2);
   auto traceRecordPtr = tracer->getProxyTraceOpPtr(sub1->traceKey);
   EXPECT_EQ(traceRecordPtr->opType, facebook_rccl::ProxyOpType::SEND);
 }
@@ -73,9 +71,10 @@ TEST_F(ProxyTraceTestFixture, getMapSizeMB) {
   EXPECT_GT(size2, size1);
   // finish sub1
   sub1->done = nSteps;
-  facebook_rccl::updateProxyOpCounter(tracer, sub1->traceKey,
-                                      facebook_rccl::ProxyCounterTypes::DONE,
-                                      sub1->done);
+  tracer->updateProxyOpCounter(
+      sub1->traceKey,
+      facebook_rccl::ProxyCounterTypes::DONE,
+      sub1->done);
   // sub1 is now serialized and should be moved from activeOps to finishedOps
   auto size3 = tracer->getMapSizeMB();
   EXPECT_GT(size3, size1);
@@ -84,13 +83,14 @@ TEST_F(ProxyTraceTestFixture, getMapSizeMB) {
 TEST_F(ProxyTraceTestFixture, updateTraceOp) {
   auto &tracer = proxyState->proxyTrace;
   AddTraceOp(sub1, facebook_rccl::ProxyOpType::SEND);
-  facebook_rccl::updateProxyOpCounter(
-      tracer, sub1->traceKey,
-      facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY, 1);
-  facebook_rccl::updateProxyOpCounter(
-      tracer, sub1->traceKey, facebook_rccl::ProxyCounterTypes::POSTED, 3);
-  facebook_rccl::updateProxyOpCounter(
-      tracer, sub1->traceKey, facebook_rccl::ProxyCounterTypes::TRANSMITTED, 2);
+  tracer->updateProxyOpCounter(
+      sub1->traceKey,
+      facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY, 
+      1);
+  tracer->updateProxyOpCounter(
+      sub1->traceKey, facebook_rccl::ProxyCounterTypes::POSTED, 3);
+  tracer->updateProxyOpCounter(
+      sub1->traceKey, facebook_rccl::ProxyCounterTypes::TRANSMITTED, 2);
 
   auto traceRecordPtr = tracer->getProxyTraceOpPtr(sub1->traceKey);
   EXPECT_NE(traceRecordPtr, nullptr);
@@ -110,25 +110,12 @@ TEST_F(ProxyTraceTestFixture, updateTraceOp2) {
   AddTraceOp(sub1, facebook_rccl::ProxyOpType::SEND);
   int64_t rand = 123456789;
   sub1->posted = rand;
-  facebook_rccl::updateProxyOpCounter(tracer, sub1->traceKey,
-                                      facebook_rccl::ProxyCounterTypes::POSTED,
-                                      sub1->posted);
+  tracer->updateProxyOpCounter(sub1->traceKey,
+                               facebook_rccl::ProxyCounterTypes::POSTED,
+                               sub1->posted);
   auto traceRecordPtr = tracer->getProxyTraceOpPtr(sub1->traceKey);
   EXPECT_EQ(traceRecordPtr->counters[facebook_rccl::ProxyCounterTypes::POSTED],
             rand);
-}
-
-TEST_F(ProxyTraceTestFixture, memoryReclaim) {
-  auto &tracer = proxyState->proxyTrace;
-  tracer->resetAll();
-  AddTraceOp(sub1, facebook_rccl::ProxyOpType::SEND);
-  sub1->done = nSteps;
-  facebook_rccl::updateProxyOpCounter(tracer, sub1->traceKey,
-                                      facebook_rccl::ProxyCounterTypes::DONE,
-                                      sub1->done);
-  auto traceRecordPtr = tracer->getProxyTraceOpPtr(sub1->traceKey);
-  EXPECT_EQ(traceRecordPtr, nullptr);
-  EXPECT_GT(tracer->getMapSizeMB(), 0);
 }
 
 } // namespace RcclUnitTesting


### PR DESCRIPTION
# Context
PyTorch Distributed's ProcessGroupNCCL has a watchdog thread that detects collective hangs or errors. For Meta's NCCLX and RCCLX, this triggers a custom NCCL API we have defined called `ncclCommDump()`, which prints data from our ProxyTrace. This is useful because we can't rely on the ProxyTrace print in `commFree()`, since PyTorch Distributed does not always clean up all the communicators during NCCL errors.

We want to open-source this functionality so that PTD jobs on open-source RCCL can have the same functionality.

# Implementation Details
- In a new file, add barebones `ncclCommDump()` API that dumps the ProxyTrace contents, similar to our current behavior in `commFree()`
  - Add `ncclCommDump()` to nccl.h
  - Modify logs so we can distringuish between ncclCommDump and commFree output
- Introduce timestamps for post and lastSend, and add them to the ProxyTrace dump
  - Add a map from proxy op stage to timestamp
  - Add helper function for setting the timestamps
  - Add calls to set the timestamps in `transport/net.cc`
- Made the public APIs for ProxyTrace thread-safe
  - Instead of having the APIs as non-member functions that called ProxyTrace member functions underneath, moved them into the class. This addition layer of indirection was confusing and made it difficult to synchornize the APIs with a shared mutex.
     - `proxyTraceInit()` -> `ProxyTrace::ProxyTrace()`
     - `updateProxyOpCounter()`
     - `setProxyOpTimestamp()`
     - `addNewProxyOp()`
   - Added a lock acquire at the start of each public API call. 
   - Made internal implementation details like `addNewProxyTraceOpImpl()` private. These will not be called by other RCCL code directly and should not be public
   - Updated unit tests
     - Removed resetAll() and its corresponding unit test. This is not used anywhere.
     - Removed unnecessary testing of getOrCreateProxyOpId(). We should just test the public API calling it underneath (`addNewProxyOp()`)

# Testing
Testing these changes requires a multi-node setup. We did this internally with a 2-node PyTorch Distributed job, as well as a 2-node MPI test. We have a somewhat convoluted Python script for doing this, but the final run arguments look like this
```
" ".join(
    [
        f"{MPIRUN}",
        f"-x LD_LIBRARY_PATH={OMPI_LIB}:{RCCL_BUILD_DIR_LIB}",
        f"-np {total_gpus}",
        f"-host {hosts_with_slots}",
        "--allow-run-as-root",
        "-x RCCL_ENABLE_PROXY_TRACE=1",
        "-x NCCL_DEBUG=WARN",
        "-x HSA_NO_SCRATCH_RECLAIM=1",
        f"{rccl_test_binary_path} -b {args.minbytes} -e {args.maxbytes} -g 1 -f 2",
    ]
),
```
This is what the logs look like at the end when the communicator is dumped.
```
[0] ~/rccl/build/release/hipify/src/init.cc:445 NCCL WARN commDump for all active ops mapSizeMB:0.01
createT:1763627168308, lastT:1763627168328, postT:0, sendT:0, cntNm:7, <1502607184520987562:1367:0>, [fu,pr,pa,tb,ck]:4,2,1,0,2097152, 0->8(R), chan:53, status:DONE, ns:240, nb:1048576, po:240, ke:0, tail/h:39240, recvT:39240, connSz/h:39238, trans:240, flushed:240, recvd:240, done:240
createT:1763627168308, lastT:1763627168329, postT:1763627168328, sendT:1763627168328, cntNm:7, <1502607184520987562:1367:10>, [fu,pr,pa,tb,ck]:4,2,1,0,2097152, 0->8(S), chan:21, status:DONE, ns:240, nb:1048576, po:240, ke:240, tail/h:39238, recvT:39240, connSz/h:1048576, trans:240, flushed:0, recvd:0, done:240
createT:1763627168308, lastT:1763627168329, postT:1763627168328, sendT:1763627168329, cntNm:7, <1502607184520987562:1367:11>, [fu,pr,pa,tb,ck]:4,2,1,0,2097152, 0->8(S), chan:42, status:DONE, ns:240, nb:1048576, po:240, ke:240, tail/h:39238, recvT:39240
```
We also pass the unit tests
```
$ sudo ONLY_FUNCS="AllReduce * * Sum f32" ./install.sh --local_gpu_only --disable-msccl-kernel --prefix /tmp/rccl 
$ UT_DATATYPES=ncclfloat32 UT_REDOPS=prod /tmp/rccl/bin/rccl-UnitTests --gtest_filter="ProxyTraceTestFixture.*"
Note: Google Test filter = ProxyTraceTestFixture.*
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from ProxyTraceTestFixture
[ RUN      ] ProxyTraceTestFixture.nonEmptySingleton
[       OK ] ProxyTraceTestFixture.nonEmptySingleton (0 ms)
[ RUN      ] ProxyTraceTestFixture.addTraceOp
[       OK ] ProxyTraceTestFixture.addTraceOp (0 ms)
[ RUN      ] ProxyTraceTestFixture.getMapSizeMB
[       OK ] ProxyTraceTestFixture.getMapSizeMB (0 ms)
[ RUN      ] ProxyTraceTestFixture.updateTraceOp
[       OK ] ProxyTraceTestFixture.updateTraceOp (0 ms)
[ RUN      ] ProxyTraceTestFixture.updateTraceOp2
[       OK ] ProxyTraceTestFixture.updateTraceOp2 (0 ms)
[----------] 5 tests from ProxyTraceTestFixture (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.
```
# References
ProcessGroupNCCL dump call: https://github.com/pytorch/pytorch/blob/fcc78410a8e51107a7f4a15431e57da137741aee/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L400-L412