### PR TITLE
[gfx942][gfx950] Leverage new cache bypass builtins for simple protocol where available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ option(TIMETRACE                               "Enable time-trace during compila
 option(TRACE                                   "Enable additional tracing"                     OFF)
 option(FAULT_INJECTION                         "Enable fault injection"                        ON)
 option(QUIET_WARNINGS                          "Supress compiler warnings"                     OFF)
+option(DWORDX4_INTRINSICS                      "Turn off compilation with dwordx4 intrinsics"  ON)
 
 # Default GPU architectures to build
 #==================================================================================================
@@ -1169,6 +1170,11 @@ if (DUMP_ASM) # Save temporary files from kernel compilation
         VERBATIM
     )
   endforeach()
+endif()
+
+if (NOT DWORDX4_INTRINSICS)
+  message(STATUS "Force disable dwordx4 intrinsics")
+  target_compile_definitions(rccl PRIVATE DWORDX4_INTRINSICS_FORCE_OFF)
 endif()
 
 ## NOTE: This is currently being handled by rocm-cmake, however may need to be re-enabled in the future

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ option(TIMETRACE                               "Enable time-trace during compila
 option(TRACE                                   "Enable additional tracing"                     OFF)
 option(FAULT_INJECTION                         "Enable fault injection"                        ON)
 option(QUIET_WARNINGS                          "Supress compiler warnings"                     OFF)
-option(DWORDX4_INTRINSICS                      "Turn off compilation with dwordx4 intrinsics"  ON)
+option(DWORDX4_INTRINSICS                      "Enable dwordx4 intrinsics where available"     ON)
 
 # Default GPU architectures to build
 #==================================================================================================

--- a/src/device/op128.h
+++ b/src/device/op128.h
@@ -301,8 +301,8 @@ DEFINE_ld_st__size(8, uint64_t, b64, l)
 
 __device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value){  
   #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
-    __builtin_amdgcn_global_store_b128((v4u_gptr) addr, value.v4u, ""); 
+    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950. 
+    rccl_sys_scope_store_b128(addr, value.v4u);
   #elif defined(__gfx950__)
     *(v4u_gptr) addr = value.v4u;
   #else
@@ -315,7 +315,7 @@ __device__ __forceinline__ BytePack<16> load16global(uintptr_t addr){
   BytePack<16> ans;
   #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
     // System scope load that bypasses the hardware caches, should generate global_load_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
-    ans.v4u = __builtin_amdgcn_global_load_b128((v4u_gptr) addr, "");
+    ans.v4u = rccl_sys_scope_load_b128(addr);
   #else
     *(u64_gptr) ans.u64 = __builtin_nontemporal_load((u64_gptr)addr); 
     *((u64_gptr) ans.u64+1) = __builtin_nontemporal_load((u64_gptr)addr+1);

--- a/src/device/op128.h
+++ b/src/device/op128.h
@@ -154,6 +154,7 @@ union alignas(16) BytePack<16> {
   uint32_t u32[4];
   uint64_t u64[2];
   ulong2 ul2[1], native;
+  v4u v4u;
   inline __device__ BytePack<16>() = default;
   inline __device__ BytePack<16>(const BytePack<16>& other) {
     *this = other;
@@ -297,17 +298,30 @@ DEFINE_ld_st__size(8, uint64_t, b64, l)
 #undef DEFINE_ld_st__size_space
 #undef DEFINE_ld_st__size
 
-#ifdef __gfx950__
-__device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value){
-  *(u64_gptr) addr = *(u64_gptr) value.u64; 
-  *((u64_gptr) addr+1) = *((u64_gptr) value.u64+1); 
+
+__device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value){  
+  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
+    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
+    __builtin_amdgcn_global_store_b128((v4u_gptr) addr, value.v4u, ""); 
+  #elif defined(__gfx950__)
+    *(v4u_gptr) addr = value.v4u;
+  #else
+    __builtin_nontemporal_store(value.u64[0], (u64_gptr) addr);
+    __builtin_nontemporal_store(value.u64[1], (u64_gptr) addr + 1);
+  #endif
 }
-#else
-__device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value){
-  __builtin_nontemporal_store(value.u64[0], (u64_gptr) addr);
-  __builtin_nontemporal_store(value.u64[1], (u64_gptr) addr + 1);
+
+__device__ __forceinline__ BytePack<16> load16global(uintptr_t addr){
+  BytePack<16> ans;
+  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
+    // System scope load that bypasses the hardware caches, should generate global_load_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
+    ans.v4u = __builtin_amdgcn_global_load_b128((v4u_gptr) addr, "");
+  #else
+    *(u64_gptr) ans.u64 = __builtin_nontemporal_load((u64_gptr)addr); 
+    *((u64_gptr) ans.u64+1) = __builtin_nontemporal_load((u64_gptr)addr+1);
+  #endif
+  return ans;
 }
-#endif
 
 #define DEFINE_ld_st_16__space(space, addr_cxx_ty, addr_reg_ty) \
   template<> \
@@ -319,10 +333,7 @@ __device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value
   } \
   template<> \
   __device__ __forceinline__ BytePack<16> ld_volatile_##space<16>(addr_cxx_ty addr) { \
-    BytePack<16> ans; \
-    *(u64_gptr) ans.u64 = __builtin_nontemporal_load((u64_gptr)addr); \
-    *((u64_gptr) ans.u64+1) = __builtin_nontemporal_load((u64_gptr)addr+1); \
-    return ans; \
+    return load16##space(addr); \
   } \
   template<> \
   __device__ __forceinline__ void st_##space<16>(addr_cxx_ty addr, BytePack<16> value) { \

--- a/src/device/op128.h
+++ b/src/device/op128.h
@@ -302,7 +302,7 @@ DEFINE_ld_st__size(8, uint64_t, b64, l)
 __device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value){  
   #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
     // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950. 
-    rccl_sys_scope_store_b128(addr, value.v4u);
+    __builtin_amdgcn_global_store_b128((v4u_gptr) addr, value.v4u, RCCL_SYSTEM_SYNCSCOPE); 
   #elif defined(__gfx950__)
     *(v4u_gptr) addr = value.v4u;
   #else
@@ -315,7 +315,7 @@ __device__ __forceinline__ BytePack<16> load16global(uintptr_t addr){
   BytePack<16> ans;
   #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
     // System scope load that bypasses the hardware caches, should generate global_load_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
-    ans.v4u = rccl_sys_scope_load_b128(addr);
+    ans.v4u = __builtin_amdgcn_global_load_b128((v4u_gptr) addr, RCCL_SYSTEM_SYNCSCOPE);
   #else
     *(u64_gptr) ans.u64 = __builtin_nontemporal_load((u64_gptr)addr); 
     *((u64_gptr) ans.u64+1) = __builtin_nontemporal_load((u64_gptr)addr+1);

--- a/src/device/rccl_ptr.h
+++ b/src/device/rccl_ptr.h
@@ -44,5 +44,6 @@ using u8_gptr = __attribute__((address_space(1))) uint8_t*;
 typedef __attribute__((__vector_size__(4 * sizeof(unsigned int)))) unsigned int v4u;
 typedef __attribute__((address_space(1))) v4u* v4u_gptr;
 
-#define rccl_sys_scope_store_b128(addr, value) __builtin_amdgcn_global_store_b128((v4u_gptr) (addr), (value), "")
-#define rccl_sys_scope_load_b128(addr) __builtin_amdgcn_global_load_b128((v4u_gptr) (addr), "")
+// "" means system scope, "agent" means device.  Adding this here because I don't think it's obvious otherwise that
+// "" means system scope.
+#define RCCL_SYSTEM_SYNCSCOPE ""

--- a/src/device/rccl_ptr.h
+++ b/src/device/rccl_ptr.h
@@ -35,7 +35,7 @@ using u32_gptr = __attribute__((address_space(1))) uint32_t*;
 using u16_gptr = __attribute__((address_space(1))) uint16_t*;
 using u8_gptr = __attribute__((address_space(1))) uint8_t*;
 
-#if (defined(__gfx942__) || defined(__gfx950__)) && __has_builtin(__builtin_amdgcn_global_load_b128) && __has_builtin(__builtin_amdgcn_global_store_b128)
+#if (defined(__gfx942__) || defined(__gfx950__)) && __has_builtin(__builtin_amdgcn_global_load_b128) && __has_builtin(__builtin_amdgcn_global_store_b128) && !defined(DWORDX4_INTRINSICS_FORCE_OFF)
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 1
 #else
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 0
@@ -43,3 +43,6 @@ using u8_gptr = __attribute__((address_space(1))) uint8_t*;
 
 typedef __attribute__((__vector_size__(4 * sizeof(unsigned int)))) unsigned int v4u;
 typedef __attribute__((address_space(1))) v4u* v4u_gptr;
+
+#define rccl_sys_scope_store_b128(addr, value) __builtin_amdgcn_global_store_b128((v4u_gptr) (addr), (value), "")
+#define rccl_sys_scope_load_b128(addr) __builtin_amdgcn_global_load_b128((v4u_gptr) (addr), "")

--- a/src/device/rccl_ptr.h
+++ b/src/device/rccl_ptr.h
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include <cstdint>
+
 // Defines a series of global address space pointers.  Casting to these
 // pointers in hot code paths should improve performance since global
 // aperture vector instrutions like global_store_dwordx4 can be used.
@@ -33,3 +35,11 @@ using u32_gptr = __attribute__((address_space(1))) uint32_t*;
 using u16_gptr = __attribute__((address_space(1))) uint16_t*;
 using u8_gptr = __attribute__((address_space(1))) uint8_t*;
 
+#if (defined(__gfx942__) || defined(__gfx950__)) && __has_builtin(__builtin_amdgcn_global_load_b128) && __has_builtin(__builtin_amdgcn_global_store_b128)
+#define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 1
+#else
+#define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 0
+#endif
+
+typedef __attribute__((__vector_size__(4 * sizeof(unsigned int)))) unsigned int v4u;
+typedef __attribute__((address_space(1))) v4u* v4u_gptr;


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** Internal

**What were the changes?**  
Replaces loads and stores to data in the simple protocol with cache bypassing load/store intrinsics that emit global dwordx4 load and store instructions on gfx942/gfx950

**Why were the changes made?**  
I found that this was faster since there's not really any meaningful data reuse to speak of at least for the ring-based algorithms.  We should just bypass the caches for loads and stores to the data arrays.

**How was the outcome achieved?**  
I worked with Carlo Bertolli and Matthew Curtis to get ```__builtin_amdgcn_global_load_b128``` and ```__builtin_amdgcn_global_store_b128``` added to the compiler.  These builtins allow writing/reading 16 bytes of data per lane to/from a specified syncscope (e.g., device or system).  Device is ```"agent"``` here, and system is ```""```.  This is consistent with some other AMD builtins for fences.  

I had initially tried inline assembly, but I found that it was brittle.  The compiler has a hard time reasoning about what's inside of the black box of ```asm volatile```.  With AMD GPUs, we additionally must specify waitcnts in a way that is correct without a large performance penalty.  After trying my hand at this, I have decided to delegate it to the compiler.

**Additional Documentation:**  
I additionally tried this with LL/LL128.  I didn't see a consistent benefit over just using extended-scope fine grain memory and [PR 1982](https://github.com/ROCm/rccl/pull/1982), so I've held off on that.  That may have changed since I last tested it, so I plan on reevaluating.

To my knowledge, the builtins require at least ROCm 7.1.1.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
