### PR TITLE
Enable Robust Multi-Node RCCL Testing with cvs-sbatch and Improve CI Reliability

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           repository: "ROCm/rccl"
           path: rccl
+          ref: de931f4c53158184b2d7f4fe6165a5dad761649c
 
       - name: Checkout rccl-tests repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           repository: "ROCm/rccl"
           path: rccl
-          ref: de931f4c53158184b2d7f4fe6165a5dad761649c
 
       - name: Checkout rccl-tests repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
+          salloc -N 4 --ntasks-per-node 8 -p 17nodexgmi38 --reservation=rccl --exclusive -t 04:00:00 bash -c "
           source /apps/cvs_tests/TheRock/.venv/bin/activate &&
           cd /apps/cvs_tests/cvs_heatmap/cvs-sbatch &&
           python ./setup_nodes.py &&

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -39,7 +39,7 @@ jobs:
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
-      OUTPUT_ARTIFACTS_DIR: /home/arravikum/dist_new/dist/rocm
+      OUTPUT_ARTIFACTS_DIR: /apps/cvs_tests/dist_new/dist/rocm
       THEROCK_BIN_DIR: "./build/bin"
       AWS_SHARED_CREDENTIALS_FILE: /home/arravikum/awsconfig/credentials.ini
     steps:
@@ -66,8 +66,8 @@ jobs:
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
           salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
-          source /home/arravikum/TheRock/.venv/bin/activate &&
-          cd /home/arravikum/cvs_heatmap/cvs-sbatch &&
+          source /apps/cvs_tests/TheRock/.venv/bin/activate &&
+          cd /apps/cvs_tests/cvs_heatmap/cvs-sbatch &&
           python ./setup_nodes.py &&
           srun -N1 -n1 ./run.sh"
 
@@ -86,6 +86,6 @@ jobs:
           python3 build_tools/github_actions/upload_test_report_script.py \
             --run-id "${{ github.run_id }}" \
             --amdgpu-family "${{ inputs.amdgpu_families }}" \
-            --report-path "/home/arravikum/test_reports" \
+            --report-path "/apps/cvs_tests/test_reports" \
             --log-destination "/logs/gfx950-dcgpu" \
             --index-file-name "index_rccl_test_report.html"

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: ff46daa79b4c826c4f4676893d0d6586de567dfa # 2026-01-12 commit
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'
@@ -61,12 +61,12 @@ jobs:
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
       # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
-      # salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
+      # salloc will hold 2 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
       # sbatch script runs rccl_heatmap_cvs script which validates and generates a bandwidth heatmap file for different rccl collectives
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          salloc -N 4 --ntasks-per-node 8 -p 17nodexgmi38 --reservation=rccl --exclusive -t 04:00:00 bash -c "
+          salloc -N 2 --ntasks-per-node 8 -p 17nodexgmi38 --reservation=rccl --exclusive -t 04:00:00 bash -c "
           source /apps/cvs_tests/TheRock/.venv/bin/activate &&
           cd /apps/cvs_tests/cvs_heatmap/cvs-sbatch &&
           python ./setup_nodes.py &&

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           salloc -N 4 --ntasks-per-node 8 -p 17nodexgmi38 --reservation=rccl --exclusive -t 04:00:00 bash -c "
           source /apps/cvs_tests/TheRock/.venv/bin/activate &&
-          cd /apps/cvs_tests/cvs_heatmap/cvs-sbatch &&
+          cd /apps/cvs_tests/cvs-sbatch &&
           python ./setup_nodes.py &&
           srun -N1 -n1 ./run.sh"
 

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -41,6 +41,7 @@ jobs:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
       OUTPUT_ARTIFACTS_DIR: /home/arravikum/dist_new/dist/rocm
       THEROCK_BIN_DIR: "./build/bin"
+      AWS_SHARED_CREDENTIALS_FILE: /home/arravikum/awsconfig/credentials.ini
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -66,15 +67,9 @@ jobs:
         run: |
           salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
           source /home/arravikum/TheRock/.venv/bin/activate &&
-          cd /home/arravikum/cvs &&
-          python input/setup.py &&
-          pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
-              --cluster_file ./input/cluster.json \
-              --config_file ./input/mi350_config.json \
-              --log-file=/tmp/rccl_log.log \
-              --html=/home/arravikum/cvs/test_reports/ci_test_report.html \
-              --capture=tee-sys \
-              --self-contained-html"
+          cd /home/arravikum/cvs_heatmap/cvs-sbatch &&
+          python ./setup_nodes.py &&
+          srun -N1 -n1 ./run.sh"
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
@@ -91,6 +86,6 @@ jobs:
           python3 build_tools/github_actions/upload_test_report_script.py \
             --run-id "${{ github.run_id }}" \
             --amdgpu-family "${{ inputs.amdgpu_families }}" \
-            --report-path "/home/arravikum/cvs/test_reports" \
+            --report-path "/home/arravikum/test_reports" \
             --log-destination "/logs/gfx950-dcgpu" \
             --index-file-name "index_rccl_test_report.html"

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -61,12 +61,12 @@ jobs:
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
       # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
-      # salloc will hold 2 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
+      # salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
       # sbatch script runs rccl_heatmap_cvs script which validates and generates a bandwidth heatmap file for different rccl collectives
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          salloc -N 2 --ntasks-per-node 8 -p 17nodexgmi38 --reservation=rccl --exclusive -t 04:00:00 bash -c "
+          salloc -N 4 --ntasks-per-node 8 -p 17nodexgmi38 --reservation=rccl --exclusive -t 04:00:00 bash -c "
           source /apps/cvs_tests/TheRock/.venv/bin/activate &&
           cd /apps/cvs_tests/cvs_heatmap/cvs-sbatch &&
           python ./setup_nodes.py &&

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -66,11 +66,7 @@ jobs:
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          salloc -N 4 --ntasks-per-node 8 -p 17nodexgmi38 --reservation=rccl --exclusive -t 04:00:00 bash -c "
-          source /apps/cvs_tests/TheRock/.venv/bin/activate &&
-          cd /apps/cvs_tests/cvs-sbatch &&
-          python ./setup_nodes.py &&
-          srun -N1 -n1 ./run.sh"
+          SETUP_NODES=1 sbatch -N4 /apps/cvs_tests/cvs-sbatch/sbatch/default.sbatch
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
+          ref: ff46daa79b4c826c4f4676893d0d6586de567dfa # 2026-01-12 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          SETUP_NODES=1 sbatch -N4 /apps/cvs_tests/cvs-sbatch/sbatch/default.sbatch
+          SETUP_NODES=1 sbatch --wait -N4 /apps/cvs_tests/cvs-sbatch/sbatch/default.sbatch
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -41,7 +41,7 @@ jobs:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
       OUTPUT_ARTIFACTS_DIR: /apps/cvs_tests/dist_new/dist/rocm
       THEROCK_BIN_DIR: "./build/bin"
-      AWS_SHARED_CREDENTIALS_FILE: /home/arravikum/awsconfig/credentials.ini
+      AWS_SHARED_CREDENTIALS_FILE: /apps/cvs_tests/awsconfig/credentials.ini
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -62,6 +62,7 @@ jobs:
 
       # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
       # salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
+      # sbatch script runs rccl_heatmap_cvs script which validates and generates a bandwidth heatmap file for different rccl collectives
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |


### PR DESCRIPTION
This PR introduces several improvements to strengthen multi-node RCCL testing and CI reliability:

Multi-node test execution via cvs-sbatch
Adds a new cvs-sbatch script for multi-node tests that iterates multiple runs per collective before evaluating pass/fail status, improving result stability and confidence in RCCL collective validation.

Update TheRock checkout SHA
Updates the pinned TheRock commit to resolve a datetime-related issue encountered during setup.

Enable S3 log uploads for forked PRs
Adds AWS_CREDENTIALS_FILE support to the multi-node workflow, allowing RCCL HTML logs to be uploaded to S3 even for pull requests originating from forks.

These changes collectively improve test robustness, fix setup issues, and ensure better visibility into multi-node test results across all PRs.

Test run:

https://github.com/ROCm/rccl/actions/runs/20703084074/job/59434816285