### PR TITLE
[AzureCI] Increase UT timeout to 3 hours

### DIFF
--- a/.azuredevops/slurm/test_rccl-UnitTests.sh
+++ b/.azuredevops/slurm/test_rccl-UnitTests.sh
@@ -2,7 +2,7 @@
 #SBATCH --job-name=rccl-UnitTests
 #SBATCH --output=%x-%j.out
 #SBATCH --error=%x-%j.out
-#SBATCH --time=120
+#SBATCH --time=180
 #SBATCH --nodes=1
 #SBATCH --exclusive
 #SBATCH --partition=gt


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Increase timeout of RCCL UnitTests in Azure CI from 2 hours to 3 hours

**Why were the changes made?**  
Upcoming addition of RCCL AllReduceBias (https://github.com/ROCm/rccl/pull/2036) is increasing the time needed for RCCL UT

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
