### PR TITLE
Remove iommu warning in KVM env

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -200,10 +200,11 @@ static ncclResult_t ncclInit() {
     INFO(NCCL_INIT, "Kernel version: %s", verStr);
     if (strstr(verStr, "cray") == NULL) {
       unsigned int eax, ebx, ecx, edx;
-      __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+      if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx))
+        ecx = 0; // cpuid not supported
       NCCLCHECK(ncclTopoGetStrFromSys("/sys/devices/virtual/dmi/id", "bios_version", strValue));
       // Check BIOS string and hypervisor presence on ecx bit 31
-      if (strncmp("Hyper-V UEFI Release", strValue, 20) != 0 && (ecx & (1 << 31)) == 0) {
+      if (strncmp("Hyper-V UEFI Release", strValue, 20) != 0 && (ecx & (1u << 31)) == 0) {
         FILE* file;
         if ((file = fopen("/proc/cmdline", "r")) != NULL) {
           if (feof(file) == 0 && ferror(file) == 0) {

--- a/src/init.cc
+++ b/src/init.cc
@@ -60,6 +60,7 @@
 #include "msccl/msccl_status.h"
 #include "latency_profiler/CollTrace.h"
 #include "latency_profiler/CollTraceFunc.h"
+#include  <cpuid.h>
 
 #ifndef STR2
   #define STR2(v) #v
@@ -198,8 +199,11 @@ static ncclResult_t ncclInit() {
     }
     INFO(NCCL_INIT, "Kernel version: %s", verStr);
     if (strstr(verStr, "cray") == NULL) {
+      unsigned int eax, ebx, ecx, edx;
+      __get_cpuid(1, &eax, &ebx, &ecx, &edx);
       NCCLCHECK(ncclTopoGetStrFromSys("/sys/devices/virtual/dmi/id", "bios_version", strValue));
-      if (strncmp("Hyper-V UEFI Release", strValue, 20) != 0) {
+      // Check BIOS string and hypervisor presence on ecx bit 31
+      if (strncmp("Hyper-V UEFI Release", strValue, 20) != 0 && (ecx & (1 << 31)) == 0) {
         FILE* file;
         if ((file = fopen("/proc/cmdline", "r")) != NULL) {
           if (feof(file) == 0 && ferror(file) == 0) {


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
SWDEV-573199

**What were the changes?**  
Remove iommu warning in KVM env

**Why were the changes made?**  
Running RCCL in some virtualized environments will result in warning "NCCL WARN Missing "iommu=pt" from kernel command line which can lead to system instablity or hang!" which is false as it is unnecessary to set iommu in these type of environments.

**How was the outcome achieved?**  
Remove iommu warning in KVM env

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
