### PR TITLE
[cherry-pick] 7.2.1 Cherry pick changes [Navi4 default tuning enablement]

### DIFF
--- a/src/graph/tuning.cc
+++ b/src/graph/tuning.cc
@@ -958,3 +958,24 @@ ncclResult_t ncclTopoGetAlgoTime(struct ncclComm* comm, int coll, int algorithm,
   *time = lat * latCount + nBytes / (1000 * bw);
   return ncclSuccess;
 }
+
+/**
+ * takes gfx arch name as C-style string and returns a tuning index to
+ */
+int rcclGetTuningIndexForArch(const char* gfxarch) {
+  static const std::vector<std::pair<std::string, int>> tuningIndexMap = {
+    {"gfx906", 0}, {"gfx908", 0}, {"gfx90a", 0}, {"gfx942", 5},
+    {"gfx950", 6}, {"gfx1030", 0}, {"gfx1100", 0}, {"gfx1102", 0},
+    {"gfx1200", 7}, {"gfx1201", 7}
+  };
+  if (gfxarch == nullptr) return 0;
+  std::string arch(gfxarch);
+  for (const auto& p : tuningIndexMap) {
+    const std::string& prefix = p.first;
+    if (arch.size() >= prefix.size() &&
+        arch.compare(0, prefix.size(), prefix) == 0) {
+      return p.second;
+    }
+  }
+  return 0;
+}

--- a/src/include/graph.h
+++ b/src/include/graph.h
@@ -144,5 +144,5 @@ ncclResult_t ncclTreeBasePostset(struct ncclComm* comm, struct ncclTopoGraph* tr
 
 ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCompCap, struct ncclTopoGraph** graphs);
 ncclResult_t ncclTopoGetAlgoTime(struct ncclComm* comm, int coll, int algorithm, int protocol, size_t nBytes, int numPipeOps, float* time);
-
+int rcclGetTuningIndexForArch(const char* gfxarch);
 #endif

--- a/src/init.cc
+++ b/src/init.cc
@@ -1253,6 +1253,8 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   // Topo detection / System graph creation
   NCCLCHECKGOTO(ncclTopoGetSystem(comm, &comm->topo), ret, fail);
   // save nRanks to ncclTopoSystem as indicator of multi-node
+  comm->topo->tuning = rcclGetTuningIndexForArch(comm->archName);
+  INFO(NCCL_INIT, "Tuning index set to: %d",  comm->topo->tuning);
   comm->topo->nRanks = comm->nRanks;
   // init netGdrLevel
   comm->topo->netGdrLevel = -2;


### PR DESCRIPTION
## Details
The changes in this PR are common to both virtual device enablement feature and and Navi4 multinode default tuning 
**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
The Virtual device feature did not make it into 7.2 , hence the common changes also missed it.

**Why were the changes made?**  
This PR addresses the missing code from intended tuning
**How was the outcome achieved?**  


**Additional Documentation:**  

- Not having these changes can affect the default performance on multinode systems by 10 to 15 % in rccl, But can be addressed with environment variables or Tuner plugin. [https://rocm.docs.amd.com/projects/rccl/en/develop/how-to/using-rccl-tuner-plugin-api.html](url)
- Unit test sweep is done with these changes on a Navi machine, and they are working fine. 

