### PR TITLE
Set default max channels to 48 for MI350 multi-node

### DIFF
--- a/src/rccl_wrap.cc
+++ b/src/rccl_wrap.cc
@@ -43,12 +43,30 @@ RCCL_PARAM(WarpSpeedEnable, "WARP_SPEED_ENABLE", 0);
 #endif
 #define RCCL_WARP_SPEED_MIN_BYTES (1ULL << 26) // 64 MB
 
-RCCL_PARAM(ReducedCuEnable, "REDUCED_CU_ENABLE", 0);
-
 void rcclRestrictMaxChannels(struct ncclComm* comm, int& nc ) {
-    if (comm->nNodes > 1 && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && rcclParamReducedCuEnable() == 1)    {
-        nc = comm->nChannels = std::min(nc, 48);
+
+  if (comm->nNodes > 1 && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
+    const char* maxNChannelsStr = getenv("NCCL_MAX_NCHANNELS");
+
+    if (maxNChannelsStr) {
+      char* end = nullptr;
+      long userMax = strtol(maxNChannelsStr, &end, 10);
+
+      if (end != maxNChannelsStr && *end == '\0' && userMax > 0) {
+        // 64 is the max number of channels for gfx950 multi-node
+        userMax = std::min<long>(userMax, 64);
+        const int cap = (int)userMax;
+        // Cap max channels, but don't permanently shrink comm->nChannels
+        // based on a small-message tuning decision (which can legitimately pick nc=1).
+        nc = std::min(nc, cap);
+        comm->nChannels = std::min(comm->nChannels, cap);
+      }
+    } else {
+      // Default restriction for gfx950 multi-node when user hasn't set a valid max.
+      nc = std::min(nc, 48);
+      comm->nChannels = std::min(comm->nChannels, 48);
     }
+  }
 }
 
 static inline bool rcclCollSupportsRing(ncclFunc_t func) {


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** AICOMRCCL-371
**What were the changes?**  
This PR set 48 as the default max channels for MI350  multi-node

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
