### PR TITLE
revert memcpy use for direct AG

### DIFF
--- a/src/collectives.cc
+++ b/src/collectives.cc
@@ -129,16 +129,14 @@ ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sen
         dstBuf = recvbuff;
      }
 
-     if (!in_place)
-         CUDACHECK(cudaMemcpyAsync((char*)dstBuf + rank * rankOffset, srcBuf, rankOffset, cudaMemcpyDeviceToDevice, stream));
-     
      NCCLCHECK(ncclGroupStart());
 
      for (int r = 0; r < nRanks; r++) {
-         if (r != rank) {
-             NCCLCHECK(ncclSend(((char*)dstBuf) + rank * rankOffset, sendcount, datatype, r, comm, stream));
-             NCCLCHECK(ncclRecv(((char*)dstBuf) + r * rankOffset, sendcount, datatype, r, comm, stream));
-         }
+         if (r == rank && in_place)
+             continue;
+         
+         NCCLCHECK(ncclSend(((char*)srcBuf), sendcount, datatype, r, comm, stream));
+         NCCLCHECK(ncclRecv(((char*)dstBuf) + r * rankOffset, sendcount, datatype, r, comm, stream));
      }
      NCCLCHECK(ncclGroupEnd());
      return ncclSuccess;


### PR DESCRIPTION
## Details
This PR reverts the use of hipMemcpy() for the local copies in direct AG. This was causing a regression on single node MI300.

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
AICOMRCCL-370

**What were the changes?**  
RCCL send()/recv() is used instead of hipMemcpy().

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
