### PR TITLE
[AzureCI] Increase timeout of per PR and nightly pipeline to 240 mins

### DIFF
--- a/.azuredevops/multinode-ci-slurm-nightly.yml
+++ b/.azuredevops/multinode-ci-slurm-nightly.yml
@@ -28,7 +28,7 @@ schedules:
 
 jobs:
 - job: rccl
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   pool: rocm-ci_rccl_slurm_pool
   workspace:
     clean: all

--- a/.azuredevops/multinode-ci-slurm-pr.yml
+++ b/.azuredevops/multinode-ci-slurm-pr.yml
@@ -33,7 +33,7 @@ stages:
     displayName: "CI Run Requires Approval"
     environment: rccl
   - job: rccl
-    timeoutInMinutes: 180
+    timeoutInMinutes: 240
     pool: rocm-ci_rccl_slurm_pool
     workspace:
       clean: all


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Increase AzureCI timeout to 4 hours for per PR pipeline and nightly pipeline

**Why were the changes made?**  
Upcoming addition of RCCL AllReduceBias (https://github.com/ROCm/rccl/pull/2036) increased the time needed for RCCL UT (https://github.com/ROCm/rccl/pull/2070), which in turn increased overall CI time.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
