### PR TITLE
Fix rcclNetP2pPolicy issue

### DIFF
--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -776,7 +776,8 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   NCCLCHECK(ncclNetGetDeviceHandle(resources->netDeviceType, resources->netDeviceVersion, false /*isRecv*/, &resources->netDeviceHandle));
   bool rccl_anp = !(strcmp(proxyState->ncclNet->name, RCCL_ANP_PLUGIN_STR));
   
-  if (rcclNetP2pPolicy) {
+  // Only call rcclNetP2pPolicy for InfiniBand
+  if (proxyState->ncclNet == &ncclNetIb) {
     NCCLCHECK(rcclNetP2pPolicy(req->handle, resources->isP2p));
   }
   

--- a/src/transport/net.cc
+++ b/src/transport/net.cc
@@ -776,7 +776,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   NCCLCHECK(ncclNetGetDeviceHandle(resources->netDeviceType, resources->netDeviceVersion, false /*isRecv*/, &resources->netDeviceHandle));
   bool rccl_anp = !(strcmp(proxyState->ncclNet->name, RCCL_ANP_PLUGIN_STR));
   
-  // Only call rcclNetP2pPolicy for InfiniBand
+  // Only call rcclNetP2pPolicy for ncclNetIb
   if (proxyState->ncclNet == &ncclNetIb) {
     NCCLCHECK(rcclNetP2pPolicy(req->handle, resources->isP2p));
   }


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
add check for ncclNet before calling rcclNetP2pPolicy 

**Why were the changes made?**  
Fix this issue #[2044](https://github.com/ROCm/rccl/issues/2044), Since rcclNetP2pPolicy is declared as extern in net.h and implemented in the stock IB backend, the previous if (rcclNetP2pPolicy) check was incorrect. It originated from the earlier weak-symbol implementation, and when the implementation changed and the weak symbol was removed, the condition was always evaluated to true.

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
