### PR TITLE
Add copyright to src/device/symmetric/all_reduce.cuh (#2080)

### DIFF
--- a/src/device/symmetric/all_reduce.cuh
+++ b/src/device/symmetric/all_reduce.cuh
@@ -1,3 +1,6 @@
+// Modification Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT 
+
 #include "symmetric.h"
 #include "symmetric/kernel.h"
 #include "symmetric/primitives.h"


### PR DESCRIPTION
Fixing for Palamida scan for release build.