### PR TITLE
 [cherry-pick] 7.2.1 Cherry pick changes, 8 byte memory leak fix

### DIFF
--- a/src/include/comm.h
+++ b/src/include/comm.h
@@ -717,7 +717,7 @@ struct ncclComm {
   int unroll;
   // custom collective [RCCL]
   bool enableCustColl;
-  // gfx name from hipDeviceProp_t [RCCL]
+  // gfx name from hipDeviceProp_t [RCCL] , Memory resource owned by comm allocated in ncclCommInitRankFunc
   char* archName;
   // multiProcessorCount from hipDeviceProp_t [RCCL]
   int cuCount;

--- a/src/init.cc
+++ b/src/init.cc
@@ -537,6 +537,7 @@ static ncclResult_t commFree(ncclComm_t comm) {
   free(comm->topParentRanks);
   free(comm->topParentLocalRanks);
   free(comm->gproxyConn);
+  free(comm->archName);
 
   NCCLCHECK(ncclRegCleanup(comm));
 
@@ -2007,8 +2008,12 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 
   CUDACHECKGOTO(hipGetDeviceProperties(&devProp, cudaDev), res, fail);
   cuCount = devProp.multiProcessorCount;
-  archName = (char*)malloc(strlen(devProp.gcnArchName) + 1);
-  strcpy(archName, devProp.gcnArchName);
+  archName = strdup(devProp.gcnArchName);
+  if (!archName) {
+    res = ncclSystemError;
+    WARN("strdup failed for architecture name");
+    goto fail;
+  }
 
   timers[TIMER_INIT_KERNELS] = clockNano();
   NCCLCHECK(ncclInitKernelsForDevice(cudaArch, maxSharedMem, &maxLocalSizeBytes));


### PR DESCRIPTION
## Details
7.2.1 cherry pick for memory leaks

PR in migrated Repo - https://github.com/ROCm/rocm-systems/pull/2764/changes
**Work item:** 
internal
**What were the changes?**  
Add a free() for strdup / malloc() 

**Why were the changes made?**  
Addresses memory leaks in rccl init subsystem

**How was the outcome achieved?**  
code changes 

**Additional Documentation:**  
Applies to all gfx archs ( hostcode)

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes - NO 
  - any changes impact library users, and/or - NO
  - any changes impact any other ROCm library - NO

