### PR TITLE
Update device.h for hip_bfloat16 inclusion guard

### DIFF
--- a/src/include/device.h
+++ b/src/include/device.h
@@ -12,12 +12,15 @@
 #include "nccl.h"
 #include "rccl_float8.h"
 #if ROCM_VERSION >= 60000
-  // hip_bf16.h should be used from ROCm 6.0
-  #include <hip/hip_bf16.h>
-  #ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_
+  // This is a workaround for the fact that the old hip_bfloat16.h header file may still be used by some rocm files.
+  // The _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_ and _HIP_BFLOAT16_H_ macros are defined in the old hip_bfloat16.h header
+  #if !defined(_HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_) && !defined(_HIP_BFLOAT16_H_)
     #define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_
     #define _HIP_BFLOAT16_H_
+    #include <hip/hip_bf16.h>
     typedef __hip_bfloat16 hip_bfloat16;
+  #else
+    #error "RCCL is not using the correct hip_bf16.h file. Please make sure that the correct header is included!"
   #endif
 #else
   #include <hip/hip_bfloat16.h>

--- a/src/include/device.h
+++ b/src/include/device.h
@@ -12,9 +12,13 @@
 #include "nccl.h"
 #include "rccl_float8.h"
 #if ROCM_VERSION >= 60000
-   // hip_bf16.h should be used from ROCm 6.0
+  // hip_bf16.h should be used from ROCm 6.0
   #include <hip/hip_bf16.h>
-  typedef __hip_bfloat16 hip_bfloat16;
+  #ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_
+    #define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_
+    #define _HIP_BFLOAT16_H_
+    typedef __hip_bfloat16 hip_bfloat16;
+  #endif
 #else
   #include <hip/hip_bfloat16.h>
 #endif


### PR DESCRIPTION
Prevents other files in rocm include the old hip/hip_bfloat16.h, which is guarded by _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_ and _HIP_BFLOAT16_H_


Got following rcclx build error w/o the change:
```
In file included from fbcode/caffe2/c10/core/Scalar.h:9:
In file included from fbcode/caffe2/c10/core/ScalarType.h:13:
In file included from fbcode/caffe2/c10/util/complex.h:7:
In file included from fbcode/caffe2/torch/headeronly/util/complex.h:9:
In file included from fbcode/third-party-buck/platform010/build/rocm/7.0.0/include/thrust/complex.h:27:
In file included from fbcode/third-party-buck/platform010/build/rocm/7.0.0/include/thrust/detail/type_traits.h:28:
In file included from fbcode/third-party-buck/platform010/build/rocm/7.0.0/include/rocprim/type_traits.hpp:24:
In file included from fbcode/third-party-buck/platform010/build/rocm/7.0.0/include/rocprim/type_traits_functions.hpp:24:
In file included from fbcode/third-party-buck/platform010/build/rocm/7.0.0/include/rocprim/config.hpp:26:
In file included from fbcode/third-party-buck/platform010/build/rocm/7.0.0/include/hip/hip_bfloat16.h:37:
fbcode/third-party-buck/platform010/build/rocm/7.0.0/include/hip/amd_detail/amd_hip_bfloat16.h:57:8: error: definition of type 'hip_bfloat16' conflicts with typedef of the same name
   57 | struct hip_bfloat16
      |        ^
buck-out/v2/gen/fbcode/comms/rcclx/__rcclx-dev-internal__/e34b4fa4ab08b4ce/buck-headers/device.h:17:26: note: 'hip_bfloat16' declared here
   17 |   typedef __hip_bfloat16 hip_bfloat16;
```

The change is to add necessary guards to prevent other files later include the old hip_bfloat16.h which provides a different definition of hip_bfloat16

Note: _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_ is a guard in `hip/amd_detail/amd_hip_bfloat16.h` and _HIP_BFLOAT16_H_ is a guard in `hip/hip_bfloat16.h`
        
