### PR TITLE
ROCM-1896 fix shutdown ordering race condition

### DIFF
--- a/src/include/alloc.h
+++ b/src/include/alloc.h
@@ -18,11 +18,32 @@
 #include <stdlib.h>
 #include <string.h>
 #include "rccl_vars.h"
+#include <atomic>
+#include <mutex>
 
 #if CUDART_VERSION >= 11030
 #include <cuda.h>
 #include "cudawrap.h"
 #endif
+
+// Global flag to detect process shutdown. Set by atexit handler before
+// HIP runtime static destructors run. This prevents use-after-free crashes
+// when RCCL proxy threads try to free GPU memory during process exit.
+inline std::atomic<bool>& rcclShutdownFlag() {
+  static std::atomic<bool> flag{false};
+  return flag;
+}
+
+inline void rcclShutdownHandler() {
+  rcclShutdownFlag().store(true, std::memory_order_release);
+}
+
+inline void rcclRegisterShutdownHandler() {
+  static std::once_flag once;
+  std::call_once(once, []() {
+    atexit(rcclShutdownHandler);
+  });
+}
 
 uint64_t clockNano(); // from utils.h with which we have a circular dependency
 
@@ -137,6 +158,12 @@ finish:
 }
 
 static inline ncclResult_t ncclCudaHostFree(void* ptr) {
+  if (ptr == NULL) return ncclSuccess;
+  // Check if process is shutting down to avoid use-after-free in HIP runtime
+  if (rcclShutdownFlag().load(std::memory_order_acquire)) {
+    INFO(NCCL_ALLOC, "ncclCudaHostFree: Skipping free (process shutdown) pointer %p", ptr);
+    return ncclSuccess;
+  }
   CUDACHECK(cudaFreeHost(ptr));
   return ncclSuccess;
 }
@@ -228,6 +255,11 @@ static inline ncclResult_t ncclCuMemAllocAddr(void **ptr, CUmemGenericAllocation
 
 static inline ncclResult_t ncclCuMemFreeAddr(void *ptr) {
   if (ptr == NULL) return ncclSuccess;
+  // Check if process is shutting down to avoid use-after-free in HIP runtime
+  if (rcclShutdownFlag().load(std::memory_order_acquire)) {
+    INFO(NCCL_ALLOC, "ncclCuMemFreeAddr: Skipping free (process shutdown) pointer %p", ptr);
+    return ncclSuccess;
+  }
   ncclResult_t result = ncclSuccess;
   size_t size = 0;
   CUCHECK(cuMemGetAddressRange(NULL, &size, (CUdeviceptr)ptr));
@@ -290,6 +322,11 @@ static inline ncclResult_t ncclCuMemAlloc(void **ptr, CUmemGenericAllocationHand
 
 static inline ncclResult_t ncclCuMemFree(void *ptr) {
   if (ptr == NULL) return ncclSuccess;
+  // Check if process is shutting down to avoid use-after-free in HIP runtime
+  if (rcclShutdownFlag().load(std::memory_order_acquire)) {
+    INFO(NCCL_ALLOC, "ncclCuMemFree: Skipping free (process shutdown) pointer %p", ptr);
+    return ncclSuccess;
+  }
   ncclResult_t result = ncclSuccess;
   CUmemGenericAllocationHandle handle;
   size_t size = 0;
@@ -451,12 +488,22 @@ finish:
 
 template <typename T>
 ncclResult_t ncclCudaFree(T* ptr) {
+  if (ptr == NULL) return ncclSuccess;
+
+  // Check if process is shutting down. The atexit handler sets this flag
+  // BEFORE HIP runtime static destructors run, so we can safely skip the free.
+  // The OS will reclaim all memory when the process exits anyway.
+  if (rcclShutdownFlag().load(std::memory_order_acquire)) {
+    INFO(NCCL_ALLOC, "ncclCudaFree: Skipping free (process shutdown) pointer %p", ptr);
+    return ncclSuccess;
+  }
+
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   TRACE(NCCL_ALLOC, "Cuda Free pointer %p", ptr);
 
-  // get the size of the allocation
-  if (ptr != NULL) {
+  // get the size of the allocation for tracking
+  {
      CUdeviceptr baseAddress;
      size_t retrievedSize;
 

--- a/src/init.cc
+++ b/src/init.cc
@@ -7,6 +7,7 @@
  ************************************************************************/
 
 #include "nccl.h"
+#include "alloc.h"
 #include "channel.h"
 #include "nvmlwrap.h"
 #include "gdrwrap.h"
@@ -185,6 +186,10 @@ exit:;
 }
 
 static ncclResult_t ncclInit() {
+    // Register atexit handler to detect process shutdown. This must happen
+    // early so the handler runs BEFORE HIP runtime static destructors.
+    rcclRegisterShutdownHandler();
+
     char strValue[2048];
     NCCLCHECK(ncclTopoGetStrFromSys("/proc/sys/kernel", "numa_balancing", strValue));
     if (strcmp(strValue, "1") == 0)


### PR DESCRIPTION
## Details
race condition at shutdown causes segmentation fault, instead have an atexit handler to set global shutdown state and avoid use after free bugs.

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
ROCM-1896

**What were the changes?**  
Added atexit handler to set shutdown flag and prevent other threads from running into segmentation faults

**Why were the changes made?**  
Without these changes, an error condition during rccl (like no open files, or running out of hip memory), could result in a segmentation fault, instead of gracefully exiting with an error reason.

**How was the outcome achieved?**  
Handle exit conditions and prevent other threads from running into segfault

**Additional Documentation:**  
cherry pick from develop
