### PR TITLE
Stream Pytest Summary from Slurm Jobs into GitHub Actions Logs

### DIFF
--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -69,6 +69,8 @@ jobs:
           JOB_ID=$(SETUP_NODES=1 sbatch --wait --parsable -N4 \
             /apps/cvs_tests/cvs-sbatch/sbatch/default.sbatch)
 
+          echo "Slurm job ID: ${JOB_ID}"
+
           LOG_FILE="/apps/cvs_tests/logs/TheRock-Multinode-RCCL-CI-Test-${JOB_ID}.out"
 
           if grep -q "short test summary info" "$LOG_FILE"; then
@@ -77,6 +79,7 @@ jobs:
             echo "[WARNING] Pytest summary not found; showing results tailing logs"
             tail -n 22 "$LOG_FILE"
           fi
+          echo "Full logs can be found at $LOG_FILE in the runner"
 
 
       - name: Configure AWS Credentials for non-forked repos

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -66,7 +66,18 @@ jobs:
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          SETUP_NODES=1 sbatch --wait -N4 /apps/cvs_tests/cvs-sbatch/sbatch/default.sbatch
+          JOB_ID=$(SETUP_NODES=1 sbatch --wait --parsable -N4 \
+            /apps/cvs_tests/cvs-sbatch/sbatch/default.sbatch)
+
+          LOG_FILE="/apps/cvs_tests/logs/TheRock-Multinode-RCCL-CI-Test-${JOB_ID}.out"
+
+          if grep -q "short test summary info" "$LOG_FILE"; then
+            sed -n '/short test summary info/,$p' "$LOG_FILE"
+          else
+            echo "[WARNING] Pytest summary not found; showing results tailing logs"
+            tail -n 22 "$LOG_FILE"
+          fi
+
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -66,20 +66,8 @@ jobs:
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          JOB_ID=$(SETUP_NODES=1 sbatch --wait --parsable -N4 \
-            /apps/cvs_tests/cvs-sbatch/sbatch/default.sbatch)
-
-          echo "Slurm job ID: ${JOB_ID}"
-
-          LOG_FILE="/apps/cvs_tests/logs/TheRock-Multinode-RCCL-CI-Test-${JOB_ID}.out"
-
-          if grep -q "short test summary info" "$LOG_FILE"; then
-            sed -n '/short test summary info/,$p' "$LOG_FILE"
-          else
-            echo "[WARNING] Pytest summary not found; showing results tailing logs"
-            tail -n 22 "$LOG_FILE"
-          fi
-          echo "Full logs can be found at $LOG_FILE in the runner"
+          chmod +x /apps/cvs_tests/ci-entrypoint.sh
+          /apps/cvs_tests/ci-entrypoint.sh
 
 
       - name: Configure AWS Credentials for non-forked repos


### PR DESCRIPTION
PR Description

This PR improves the GitHub Actions output for Slurm-based CVS test runs by surfacing only the relevant pytest results instead of the full Slurm logs.

**Changes:**

- Log surfacing and readability
- Capture and print the Slurm job ID returned by sbatch --wait.
- Extract and print pytest output starting from “short test summary info” to the end of the Slurm stdout log.
- Add a fallback to tail the last lines of the log when the pytest summary is not present.
- Always print the Slurm job ID and paths to the full stdout/stderr log files for easy debugging.

**Correct CI failure semantics:**

- Query the final Slurm job state after completion using sacct (with scontrol fallback).
- Treat jobs that are CANCELLED, FAILED, PREEMPTED, TIMEOUT, or never started as CI failures.
- Allow CI to pass only when the Slurm job reaches the COMPLETED state, ensuring the test actually ran.
- Prevent false-positive CI passes when jobs are cancelled before execution and no logs are produced.

**Impact**

- Keeps CI logs concise and readable.
- Preserves full Slurm logs for offline analysis.
- Makes it easier to correlate GitHub Actions runs with Slurm jobs.
- Passing run printing the relevant logs:

https://github.com/ROCm/rccl/actions/runs/21156987948/job/60846454749#step:4:29