### PR TITLE
Add missing header in alloc.h

### DIFF
--- a/src/include/alloc.h
+++ b/src/include/alloc.h
@@ -17,7 +17,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-#include <map>
+#include <unordered_map>
 #include "rccl_vars.h"
 
 #if CUDART_VERSION >= 11030


### PR DESCRIPTION
**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Use unordered_map header instead of map.

**Why were the changes made?**  
To fix build failure.
```
rccl/build/debug/hipify/src/include/alloc.h:40:13: error: no template named 'unordered_map' in namespace 'std'
    40 | inline std::unordered_map<int64_t, ncclSideStream> sideStream;
       |        ~~~~~^
```

**How was the outcome achieved?**  
Replaced header inclusion with the correct one.

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
