### PR TITLE
Fix doxygen @param direction tags for caller-allocated recvbuff

### DIFF
--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -549,7 +549,7 @@ ncclResult_t pncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm);
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Local device data buffer to be reduced
-    @param[out] recvbuff      Data buffer where result is stored (only for *root* rank).  May be null for other ranks.
+    @param[in,out] recvbuff      Data buffer where result is stored (only for *root* rank).  May be null for other ranks.
     @param[in]  count         Number of elements in every send buffer
     @param[in]  datatype      Data buffer element datatype
     @param[in]  op            Reduction operator type
@@ -591,7 +591,7 @@ ncclResult_t pncclBcast(void* buff, size_t count, ncclDataType_t datatype, int r
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Data array to copy (if *root*).  May be NULL for other ranks
-    @param[in]  recvbuff      Data array to store received array
+    @param[in,out] recvbuff   Data array to store received array
     @param[in]  count         Number of elements in data buffer
     @param[in]  datatype      Data buffer element datatype
     @param[in]  root          Rank of broadcast root
@@ -611,7 +611,7 @@ ncclResult_t pncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, 
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Input data array to reduce
-    @param[out] recvbuff      Data array to store reduced result array
+    @param[in,out] recvbuff      Data array to store reduced result array
     @param[in]  count         Number of elements in data buffer
     @param[in]  datatype      Data buffer element datatype
     @param[in]  op            Reduction operator
@@ -631,7 +631,7 @@ ncclResult_t pncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Input data array to reduce
-    @param[out] recvbuff      Data array to store reduced result array
+    @param[in,out] recvbuff      Data array to store reduced result array
     @param[in]  count         Number of elements in data buffer
     @param[in]  datatype      Data buffer element datatype
     @param[in]  op            Reduction operator
@@ -655,7 +655,7 @@ ncclResult_t pncclAllReduceWithBias(const void* sendbuff, void* recvbuff, size_t
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Input data array to reduce
-    @param[out] recvbuff      Data array to store reduced result subarray
+    @param[in,out] recvbuff      Data array to store reduced result subarray
     @param[in]  recvcount     Number of elements each rank receives
     @param[in]  datatype      Data buffer element datatype
     @param[in]  op            Reduction operator
@@ -679,7 +679,7 @@ ncclResult_t pncclReduceScatter(const void* sendbuff, void* recvbuff,
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Input data array to send
-    @param[out] recvbuff      Data array to store the gathered result
+    @param[in,out] recvbuff      Data array to store the gathered result
     @param[in]  sendcount     Number of elements each rank sends
     @param[in]  datatype      Data buffer element datatype
     @param[in]  comm          Communicator group object to execute on
@@ -699,7 +699,7 @@ ncclResult_t pncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcou
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Data array to send (contains blocks for each other rank)
-    @param[out] recvbuff      Data array to receive (contains blocks from each other rank)
+    @param[in,out] recvbuff      Data array to receive (contains blocks from each other rank)
     @param[in]  count         Number of elements to send between each pair of ranks
     @param[in]  datatype      Data buffer element datatype
     @param[in]  comm          Communicator group object to execute on
@@ -723,7 +723,7 @@ ncclResult_t pncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count,
     @param[in]  sendbuff      Data array to send (contains blocks for each other rank)
     @param[in]  sendcounts    Array containing number of elements to send to each participating rank
     @param[in]  sdispls       Array of offsets into *sendbuff* for each participating rank
-    @param[out] recvbuff      Data array to receive (contains blocks from each other rank)
+    @param[in,out] recvbuff      Data array to receive (contains blocks from each other rank)
     @param[in]  recvcounts    Array containing number of elements to receive from each participating rank
     @param[in]  rdispls       Array of offsets into *recvbuff* for each participating rank
     @param[in]  datatype      Data buffer element datatype
@@ -748,7 +748,7 @@ ncclResult_t pncclAlltoAllv(const void *sendbuff, const size_t sendcounts[],
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Data array to send
-    @param[in]  recvbuff      Data array to recv
+    @param[in,out] recvbuff   Data array to recv
     @param[in]  count         Number of elements
     @param[in]  datatype      Data buffer element datatype
     @param[in]  root          Rank of gather root
@@ -771,7 +771,7 @@ ncclResult_t pncclGather(const void* sendbuff, void* recvbuff, size_t count,
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Data array to send
-    @param[in]  recvbuff      Data array to recv
+    @param[in,out] recvbuff   Data array to recv
     @param[in]  count         Number of elements
     @param[in]  datatype      Data buffer element datatype
     @param[in]  root          Rank of scatter root
@@ -794,7 +794,7 @@ ncclResult_t pncclScatter(const void* sendbuff, void* recvbuff, size_t count,
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Data array to send (contains blocks for each other rank)
-    @param[out] recvbuff      Data array to receive (contains blocks from each other rank)
+    @param[in,out] recvbuff      Data array to receive (contains blocks from each other rank)
     @param[in]  count         Number of elements to send between each pair of ranks
     @param[in]  datatype      Data buffer element datatype
     @param[in]  comm          Communicator group object to execute on
@@ -820,7 +820,7 @@ ncclResult_t pncclAllToAll(const void* sendbuff, void* recvbuff, size_t count,
     @param[in]  sendbuff      Data array to send (contains blocks for each other rank)
     @param[in]  sendcounts    Array containing number of elements to send to each participating rank
     @param[in]  sdispls       Array of offsets into *sendbuff* for each participating rank
-    @param[out] recvbuff      Data array to receive (contains blocks from each other rank)
+    @param[in,out] recvbuff      Data array to receive (contains blocks from each other rank)
     @param[in]  recvcounts    Array containing number of elements to receive from each participating rank
     @param[in]  rdispls       Array of offsets into *recvbuff* for each participating rank
     @param[in]  datatype      Data buffer element datatype
@@ -867,7 +867,7 @@ ncclResult_t pncclSend(const void* sendbuff, size_t count, ncclDataType_t dataty
                 ncclGroupEnd section.
     @return     Result code. See @ref rccl_result_code for more details.
 
-    @param[out] recvbuff      Data array to receive
+    @param[in,out] recvbuff      Data array to receive
     @param[in]  count         Number of elements to receive
     @param[in]  datatype      Data buffer element datatype
     @param[in]  peer          Peer rank to send to


### PR DESCRIPTION
## Summary

Every collective in `src/nccl.h.in` documents `recvbuff` with the wrong doxygen direction tag. The buffer is **caller-allocated** device memory that the function writes into, which per doxygen convention should be `@param[in,out]`, not `@param[out]` (function fully owns/produces) and certainly not `@param[in]` (read-only).

This PR is a **comment-only audit pass** across every public collective in the header.

## Why this matters

Per the upstream report ([AICOMRCCL-1017](https://amd-hub.atlassian.net/browse/AICOMRCCL-1017)):

- `@param[out]` denotes a parameter the function fully owns / produces / writes-without-prerequisite-state. Tooling (IDE help-popups, language-binding generators, header-driven static analysis) consumes this tag literally — e.g., binding generators move pure-OUT parameters into the wrapper's return value.
- `recvbuff` is a `void*` into pre-`hipMalloc`-ed device memory. The function does not allocate it; the caller must.
- Mistagging it `[out]` (or worse, `[in]` on `ncclBroadcast`/`ncclGather`/`ncclScatter`) trains users to write code that crashes on first call because the docs imply the function will produce the buffer.

`ncclBcast`'s `buff` parameter is genuinely in-place and was already correctly tagged `@param[in,out]` — left untouched.

## What changed

13 doxygen lines in `src/nccl.h.in`. No code changes.

| Function | Old tag | New tag |
|---|---|---|
| `ncclReduce` | `[out]` | `[in,out]` |
| `ncclBroadcast` | `[in]` | `[in,out]` |
| `ncclAllReduce` | `[out]` | `[in,out]` |
| `ncclAllReduceWithBias` | `[out]` | `[in,out]` |
| `ncclReduceScatter` | `[out]` | `[in,out]` |
| `ncclAllGather` | `[out]` | `[in,out]` |
| `ncclAlltoAll` | `[out]` | `[in,out]` |
| `ncclAlltoAllv` | `[out]` | `[in,out]` |
| `ncclGather` | `[in]` | `[in,out]` |
| `ncclScatter` | `[in]` | `[in,out]` |
| `ncclAllToAll` | `[out]` | `[in,out]` |
| `ncclAllToAllv` | `[out]` | `[in,out]` |
| `ncclRecv` | `[out]` | `[in,out]` |

PMPI mirrors (`p*` declarations) live in `@cond include_hidden` blocks without per-param tags, so no parallel changes are needed.

## Verification

- `grep` confirms zero remaining `@param[out] recvbuff` or `@param[in] recvbuff` in the file.
- All 173 `@param[<dir>]` tags in the header use a valid direction (`in`, `out`, or `in,out`).
- `sendbuff` parameters remain `[in]` (read-only); `ncclBcast` `buff` remains `[in,out]` (true in-place).

## Risk

Effectively zero — this is a doxygen comment change. No ABI, no behavior, no codegen impact.

Fixes AICOMRCCL-1017.

[AICOMRCCL-1017]: https://amd-hub.atlassian.net/browse/AICOMRCCL-1017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ