### PR TITLE
Retain the in-place P2P self-copy when batching is enabled to prevent hangs for configurations exceeding 32 nodes

### DIFF
--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -1257,8 +1257,9 @@ static ncclResult_t scheduleP2pTasksToPlan(
       ssize_t recvBytes = recv ? recv->bytes : -1;
       void* sendBuff = send ? send->buff : nullptr;
       void* recvBuff = recv ? recv->buff : nullptr;
-
-      if (sendRank == comm->rank && send->buff == recv->buff) {
+      // Add check to keep in-place send to self when P2P batching is enabled
+      // Such case is not supported currently and is causing hangs
+      if (sendRank == comm->rank && send->buff == recv->buff && rcclParamP2pBatchEnable() == 0) {
         // Skip send to self in-place (we don't need to support this).
         ncclIntruQueueDequeue(&peers[sendRank].sendQueue);
         ncclIntruQueueDequeue(&peers[recvRank].recvQueue);


### PR DESCRIPTION

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _Internal_

**What were the changes?**  
Ensure that in-place copy-to-self is only skipped when batching is disabled to unblock batched in-place alltoall/scatter/gather in rccl-tests. 
Note that alltoall in-place is invalid and verification is skipped in such case. 

**Why were the changes made?**  
Avoid in-place hang when batching is enabled for > 32 Nodes. 

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
Credit to @isaki001 on this finding 

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
