### PR TITLE
[ci] Adding org var and dynamic runner selection

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -9,6 +9,8 @@ on:
         type: string
       extra_cmake_options:
         type: string
+      test_runs_on:
+        type: string
 
 permissions:
   contents: read
@@ -34,7 +36,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: d76278526218def9fb1b016bc9e421738cb4f8f6 # 2025-12-09 commit
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Checkout rccl repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -143,5 +145,5 @@ jobs:
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
-      test_runs_on: linux-mi325-1gpu-ossci-rocm-frac
+      test_runs_on: ${{ inputs.test_runs_on }}
       artifact_run_id: ${{ github.run_id }}

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -31,6 +31,7 @@ jobs:
       BASE_REF: HEAD^
     outputs:
       enable_therock_ci: ${{ steps.configure.outputs.enable_therock_ci }}
+      linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -38,12 +39,30 @@ jobs:
           # We need the parent commit to do a diff
           fetch-depth: 2
 
+      - name: Checkout TheRock repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/TheRock"
+          path: TheRock
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
+
       - name: "Configuring CI options"
         id: configure
         run: python .github/scripts/therock_configure_ci.py
 
+      - name: Fetch Linux targets for build and test
+        env:
+          THEROCK_PACKAGE_PLATFORM: "linux"
+          # TODO(geomin12): Allow dynamic values of AMDGPU_FAMILIES, with opt-in options
+          AMDGPU_FAMILIES: "gfx94X, gfx950"
+          # Variable comes from ROCm organization variable 'ROCM_THEROCK_TEST_RUNNERS'
+          ROCM_THEROCK_TEST_RUNNERS: ${{ vars.ROCM_THEROCK_TEST_RUNNERS }}
+          LOAD_TEST_RUNNERS_FROM_VAR: true
+        id: configure_linux
+        run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
+
   therock-ci-linux:
-    name: TheRock CI Linux
+    name: TheRock CI Linux (${{ matrix.target_bundle.amdgpu_family }})
     needs: setup
     if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
     permissions:
@@ -52,12 +71,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amdgpu_family: [gfx94X-dcgpu, gfx950-dcgpu]
+        target_bundle: ${{ fromJSON(needs.setup.outputs.linux_package_targets) }}
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
-      amdgpu_families: ${{ matrix.amdgpu_family }}
-      artifact_group: ${{ matrix.amdgpu_family }}
+      amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
+      artifact_group: ${{ matrix.target_bundle.amdgpu_family }}
+      test_runs_on: ${{ matrix.target_bundle.test_machine }}
       extra_cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF 
         -DTHEROCK_BUILD_TESTING=ON 

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: d76278526218def9fb1b016bc9e421738cb4f8f6 # 2025-12-09 commit
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages-single-node.yml
+++ b/.github/workflows/therock-test-packages-single-node.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: d76278526218def9fb1b016bc9e421738cb4f8f6 # 2025-12-09 commit
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'


### PR DESCRIPTION
Changes: 
- Pulling test runner labels from the ROCm organization variable, in order to update faster and be more dynamic
- Test labels and AMD GPU families are pulled from TheRock instead of hard-coded, allowing for the eventual expansion