### PR TITLE
Fix bad-magic init hang in bootstrap and async-mode transport accept paths

### DIFF
--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -256,6 +256,27 @@ static ncclResult_t setFilesLimit() {
   return ncclSuccess;
 }
 
+// Bootstrap-side accept wrapper. ncclSocketAccept's default behavior
+// (retryOnBadMagic=true) loops internally on bad-magic events, which can
+// monopolize CPU and starve legitimate peer connects when a non-NCCL TCP
+// peer hits the bootstrap listen socket. We pass retryOnBadMagic=false and
+// drive the retry from here: close the rejected socket, yield 1ms, retry.
+// abortFlag is honored between iterations.
+static ncclResult_t bootstrapAccept(struct ncclSocket* sock, struct ncclSocket* listenSock,
+                                    volatile uint32_t* abortFlag) {
+  while (1) {
+    if (abortFlag != NULL && __atomic_load_n(abortFlag, __ATOMIC_ACQUIRE) != 0) {
+      return ncclInternalError;
+    }
+    NCCLCHECK(ncclSocketInit(sock));
+    NCCLCHECK(ncclSocketAccept(sock, listenSock, /*retryOnBadMagic=*/false));
+    if (sock->state != ncclSocketStateBadMagic) return ncclSuccess;
+    INFO(NCCL_INIT|NCCL_NET, "bootstrap: rejected bad-magic peer connection on listen sock, retrying accept");
+    (void)ncclSocketClose(sock);
+    usleep(1000);
+  }
+}
+
 static ncclResult_t rootSend(union ncclSocketAddress* addr, uint64_t magic, union ringConnectInfo* info) {
   ncclResult_t res = ncclSuccess;
   struct ncclSocket sock;
@@ -294,8 +315,8 @@ static void* bootstrapRoot(void* rargs) {
   /* Receive addresses from all ranks */
   do {
     struct ncclSocket sock;
-    NCCLCHECKGOTO(ncclSocketInit(&sock), res, out);
-    NCCLCHECKGOTO(ncclSocketAccept(&sock, listenSock), res, out);
+    // No abortFlag: bootstrapRoot is a detached thread without a comm.
+    NCCLCHECKGOTO(bootstrapAccept(&sock, listenSock, /*abortFlag=*/NULL), res, out);
     NCCLCHECKGOTO(socketRecv(&sock, &info, sizeof(info)), res, out);
     NCCLCHECKGOTO(ncclSocketClose(&sock), res, out);
 
@@ -553,8 +574,7 @@ static ncclResult_t netRingConnect(ncclNet_t* net, struct bootstrapListen_t* lis
 static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket* sendSocket, struct ncclSocket* listenSock, struct ncclSocket* recvSocket, uint64_t magic, volatile uint32_t* abortFlag) {
   NCCLCHECK(ncclSocketInit(sendSocket, addr, magic, ncclSocketTypeBootstrap, abortFlag));
   NCCLCHECK(ncclSocketConnect(sendSocket));
-  NCCLCHECK(ncclSocketInit(recvSocket));
-  NCCLCHECK(ncclSocketAccept(recvSocket, listenSock));
+  NCCLCHECK(bootstrapAccept(recvSocket, listenSock, abortFlag));
   return ncclSuccess;
 }
 static ncclResult_t ringAllInfo(struct ncclComm* comm, struct bootstrapState* state,
@@ -705,8 +725,7 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm) {
 
   // get info on my "next" rank in the bootstrap ring from root
   BOOTSTRAP_PROF_OPEN(timers[BOOTSTRAP_INIT_TIME_RECV]);
-  NCCLCHECK(ncclSocketInit(&sock));
-  NCCLCHECK(ncclSocketAccept(&sock, &listenSockRoot));
+  NCCLCHECK(bootstrapAccept(&sock, &listenSockRoot, comm->abortFlag));
   NCCLCHECK(socketRecv(&sock, &nextPeer, sizeof(nextPeer)));
   NCCLCHECK(ncclSocketClose(&sock));
   NCCLCHECK(ncclSocketClose(&listenSockRoot));
@@ -959,8 +978,7 @@ static ncclResult_t socketAccept(void* commState, int peer, int tag, struct nccl
   // Then look for new connections
   while (1) {
     struct socketAckInfo ack = {0};
-    NCCLCHECKGOTO(ncclSocketInit(sock), ret, fail);
-    NCCLCHECKGOTO(ncclSocketAccept(sock, &STATE_LISTEN(state, peerSocket)), ret, fail);
+    NCCLCHECKGOTO(bootstrapAccept(sock, &STATE_LISTEN(state, peerSocket), state->abortFlag), ret, fail);
     NCCLCHECKGOTO(socketRecv(sock, &ack, sizeof(struct socketAckInfo)), ret, fail);
     if (ack.rank == peer && ack.tag == tag) return ncclSuccess;
     NCCLCHECKGOTO(unexpectedEnqueue(state, ack.rank, ack.tag, sock), ret, fail);

--- a/src/include/socket.h
+++ b/src/include/socket.h
@@ -39,7 +39,8 @@ enum ncclSocketState {
   ncclSocketStateTerminating = 8,
   ncclSocketStateClosed = 9,
   ncclSocketStateError = 10,
-  ncclSocketStateNum = 11
+  ncclSocketStateBadMagic = 11,
+  ncclSocketStateNum = 12
 };
 
 enum ncclSocketType {
@@ -84,7 +85,7 @@ ncclResult_t ncclSocketConnect(struct ncclSocket* sock);
 // Return socket connection state.
 ncclResult_t ncclSocketReady(struct ncclSocket* sock, int *running);
 // Accept an incoming connection from listenSock->fd and keep the file descriptor in sock->fd, with the remote side IP/port in sock->addr.
-ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* ulistenSock);
+ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* ulistenSock, bool retryOnBadMagic = true);
 ncclResult_t ncclSocketGetFd(struct ncclSocket* sock, int* fd);
 ncclResult_t ncclSocketSetFd(int fd, struct ncclSocket* sock);
 

--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -663,6 +663,12 @@ static ncclResult_t socketFinalizeConnect(struct ncclSocket* sock) {
 }
 
 static ncclResult_t socketProgressState(struct ncclSocket* sock) {
+  // BadMagic is set by socketFinalizeAccept on magic mismatch. The reset in
+  // ncclSocketAccept's do-while only fires while that loop runs; this covers
+  // the path where a caller re-enters via ncclSocketReady with state=BadMagic.
+  if (sock->state == ncclSocketStateBadMagic) {
+    sock->state = ncclSocketStateAccepting;
+  }
   if (sock->state == ncclSocketStateAccepting) {
     NCCLCHECK(socketTryAccept(sock));
   }

--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -522,6 +522,7 @@ static ncclResult_t socketFinalizeAccept(struct ncclSocket* sock) {
     }
     if (magic != sock->magic) {
       socketResetAccept(sock);
+      sock->state = ncclSocketStateBadMagic;
       return ncclSuccess;
     }
   }
@@ -743,7 +744,7 @@ ncclResult_t ncclSocketConnect(struct ncclSocket* sock) {
   }
 }
 
-ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* listenSock) {
+ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* listenSock, bool retryOnBadMagic) {
   ncclResult_t ret = ncclSuccess;
 
   if (listenSock == NULL || sock == NULL) {
@@ -769,6 +770,9 @@ ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* listen
 
   do {
     NCCLCHECKGOTO(socketProgressState(sock), ret, exit);
+    if (sock->state == ncclSocketStateBadMagic && retryOnBadMagic) {
+      sock->state = ncclSocketStateAccepting;
+    }
   } while (sock->asyncFlag == 0 &&
       (sock->abortFlag == NULL || __atomic_load_n(sock->abortFlag, __ATOMIC_ACQUIRE) == 0) &&
       (sock->state == ncclSocketStateAccepting ||
@@ -780,6 +784,7 @@ ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* listen
     case ncclSocketStateAccepting:
     case ncclSocketStateAccepted:
     case ncclSocketStateReady:
+    case ncclSocketStateBadMagic:
       ret = ncclSuccess;
       break;
     case ncclSocketStateError:

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -1680,7 +1680,7 @@ void* ncclProxyService(void* _args) {
         WARN("[Service thread] Initialize peers[%d].sock fails", s);
         return NULL;
       }
-      if (ncclSocketAccept(&peers[s].sock, proxyState->listenSock) != ncclSuccess) {
+      if (ncclSocketAccept(&peers[s].sock, proxyState->listenSock, /*retryOnBadMagic*/false) != ncclSuccess) {
         WARN("[Service thread] Accept failed %s", strerror(errno));
       } else {
         if (ncclSocketGetFd(&peers[s].sock, &pollfds[s].fd) != ncclSuccess) {

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -1652,6 +1652,10 @@ void* ncclProxyService(void* _args) {
   int npeers = 0;
   int stop = PROXY_RUNNING;
   int asyncOpCount = 0;
+  {
+    char line[SOCKET_NAME_MAXLEN+1];
+    INFO(NCCL_INIT, "proxy listening socket at %s", ncclSocketToString(&proxyState->listenSock->addr, line));
+  }
   while (stop == PROXY_RUNNING || npeers > 0) {
     /* Even if local comm aborts, we cannot let proxy thread exit if we still have peer
      * connections. Need to wait until all other related comms call abort and safely exit
@@ -1687,8 +1691,12 @@ void* ncclProxyService(void* _args) {
           WARN("[Service thread] Get peers[%d].sock fd fails", s);
           return NULL;
         }
-        npeers++;
-        peers[s].tpLocalRank = -1;
+        if (pollfds[s].fd == -1) {
+          (void)ncclSocketClose(&peers[s].sock);
+        } else {
+          npeers++;
+          peers[s].tpLocalRank = -1;
+        }
       }
     }
     for (int s=0; s<maxnpeers; s++) {

--- a/src/ras/ras.cc
+++ b/src/ras/ras.cc
@@ -630,6 +630,13 @@ static void* rasThreadMain(void*) {
     for (int pollIdx = 0; pollIdx < nRasPfds && nEvents > 0; pollIdx++) {
       if (rasPfds[pollIdx].revents) {
         nEvents--;
+        if (rasPfds[pollIdx].revents & POLLNVAL) {
+          // We passed an invalid file descriptor.  For now mark it to be ignored at the next iteration.  Hopefully
+          // in the meantime one of the event handlers will terminate it.
+          INFO(NCCL_RAS, "RAS poll returned POLLNVAL on pollIdx %d (fd %d) -- internal error?",
+               pollIdx, rasPfds[pollIdx].fd);
+          rasPfds[pollIdx].fd = POLL_FD_IGNORE;
+        }
         if (rasPfds[pollIdx].fd == rasNotificationPipe[0]) {
           bool terminate = false;
           NCCLCHECKGOTO(rasLocalHandle(&terminate), ret, exit);

--- a/src/ras/ras_internal.h
+++ b/src/ras/ras_internal.h
@@ -181,6 +181,10 @@ static inline size_t rasMsgLength(rasMsgType type, rasCollectiveType collType = 
 // How much to enlarge any RAS array by if we run out of space.
 #define RAS_INCREMENT 4
 
+// Magic file descriptor number when we want poll() to ignore an entry.  Anything negative would do, but
+// I didn't want to use -1 because it has a special meaning for us.
+#define POLL_FD_IGNORE -2
+
 // Our clock has nanosecond resolution.
 #define CLOCK_UNITS_PER_SEC 1000000000L
 

--- a/src/ras/rasnet.cc
+++ b/src/ras/rasnet.cc
@@ -362,7 +362,7 @@ ncclResult_t rasNetAcceptNewSocket() {
   NCCLCHECKGOTO(ncclSocketInit(&sock->sock, nullptr, NCCL_SOCKET_MAGIC, ncclSocketTypeRasNetwork, nullptr,
                                /*asyncFlag*/1), ret, fail);
   socketInitialized = true;
-  NCCLCHECKGOTO(ncclSocketAccept(&sock->sock, &rasNetListeningSocket), ret, fail);
+  NCCLCHECKGOTO(ncclSocketAccept(&sock->sock, &rasNetListeningSocket, false), ret, fail);
   NCCLCHECKGOTO(ncclSocketReady(&sock->sock, &ready), ret, fail);
 
   if (sock->sock.fd == -1)

--- a/src/ras/rasnet.cc
+++ b/src/ras/rasnet.cc
@@ -20,10 +20,6 @@ struct rasConnection* rasConnsTail;
 struct rasSocket *rasSocketsHead;
 struct rasSocket *rasSocketsTail;
 
-// Magic file descriptor number when we want poll() to ignore an entry.  Anything negative would do, but
-// I didn't want to use -1 because it has a special meaning for us.
-#define POLL_FD_IGNORE -2
-
 static void freeConnEntry(struct rasConnection* conn);
 static void rasConnOpen(struct rasConnection* conn);
 static ncclResult_t rasConnPrepare(struct rasConnection* conn);
@@ -362,7 +358,7 @@ ncclResult_t rasNetAcceptNewSocket() {
   NCCLCHECKGOTO(ncclSocketInit(&sock->sock, nullptr, NCCL_SOCKET_MAGIC, ncclSocketTypeRasNetwork, nullptr,
                                /*asyncFlag*/1), ret, fail);
   socketInitialized = true;
-  NCCLCHECKGOTO(ncclSocketAccept(&sock->sock, &rasNetListeningSocket, false), ret, fail);
+  NCCLCHECKGOTO(ncclSocketAccept(&sock->sock, &rasNetListeningSocket), ret, fail);
   NCCLCHECKGOTO(ncclSocketReady(&sock->sock, &ready), ret, fail);
 
   if (sock->sock.fd == -1)
@@ -589,8 +585,12 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
           }
         } // if (connectSide)
       } else { // !ready
-        if (sock->sock.state == ncclSocketStateConnecting)
+        if (sock->sock.state == ncclSocketStateConnecting) {
           rasPfds[sock->pfd].fd = POLL_FD_IGNORE; // Don't poll on this socket before connect().
+        } else if (sock->sock.fd == -1) {
+          // Most likely an incoming connection that failed the magic test.
+          rasSocketTerminate(sock);
+        }
       }
     } // if (ncclSocketReady)
   } else { // RAS_SOCK_HANDSHAKE || RAS_SOCK_READY || RAS_SOCK_TERMINATING.


### PR DESCRIPTION
## Details

**Work item:** "Internal"

---

**What were the changes?**  
Fix bad-magic related nccl/rccl init hang.
The first two commits are pure upstream backports and would be unnecessary once the underlying upstream commits land in mainline NCCL and are merged into RCCL through the normal sync. The third commit is the actual new work in this PR; it would also be a candidate for upstream submission to NVIDIA.


---

# **Why were the changes made?**  

NCCL/RCCL listen sockets check the first 8 bytes of every incoming connection against an expected magic value (the static `NCCL_SOCKET_MAGIC` constant for proxy and transport sockets; a per-job random magic from `ncclUniqueId` for bootstrap sockets). The check exists precisely so that unrelated TCP traffic — connections that are not part of an NCCL handshake — can be rejected without corrupting NCCL state.

NCCL's bootstrap and proxy listen sockets bind to ephemeral TCP ports chosen by the kernel from the local port range — the same range that *every* other userspace service on the host draws from for its own ephemeral allocations. On a shared multi-tenant cluster, this leads to occasional unrelated TCP traffic arriving at NCCL's listen ports. Two common mechanisms:

- **Port reuse with stale state.** A peer holds open or cached state pointing at `our_ip:port` from a process that previously owned that port. After that process dies and the kernel reassigns the port to NCCL's listen socket, the peer's retransmits, reconnect attempts, or keepalives land at NCCL.
- **Infrastructure probes.** Service-discovery or healthcheck agents scan port ranges that overlap the ephemeral range; eventually one lands at NCCL's port.

The peer in either case sends bytes that aren't the expected magic (it has no idea it's talking to NCCL). The magic check correctly rejects the peer. The bug is in **how the rejection is handled**, not in the rejection itself. After the bad-magic peer is dropped, two failure modes can cause the entire job to hang at init:

1. **Sync-mode caller monopolization.** `ncclSocketAccept`'s do-while loop in sync mode resets state back to `Accepting` after every bad-magic event and continues. Once the bad-magic queue is drained, the next `accept()` returns `EAGAIN` (on a non-blocking listen socket), state stays `Accepting`, and the loop spins forever. The caller (proxy thread, bootstrap thread) is trapped inside `ncclSocketAccept` and cannot return to its top-level dispatch (`poll()`, etc.). All other file descriptors that caller is responsible for — including legitimate peer connections — are starved indefinitely. A single stuck rank then deadlocks the whole job because every rank participates in the global PG init.

2. **Async-mode silent stall** (introduced as a side effect of the upstream fix described below). Async-mode callers re-enter `socketProgressState` via `ncclSocketReady` after the listen socket signals `POLLIN`. If state lands at `BadMagic` during such a re-entry, the if-cascade in `socketProgressState` has no case for it. State stays `BadMagic` forever; `ncclSocketReady` returns `*running=0` indefinitely. The thread is not stuck (it continues servicing other work), but the specific per-`recvComm` accept stage stops making progress. Any global PG depending on that peer-pair handshake hangs.

Each individual occurrence is rare per-rank. At a few thousand ranks per job and many jobs, the probability of at least one rank hitting it during the brief `commInit` window approaches certainty. The fix below makes both failure modes return cleanly so that one transient event does not become a permanent cluster-wide deadlock.

---

# **How was the outcome achieved?**  
## Existing upstream NCCL fixes (v2.30u1 branch)

NVIDIA has landed two related commits on the `v2.30u1` branch of `NVIDIA/nccl`. Both are partial fixes; together they cover proxy and rasnet but leave bootstrap and transport vulnerable.

### `8fdd98c` — fix #1808: do not retry on bad magic when proxy and ras net accept

- Adds `ncclSocketStateBadMagic` to the socket state enum
- Adds a `retryOnBadMagic` parameter (default `true`) to `ncclSocketAccept`
- In `socketFinalizeAccept`, on magic mismatch, additionally sets `state = BadMagic` (previously state was reset to `Accepting` only)
- In `ncclSocketAccept`'s do-while, after `socketProgressState`: if `state==BadMagic && retryOnBadMagic` → reset to `Accepting`
- Passes `retryOnBadMagic=false` at the proxy.cc and ras/rasnet.cc accept callsites

The escape mechanism is: with `retryOnBadMagic=false`, the new `BadMagic` terminal state is no longer reset inside the loop, so the do-while exits and the caller can react.

This commit is backported into RCCL in this PR as the first commit.

### `7310803b` — Deal with incomplete socket accepts

- Defensive cleanup in proxy.cc: after `ncclSocketAccept` returns, if the resulting fd is invalid (the bad-magic peer was dropped, so no real fd was registered), close the sock without registering the slot. Without this, every dropped bad-magic accept slowly leaks a slot in `pollfds[]`, and after enough events the proxy exhausts its connection table.
- Adds POLLNVAL handling in the RAS event loop to prevent a busy loop on an invalidated fd.
- Reverts `retryOnBadMagic=false` at the ras/rasnet.cc accept callsite. Rasnet's listen socket is async-mode, so the do-while exits after one iteration regardless; the new commit relies on async-mode natural retry plus a new `fd==-1` cleanup in `rasSockEventLoop`.
- Moves the `POLL_FD_IGNORE` define from `rasnet.cc` to `ras_internal.h` so both `ras.cc` and `rasnet.cc` can use it.

This commit is backported into RCCL in this PR as the second commit.

## Why those patches are not enough

The upstream commits explicitly scope `retryOnBadMagic=false` to proxy and rasnet only. There are seven other `ncclSocketAccept` callsites in the codebase that retain the default `retryOnBadMagic=true` and remain vulnerable.

### Gap 1: Bootstrap accept callsites

Four accept callsites in `bootstrap.cc`:

- `bootstrap.cc:298` — bootstrapRoot's per-rank accept loop
- `bootstrap.cc:557` — socketRingConnect's recv-side accept
- `bootstrap.cc:709` — bootstrapInit's connect-back accept
- `bootstrap.cc:963` — socketAccept used by bootstrapRecv

All four use the default `retryOnBadMagic=true`, so the do-while continues on `BadMagic` exactly as it did before `8fdd98c`. When a non-NCCL TCP peer hits the bootstrap listen socket during `commInit`, the bootstrap thread on that rank is monopolized inside `ncclSocketAccept`. This is the same EAGAIN-spin-after-drained pathology that motivated the proxy fix, just at a different layer.

### Gap 2: Async-mode transport accept callsites

Three accept callsites in transport:

- `transport/net_ib.cc:1704` — `ncclIbAccept`
- `transport/net_ib_rocm.cc:1831` — `rocmIbAccept` (RCCL-specific)
- `transport/net_socket.cc:439` — TCP transport accept

These callsites use the default `retryOnBadMagic=true` *and* their listen sockets inherit `asyncFlag=1` from `lComm->sock`. The do-while exits after one iteration in async mode regardless of the retry flag, so monopolization is not the issue here. The issue is that `8fdd98c`'s new `BadMagic` state has no case in `socketProgressState`'s if-cascade. When the proxy poll loop subsequently calls `ncclSocketReady` on a `recvComm` whose first peer hit bad-magic, the cascade makes no progress, and the per-`recvComm` accept stage parks at `BadMagic` forever.

This is a regression introduced by `8fdd98c`'s addition of the `BadMagic` terminal state. Baseline RCCL (before `8fdd98c` is backported) does not have this vulnerability because it has no `BadMagic` state to get stuck at.

## What this PR adds

One additional commit on top of the upstream backports, containing two related fixes.

### Bootstrap accept wrapper (`bootstrap.cc`)

A static helper `bootstrapAccept` that closes the gap for the four bootstrap callsites:

```c
static ncclResult_t bootstrapAccept(struct ncclSocket* sock, struct ncclSocket* listenSock,
                                    volatile uint32_t* abortFlag) {
  while (1) {
    if (abortFlag != NULL && __atomic_load_n(abortFlag, __ATOMIC_ACQUIRE) != 0) {
      return ncclInternalError;
    }
    NCCLCHECK(ncclSocketInit(sock));
    NCCLCHECK(ncclSocketAccept(sock, listenSock, /*retryOnBadMagic=*/false));
    if (sock->state != ncclSocketStateBadMagic) return ncclSuccess;
    INFO(NCCL_INIT|NCCL_NET, "bootstrap: rejected bad-magic peer connection on listen sock, retrying accept");
    (void)ncclSocketClose(sock);
    usleep(1000);
  }
}
```

Behavior: pass `retryOnBadMagic=false` so `ncclSocketAccept` returns control to the wrapper after each bad-magic event; close the rejected socket; yield 1 ms (avoid 100% CPU between iterations under sustained flood); honor `abortFlag` between iterations. The four bootstrap callsites are updated to call this helper.

### `socketProgressState` BadMagic recovery (`misc/socket.cc`)

A 4-line addition at the top of `socketProgressState`:

```c
static ncclResult_t socketProgressState(struct ncclSocket* sock) {
  // BadMagic is set by socketFinalizeAccept on magic mismatch. The reset in
  // ncclSocketAccept's do-while only fires while that loop runs; this covers
  // the path where a caller re-enters via ncclSocketReady with state=BadMagic.
  if (sock->state == ncclSocketStateBadMagic) {
    sock->state = ncclSocketStateAccepting;
  }
  if (sock->state == ncclSocketStateAccepting) {
    NCCLCHECK(socketTryAccept(sock));
  }
  ...
}
```

This makes the if-cascade self-healing: any caller (sync or async) that re-enters `socketProgressState` with `state=BadMagic` gets state reset to `Accepting` and progresses normally on the next poll. Sync callers that pass `retryOnBadMagic=false` (proxy, rasnet, bootstrapAccept) are unaffected: their state only becomes `BadMagic` after `socketProgressState` returns inside the loop, the do-while exits, and the caller observes `BadMagic` before the next `socketProgressState` call.

---

# **Additional Documentation:**  
## Symptom evidence

### Sync-mode bootstrap monopolization (representative stack)

```
__libc_accept
socketProgressState
ncclSocketAccept(retryOnBadMagic=true [DEFAULT])
socketAccept (bootstrap.cc)
bootstrapRecv (bootstrap.cc)
ncclTransportP2pSetup
ncclTransportTreeConnect
initTransportsRank
ncclCommInitRankFunc
ncclAsyncJobMain
```

The thread is trapped inside `ncclSocketAccept`'s do-while. After the bad-magic peer (or peers) is drained, `accept()` returns `EAGAIN`, state stays `Accepting`, and the loop spins. Other peer connections this thread should service are starved.

The proxy variant has an identical shape with `ncclProxyService` as the outer caller instead of `bootstrapRecv`. This is what `8fdd98c` fixes for proxy and what the bootstrap wrapper in this PR fixes for the bootstrap layer.

### Async-mode transport silent stall (no stuck thread)

The proxy poll loop continues servicing other connections normally. The stall is per-`recvComm` state: one specific accept stage has `state=BadMagic` and `fd=-1`, and never advances. The proxy poll loop keeps invoking the transport's accept-check function, which calls `ncclSocketReady` on the stuck sock; `ncclSocketReady` calls `socketProgressState`, the if-cascade has no `BadMagic` case, and `*running=0` is returned indefinitely. Any global PG that depends on the corresponding peer-pair handshake hangs.

This stall is fixed by the `socketProgressState` reset in this PR.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.