### PR TITLE
Cherry-pick CI fixes for ROCm 7.2 (PRs #2123, #2142)

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: aa315ec2801ff6772a6c9ca6799669395630c45c
+          ref: ff46daa79b4c826c4f4676893d0d6586de567dfa # 2026-01-12 commit
 
       - name: Checkout rccl repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -142,5 +142,6 @@ jobs:
     uses: ./.github/workflows/therock-test-packages-single-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: linux-mi325-1gpu-ossci-rocm
+      artifact_group: ${{ inputs.artifact_group }}
+      test_runs_on: linux-mi325-4gpu-ossci-rocm
       artifact_run_id: ${{ github.run_id }}

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           python3 build_tools/github_actions/post_build_upload.py \
             --run-id ${{ github.run_id }} \
-            --amdgpu-family ${{ env.AMDGPU_FAMILIES }} \
+            --artifact-group ${{ env.AMDGPU_FAMILIES }} \
             --build-dir build \
             --upload
 

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -39,8 +39,9 @@ jobs:
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
-      OUTPUT_ARTIFACTS_DIR: /home/arravikum/dist_new/dist/rocm
+      OUTPUT_ARTIFACTS_DIR: /apps/cvs_tests/dist_new/dist/rocm
       THEROCK_BIN_DIR: "./build/bin"
+      AWS_SHARED_CREDENTIALS_FILE: /apps/cvs_tests/awsconfig/credentials.ini
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -61,20 +62,11 @@ jobs:
 
       # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
       # salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
+      # sbatch script runs rccl_heatmap_cvs script which validates and generates a bandwidth heatmap file for different rccl collectives
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          salloc -N 4 -p meta64 -t 04:00:00 --exclusive bash -c "
-          source /home/arravikum/TheRock/.venv/bin/activate &&
-          cd /home/arravikum/cvs &&
-          python input/setup.py &&
-          pytest -vvv -s ./tests/rccl/rccl_multinode_cvs.py \
-              --cluster_file ./input/cluster.json \
-              --config_file ./input/mi350_config.json \
-              --log-file=/tmp/rccl_log.log \
-              --html=/home/arravikum/cvs/test_reports/ci_test_report.html \
-              --capture=tee-sys \
-              --self-contained-html"
+          SETUP_NODES=1 sbatch --wait -N4 /apps/cvs_tests/cvs-sbatch/sbatch/default.sbatch
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
@@ -91,6 +83,6 @@ jobs:
           python3 build_tools/github_actions/upload_test_report_script.py \
             --run-id "${{ github.run_id }}" \
             --amdgpu-family "${{ inputs.amdgpu_families }}" \
-            --report-path "/home/arravikum/cvs/test_reports" \
+            --report-path "/apps/cvs_tests/test_reports" \
             --log-destination "/logs/gfx950-dcgpu" \
             --index-file-name "index_rccl_test_report.html"

--- a/.github/workflows/therock-test-packages-multi-node.yml
+++ b/.github/workflows/therock-test-packages-multi-node.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 6ecc2af91fc8a4271a949005d7404bd13278c005 # 2025-10-23 commit
+          ref: ff46daa79b4c826c4f4676893d0d6586de567dfa # 2026-01-12 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages-single-node.yml
+++ b/.github/workflows/therock-test-packages-single-node.yml
@@ -5,6 +5,8 @@ on:
     inputs:
       amdgpu_families:
         type: string
+      artifact_group:
+        type: string
       test_runs_on:
         type: string
       artifact_run_id:
@@ -12,6 +14,8 @@ on:
   workflow_dispatch:
     inputs:
       amdgpu_families:
+        type: string
+      artifact_group:
         type: string
       test_runs_on:
         type: string
@@ -26,13 +30,16 @@ jobs:
     name: 'Test single-node'
     runs-on: ${{ inputs.test_runs_on }}
     container:
-      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26
+      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98
       options: --ipc host
         --group-add video
         --device /dev/kfd
         --device /dev/dri
         --group-add 110
+        --ulimit memlock=-1:-1
+        --security-opt seccomp=unconfined
         --env-file /etc/podinfo/gha-gpu-isolation-settings
+        --user 0:0
     defaults:
       run:
         shell: bash
@@ -46,13 +53,14 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: f89dcd5c5625baecb467b9287e952c5c819073fd
+          ref: ff46daa79b4c826c4f4676893d0d6586de567dfa # 2026-01-12 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+          ARTIFACT_GROUP: ${{ inputs.artifact_group }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
           FETCH_ARTIFACT_ARGS: "--rccl --tests"
@@ -65,5 +73,5 @@ jobs:
         # TODO (geomin12): Rebuild rccl-tests without MPI to enable RCCL correctness tests.
         run: |
           pytest ./build_tools/github_actions/test_executable_scripts/test_rccl.py -v -s \
-            --log-cli-level=info \
-            -k "not test_rccl_correctness_tests"
+            -k "not test_rccl_correctness_tests" \
+            --log-cli-level=info


### PR DESCRIPTION
#### Cherry-picks the following merged PRs onto ROCm 7.2 release branch:
- #2123 Enable Robust Multi-Node RCCL Testing with cvs-sbatch and Improve CI Reliability
- #2142 [TheRock CI] Adding working single node tests