### PR TITLE
Don't use `--offload-compress` at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1207,7 +1207,6 @@ if (HAVE_PARALLEL_JOBS)
 endif()
 
 if (ROCM_VERSION VERSION_GREATER_EQUAL "60200")
-  target_compile_options(rccl PRIVATE --offload-compress)    # Compress GPU code at compile time.
   target_link_libraries(rccl PRIVATE --offload-compress)     # Compress GPU code at link time.
   message(STATUS "--offload-compress enabled - ROCm version >= 6.2.0")
 else()


### PR DESCRIPTION
Since `-fgpu-rdc` is enabled, there is no benefit of doing compression at compile time, because the compressed device "object file" (an IR file in binary format) will be decompressed immediately at link time, so the compression at compile time is completely a waste of time and resource.
