### PR TITLE
4nic mi325 cvs heatmap tests workflow integration

### DIFF
--- a/.github/workflows/therock-4nic-heatmap-tests.yml
+++ b/.github/workflows/therock-4nic-heatmap-tests.yml
@@ -65,9 +65,9 @@ jobs:
       - name: Test mi325
         if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
         run: |
-          source /home/arravikum/cvs/test_venv/bin/activate
-          cd /home/arravikum/cvs/cvs
-          cvs run -vvv -s rccl_heatmap_cvs   --cluster_file ./input/cluster_file/cluster.json   --config_file ./input/config_file/rccl/rccl_config.json   --log-file=/tmp/rccl_log.log   --html=/home/arravikum/cvs/test_reports/ci_test_report.html   --capture=tee-sys   --self-contained-html
+          source /home/arravikum/TheRock/.venv/bin/activate
+          cd /home/arravikum/cvs/
+          pytest -vvv -s ./tests/rccl/rccl_heatmap_cvs.py   --cluster_file ./input/cluster_file/cluster.json   --config_file ./input/config_file/rccl/rccl_config.json   --log-file=/tmp/rccl_log.log   --html=/home/arravikum/cvs/test_reports/ci_test_report.html   --capture=tee-sys   --self-contained-html
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/therock-4nic-heatmap-tests.yml
+++ b/.github/workflows/therock-4nic-heatmap-tests.yml
@@ -1,0 +1,89 @@
+name: TheRock Test Packages multi-node
+
+on:
+  workflow_call:
+    inputs:
+      amdgpu_families:
+        type: string
+      artifact_group:
+        type: string
+      test_runs_on:
+        type: string
+      artifact_run_id:
+        type: string
+  workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        type: string
+      artifact_group:
+        type: string
+      test_runs_on:
+        type: string
+      artifact_run_id:
+        type: string
+        
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test_rccl_heatmap_multi_node:
+    name: 'Test heatmap multi-node'
+    runs-on: ${{ inputs.test_runs_on }}
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      VENV_DIR: ${{ github.workspace }}/.venv
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
+      OUTPUT_ARTIFACTS_DIR: /home/arravikum/dist_new/dist/rocm
+      THEROCK_BIN_DIR: "./build/bin"
+      AWS_SHARED_CREDENTIALS_FILE: /home/arravikum/awsconfig/credentials.ini
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
+
+      - name: Run setup test environment workflow
+        uses: './.github/actions/setup_test_environment'
+        with:
+          ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
+          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+          ARTIFACT_GROUP: ${{ inputs.artifact_group }}
+          OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
+          VENV_DIR: ${{ env.VENV_DIR }}
+          FETCH_ARTIFACT_ARGS: "--rccl --tests"
+          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+
+      # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
+      # salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
+      - name: Test mi325
+        if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
+        run: |
+          source /home/arravikum/cvs/test_venv/bin/activate
+          cd /home/arravikum/cvs/cvs
+          cvs run -vvv -s rccl_heatmap_cvs   --cluster_file ./input/cluster_file/cluster.json   --config_file ./input/config_file/rccl/rccl_config.json   --log-file=/tmp/rccl_log.log   --html=/home/arravikum/cvs/test_reports/ci_test_report.html   --capture=tee-sys   --self-contained-html
+
+      - name: Configure AWS Credentials for non-forked repos
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts-external
+
+      - name: Post test report upload
+        if: always()
+        working-directory: ${{ github.workspace }}
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${{ github.workspace }}/build_tools"
+          python3 build_tools/github_actions/upload_test_report_script.py \
+            --run-id "${{ github.run_id }}" \
+            --amdgpu-family "${{ inputs.amdgpu_families }}" \
+            --report-path "/home/arravikum/cvs/test_reports" \
+            --log-destination "/logs/gfx94X-dcgpu" \
+            --index-file-name "index_rccl_test_report.html"

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: d76278526218def9fb1b016bc9e421738cb4f8f6 # 2025-12-09 commit
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Checkout rccl repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -9,6 +9,33 @@ on:
         type: string
       extra_cmake_options:
         type: string
+  workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        description: "AMDGPU families to build/test (e.g. gfx94X-dcgpu)"
+        type: string
+        required: true
+        default: gfx94X-dcgpu
+      artifact_group:
+        description: "Artifact group name used for upload and downstream tests"
+        type: string
+        required: true
+        default: gfx94X-dcgpu
+      extra_cmake_options:
+        description: "Extra CMake options passed to the configure step"
+        type: string
+        required: false
+        default: >-
+          -DTHEROCK_ENABLE_ALL=OFF
+          -DTHEROCK_BUILD_TESTING=ON
+          -DTHEROCK_BUNDLE_SYSDEPS=ON
+          -DTHEROCK_ENABLE_COMM_LIBS=ON
+          -DTHEROCK_ENABLE_ROCPROFV3=ON
+          -DTHEROCK_USE_EXTERNAL_RCCL=ON
+          -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON
+          -DTHEROCK_RCCL_SOURCE_DIR=./rccl
+          -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
+          -DTHEROCK_ENABLE_MPI=ON
 
 permissions:
   contents: read
@@ -123,7 +150,7 @@ jobs:
 
   therock-test-linux-multi-node:
     name: "Test multi-node"
-    if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
+    if: ${{ github.event_name == 'workflow_call' && inputs.amdgpu_families == 'gfx950-dcgpu' }}
     permissions:
       contents: read
       id-token: write
@@ -137,11 +164,25 @@ jobs:
 
   therock-test-linux-single-node:
     name: "Test single-node"
-    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
+    if: ${{ github.event_name == 'workflow_call' && inputs.amdgpu_families == 'gfx94X-dcgpu' }}
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-test-packages-single-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
       test_runs_on: linux-mi325-1gpu-ossci-rocm-frac
+      artifact_run_id: ${{ github.run_id }}
+
+  therock-4N-mi325-multi-node-test:
+    name: Test heatmap multi-node
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.amdgpu_families == 'gfx94X-dcgpu' }}
+    permissions:
+      contents: read
+      id-token: write
+    needs: [therock-build-linux]
+    uses: ./.github/workflows/therock-4nic-heatmap-tests.yml
+    with:
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      artifact_group: ${{ inputs.artifact_group }}
+      test_runs_on: linux-vultr-mi325-scale-runner
       artifact_run_id: ${{ github.run_id }}

--- a/.github/workflows/therock-mi325-linux.yml
+++ b/.github/workflows/therock-mi325-linux.yml
@@ -31,22 +31,7 @@ on:
           -DTHEROCK_RCCL_SOURCE_DIR=./rccl
           -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
           -DTHEROCK_ENABLE_MPI=ON
-# Defaults used for push
-env:
-  DEFAULT_AMDGPU_FAMILIES: gfx94X-dcgpu
-  DEFAULT_ARTIFACT_GROUP: gfx94X-dcgpu
-  DEFAULT_EXTRA_CMAKE_OPTIONS: >-
-    -DTHEROCK_ENABLE_ALL=OFF
-    -DTHEROCK_BUILD_TESTING=ON
-    -DTHEROCK_BUNDLE_SYSDEPS=ON
-    -DTHEROCK_ENABLE_COMM_LIBS=ON
-    -DTHEROCK_ENABLE_ROCPROFV3=ON
-    -DTHEROCK_USE_EXTERNAL_RCCL=ON
-    -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON
-    -DTHEROCK_RCCL_SOURCE_DIR=./rccl
-    -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
-    -DTHEROCK_ENABLE_MPI=ON
-
+          
 permissions:
   contents: read
 
@@ -60,9 +45,19 @@ jobs:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:1f1ce0ab151146c7f86ee4345be74c42d8ca83200d9d26843e8a71df01ecad4e
       options: -v /runner/config:/home/awsconfig/
     env:
-      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families || env.DEFAULT_AMDGPU_FAMILIES }}
-      EXTRA_CMAKE_OPTIONS: ${{ inputs.extra_cmake_options || env.DEFAULT_EXTRA_CMAKE_OPTIONS }}
-      ARTIFACT_GROUP: ${{ inputs.artifact_group || env.DEFAULT_ARTIFACT_GROUP }}
+      AMDGPU_FAMILIES: gfx94X-dcgpu
+      ARTIFACT_GROUP: gfx94X-dcgpu
+      EXTRA_CMAKE_OPTIONS: >-
+        -DTHEROCK_ENABLE_ALL=OFF
+        -DTHEROCK_BUILD_TESTING=ON
+        -DTHEROCK_BUNDLE_SYSDEPS=ON
+        -DTHEROCK_ENABLE_COMM_LIBS=ON
+        -DTHEROCK_ENABLE_ROCPROFV3=ON
+        -DTHEROCK_USE_EXTERNAL_RCCL=ON
+        -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON
+        -DTHEROCK_RCCL_SOURCE_DIR=./rccl
+        -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
+        -DTHEROCK_ENABLE_MPI=ON
       TEATIME_FORCE_INTERACTIVE: 0
       AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
       CACHE_DIR: ${{ github.workspace }}/.container-cache
@@ -164,7 +159,7 @@ jobs:
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-4nic-heatmap-tests.yml
     with:
-      amdgpu_families: ${{ inputs.amdgpu_families || env.DEFAULT_AMDGPU_FAMILIES }}
-      artifact_group: ${{ inputs.artifact_group || env.DEFAULT_ARTIFACT_GROUP }}
+      amdgpu_families: gfx94X-dcgpu
+      artifact_group: gfx94X-dcgpu
       test_runs_on: linux-vultr-mi325-scale-runner
       artifact_run_id: ${{ github.run_id }}

--- a/.github/workflows/therock-mi325-linux.yml
+++ b/.github/workflows/therock-mi325-linux.yml
@@ -20,7 +20,17 @@ on:
         description: "Extra CMake options passed to the configure step"
         type: string
         required: false
-        default: ""
+        default: >-
+          -DTHEROCK_ENABLE_ALL=OFF
+          -DTHEROCK_BUILD_TESTING=ON
+          -DTHEROCK_BUNDLE_SYSDEPS=ON
+          -DTHEROCK_ENABLE_COMM_LIBS=ON
+          -DTHEROCK_ENABLE_ROCPROFV3=ON
+          -DTHEROCK_USE_EXTERNAL_RCCL=ON
+          -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON
+          -DTHEROCK_RCCL_SOURCE_DIR=./rccl
+          -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
+          -DTHEROCK_ENABLE_MPI=ON
 
 permissions:
   contents: read

--- a/.github/workflows/therock-mi325-linux.yml
+++ b/.github/workflows/therock-mi325-linux.yml
@@ -31,6 +31,21 @@ on:
           -DTHEROCK_RCCL_SOURCE_DIR=./rccl
           -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
           -DTHEROCK_ENABLE_MPI=ON
+# Defaults used for push
+env:
+  DEFAULT_AMDGPU_FAMILIES: gfx94X-dcgpu
+  DEFAULT_ARTIFACT_GROUP: gfx94X-dcgpu
+  DEFAULT_EXTRA_CMAKE_OPTIONS: >-
+    -DTHEROCK_ENABLE_ALL=OFF
+    -DTHEROCK_BUILD_TESTING=ON
+    -DTHEROCK_BUNDLE_SYSDEPS=ON
+    -DTHEROCK_ENABLE_COMM_LIBS=ON
+    -DTHEROCK_ENABLE_ROCPROFV3=ON
+    -DTHEROCK_USE_EXTERNAL_RCCL=ON
+    -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON
+    -DTHEROCK_RCCL_SOURCE_DIR=./rccl
+    -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
+    -DTHEROCK_ENABLE_MPI=ON
 
 permissions:
   contents: read
@@ -45,7 +60,9 @@ jobs:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:1f1ce0ab151146c7f86ee4345be74c42d8ca83200d9d26843e8a71df01ecad4e
       options: -v /runner/config:/home/awsconfig/
     env:
-      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families || env.DEFAULT_AMDGPU_FAMILIES }}
+      EXTRA_CMAKE_OPTIONS: ${{ inputs.extra_cmake_options || env.DEFAULT_EXTRA_CMAKE_OPTIONS }}
+      ARTIFACT_GROUP: ${{ inputs.artifact_group || env.DEFAULT_ARTIFACT_GROUP }}
       TEATIME_FORCE_INTERACTIVE: 0
       AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
       CACHE_DIR: ${{ github.workspace }}/.container-cache
@@ -98,7 +115,7 @@ jobs:
         env:
           amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
           package_version: ADHOCBUILD
-          extra_cmake_options: ${{ inputs.extra_cmake_options }}
+          extra_cmake_options: ${{ env.EXTRA_CMAKE_OPTIONS }}
           BUILD_DIR: build
         run: |
           python3 build_tools/github_actions/build_configure.py
@@ -147,7 +164,7 @@ jobs:
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-4nic-heatmap-tests.yml
     with:
-      amdgpu_families: ${{ inputs.amdgpu_families }}
-      artifact_group: ${{ inputs.artifact_group }}
+      amdgpu_families: ${{ inputs.amdgpu_families || env.DEFAULT_AMDGPU_FAMILIES }}
+      artifact_group: ${{ inputs.artifact_group || env.DEFAULT_ARTIFACT_GROUP }}
       test_runs_on: linux-vultr-mi325-scale-runner
       artifact_run_id: ${{ github.run_id }}

--- a/.github/workflows/therock-mi325-linux.yml
+++ b/.github/workflows/therock-mi325-linux.yml
@@ -1,6 +1,9 @@
 name: TheRock mi325 Linux
 
 on:
+  push:
+    branches:
+      - users/arravikum/mi325_test
   workflow_dispatch:
     inputs:
       amdgpu_families:

--- a/.github/workflows/therock-mi325-linux.yml
+++ b/.github/workflows/therock-mi325-linux.yml
@@ -152,7 +152,7 @@ jobs:
 
   therock-test-linux-multi-node:
     name: Test heatmap multi-node
-    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
+    #if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/therock-mi325-linux.yml
+++ b/.github/workflows/therock-mi325-linux.yml
@@ -1,0 +1,140 @@
+name: TheRock mi325 Linux
+
+on:
+  workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        description: "AMDGPU families to build/test (e.g. gfx94X-dcgpu)"
+        type: string
+        required: true
+        default: gfx94X-dcgpu
+      artifact_group:
+        description: "Artifact group name used for upload and downstream tests"
+        type: string
+        required: true
+        default: gfx94X-dcgpu
+      extra_cmake_options:
+        description: "Extra CMake options passed to the configure step"
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  therock-build-linux:
+    name: Build Linux Packages
+    runs-on: azure-linux-scale-rocm
+    permissions:
+      id-token: write
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:1f1ce0ab151146c7f86ee4345be74c42d8ca83200d9d26843e8a71df01ecad4e
+      options: -v /runner/config:/home/awsconfig/
+    env:
+      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+      TEATIME_FORCE_INTERACTIVE: 0
+      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      CACHE_DIR: ${{ github.workspace }}/.container-cache
+      CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
+
+    steps:
+      - name: Checkout TheRock repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ROCm/TheRock
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d
+
+      - name: Checkout rccl repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: ROCm/rccl
+          path: rccl
+
+      - name: Checkout rccl-tests repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          repository: ROCm/rccl-tests
+          path: rccl-tests
+
+      - name: Install python deps
+        run: |
+          pip install -r requirements.txt
+
+      - name: Adjust git config
+        run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
+
+      - name: Setup ccache
+        run: |
+          ./build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+
+      - name: Runner health status
+        run: |
+          ./build_tools/health_status.py
+
+      - name: Fetch sources
+        run: |
+          ./build_tools/fetch_sources.py --jobs 12
+
+      - name: Configure Projects
+        env:
+          amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
+          package_version: ADHOCBUILD
+          extra_cmake_options: ${{ inputs.extra_cmake_options }}
+          BUILD_DIR: build
+        run: |
+          python3 build_tools/github_actions/build_configure.py
+
+      - name: Build therock-dist
+        run: cmake --build build
+
+      - name: Build therock-archives
+        run: cmake --build build --target therock-archives
+
+      - name: Report
+        run: |
+          echo "Full SDK du:"
+          du -h -d 1 build/dist/rocm
+          echo "Artifact Archives:"
+          ls -lh build/artifacts/*.tar.xz
+          echo "Artifacts:"
+          du -h -d 1 build/artifacts
+          echo "CCache Stats:"
+          ccache -s -v
+          tail -v -n +1 .ccache/compiler_check_cache/* \
+            > build/logs/ccache_compiler_check_cache.log
+
+      - name: Configure AWS Credentials for non-forked repos
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts-external
+
+      - name: Post Build Upload
+        if: always()
+        run: |
+          python3 build_tools/github_actions/post_build_upload.py \
+            --run-id ${{ github.run_id }} \
+            --artifact-group ${{ inputs.artifact_group }} \
+            --build-dir build \
+            --upload
+
+  therock-test-linux-multi-node:
+    name: Test heatmap multi-node
+    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
+    permissions:
+      contents: read
+      id-token: write
+    needs: [therock-build-linux]
+    uses: ./.github/workflows/therock-4nic-heatmap-tests.yml
+    with:
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      artifact_group: ${{ inputs.artifact_group }}
+      test_runs_on: linux-vultr-mi325-scale-runner
+      artifact_run_id: ${{ github.run_id }}

--- a/.github/workflows/therock-mi325-linux.yml
+++ b/.github/workflows/therock-mi325-linux.yml
@@ -31,7 +31,7 @@ on:
           -DTHEROCK_RCCL_SOURCE_DIR=./rccl
           -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
           -DTHEROCK_ENABLE_MPI=ON
-          
+
 permissions:
   contents: read
 
@@ -146,7 +146,7 @@ jobs:
         run: |
           python3 build_tools/github_actions/post_build_upload.py \
             --run-id ${{ github.run_id }} \
-            --artifact-group ${{ inputs.artifact_group }} \
+            --artifact-group ${{ env.AMDGPU_FAMILIES }} \
             --build-dir build \
             --upload
 

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -41,12 +41,13 @@ jobs:
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
       OUTPUT_ARTIFACTS_DIR: /home/arravikum/dist_new/dist/rocm
       THEROCK_BIN_DIR: "./build/bin"
+      AWS_SHARED_CREDENTIALS_FILE: /home/arravikum/awsconfig/credentials.ini
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: d76278526218def9fb1b016bc9e421738cb4f8f6 # 2025-12-09 commit
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'
@@ -66,15 +67,9 @@ jobs:
         run: |
           salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
           source /home/arravikum/TheRock/.venv/bin/activate &&
-          cd /home/arravikum/cvs &&
-          python input/setup.py &&
-          pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
-              --cluster_file ./input/cluster.json \
-              --config_file ./input/mi350_config.json \
-              --log-file=/tmp/rccl_log.log \
-              --html=/home/arravikum/cvs/test_reports/ci_test_report.html \
-              --capture=tee-sys \
-              --self-contained-html"
+          cd /home/arravikum/cvs_heatmap/cvs-sbatch &&
+          python ./setup_nodes.py &&
+          srun -N1 -n1 ./run.sh"
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
@@ -91,6 +86,6 @@ jobs:
           python3 build_tools/github_actions/upload_test_report_script.py \
             --run-id "${{ github.run_id }}" \
             --amdgpu-family "${{ inputs.amdgpu_families }}" \
-            --report-path "/home/arravikum/cvs/test_reports" \
+            --report-path "/home/arravikum/test_reports" \
             --log-destination "/logs/gfx950-dcgpu" \
             --index-file-name "index_rccl_test_report.html"

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -39,7 +39,7 @@ jobs:
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
-      OUTPUT_ARTIFACTS_DIR: /home/arravikum/dist_new/dist/rocm
+      OUTPUT_ARTIFACTS_DIR: /apps/cvs_tests/dist_new/dist/rocm
       THEROCK_BIN_DIR: "./build/bin"
       AWS_SHARED_CREDENTIALS_FILE: /home/arravikum/awsconfig/credentials.ini
     steps:
@@ -66,8 +66,8 @@ jobs:
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
           salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
-          source /home/arravikum/TheRock/.venv/bin/activate &&
-          cd /home/arravikum/cvs_heatmap/cvs-sbatch &&
+          source /apps/cvs_tests/TheRock/.venv/bin/activate &&
+          cd /apps/cvs_tests/cvs_heatmap/cvs-sbatch &&
           python ./setup_nodes.py &&
           srun -N1 -n1 ./run.sh"
 
@@ -86,6 +86,6 @@ jobs:
           python3 build_tools/github_actions/upload_test_report_script.py \
             --run-id "${{ github.run_id }}" \
             --amdgpu-family "${{ inputs.amdgpu_families }}" \
-            --report-path "/home/arravikum/test_reports" \
+            --report-path "/apps/cvs_tests/test_reports" \
             --log-destination "/logs/gfx950-dcgpu" \
             --index-file-name "index_rccl_test_report.html"

--- a/.github/workflows/therock-test-packages-single-node.yml
+++ b/.github/workflows/therock-test-packages-single-node.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: d76278526218def9fb1b016bc9e421738cb4f8f6 # 2025-12-09 commit
+          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'


### PR DESCRIPTION
This PR introduces a workflow-dispatch–based CI workflow for running RCCL validation on a 4-node MI325 cluster using the rccl develop branch.

The workflow adds the following capabilities:

On-demand triggering of TheRock builds using the latest HEAD of the rccl repository.

Builds RCCL and RCCL-tests artifacts via TheRock, publishes them to S3, and prepares them for consumption on the test runners.

Fetches and deploys the built artifacts on the Vultr MI325 cluster, and executes CVS heatmap and performance tests across the cluster.

Collects and uploads CVS heatmap outputs and performance reports for multiple collectives and message sizes to S3 for post-run analysis and debugging.