### PR TITLE
Add per-comm debug logging for extra WR insertion in ncclIbMultiSend

### DIFF
--- a/ext-src/rocm_netib.patch
+++ b/ext-src/rocm_netib.patch
@@ -1,5 +1,5 @@
 diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
-index ba4a8739f6..174311958e 100644
+index 53b2f42b..36acca61 100644
 --- a/src/transport/net_ib.cc
 +++ b/src/transport/net_ib.cc
 @@ -28,6 +28,7 @@
@@ -10,7 +10,7 @@ index ba4a8739f6..174311958e 100644
  #include "graph/xml.h"
  #include "net_ib_checksum.h"
  
-@@ -108,9 +109,31 @@
+@@ -108,9 +109,31 @@ struct ncclIbMergedDev ncclIbMergedDevs[MAX_IB_VDEVS];
  struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
  pthread_mutex_t ncclIbLock = PTHREAD_MUTEX_INITIALIZER;
  static int ncclIbRelaxedOrderingEnabled = 0;
@@ -42,9 +42,7 @@ index ba4a8739f6..174311958e 100644
  #define NCCL_IB_SL_DEFAULT 0
  #define NCCL_IB_TC_DEFAULT 0
  
-@@ -134,8 +157,15 @@
- RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
- #if RCCL_IB_CHECKSUM_DEVICE_ENABLED
+@@ -136,6 +159,13 @@ RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
  RCCL_PARAM(IbRdmaChecksum, "IB_RDMA_CHECKSUM", 1);
  RCCL_PARAM(IbRdmaChecksumTrace, "IB_RDMA_CHECKSUM_TRACE", 0);
  #endif
@@ -58,7 +56,7 @@ index ba4a8739f6..174311958e 100644
  
  static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
    __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
-@@ -633,6 +663,10 @@
+@@ -635,6 +665,10 @@ ncclResult_t ncclIbInit(ncclDebugLogger_t logFunction, ncclProfilerCallback_t pr
    static int shownIbHcaEnv = 0;
    if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
    if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
@@ -69,7 +67,7 @@ index ba4a8739f6..174311958e 100644
  
    // Detect IB cards
    int nIbDevs = 0;
-@@ -786,6 +820,24 @@
+@@ -788,6 +822,24 @@ ncclResult_t ncclIbInit(ncclDebugLogger_t logFunction, ncclProfilerCallback_t pr
      INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
            ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
  
@@ -94,7 +92,7 @@ index ba4a8739f6..174311958e 100644
      pthread_mutex_unlock(&ncclIbLock);
    }
  exit:
-@@ -1118,6 +1170,8 @@
+@@ -1124,6 +1176,8 @@ struct ncclIbListenComm {
    struct ncclIbCommStage stage;
  };
  
@@ -103,7 +101,7 @@ index ba4a8739f6..174311958e 100644
  struct alignas(64) ncclIbSendFifo {
    uint64_t addr;
    uint64_t size;
-@@ -1128,10 +1182,21 @@
+@@ -1134,10 +1188,21 @@ struct alignas(64) ncclIbSendFifo {
    char padding[16];
  };
  
@@ -125,7 +123,7 @@ index ba4a8739f6..174311958e 100644
  };
  
  struct ncclIbRemSizesFifo {
-@@ -1178,6 +1243,7 @@
+@@ -1184,6 +1249,7 @@ struct ncclIbSendComm {
    struct ncclIbNetCommBase base;
    // Start with fifo and ibv structs as they have alignment restrictions
    struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -133,7 +131,15 @@ index ba4a8739f6..174311958e 100644
    struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
    struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
    // Each dev correlates to a mergedIbDev
-@@ -1194,6 +1260,7 @@
+@@ -1195,6 +1261,7 @@ struct ncclIbSendComm {
+ #endif
+   uint64_t fifoHead;
+   int ar; // Use adaptive routing when all merged devices have it enabled
++  uint64_t extraWrCount; // Per-comm counter for extra WR insertions (multi-recv / AR)
+ };
+ // The SendFifo needs to be 32-byte aligned and each element needs
+ // to be a 32-byte multiple, so that an entry does not get split and
+@@ -1202,6 +1269,7 @@ struct ncclIbSendComm {
  static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
  static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
  static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
@@ -141,7 +147,7 @@ index ba4a8739f6..174311958e 100644
  static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
  static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
  
-@@ -1208,6 +1275,7 @@
+@@ -1216,6 +1284,7 @@ struct ncclIbGpuFlush {
  
  struct ncclIbRemFifo {
    struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -149,7 +155,7 @@ index ba4a8739f6..174311958e 100644
    uint64_t fifoTail;
    uint64_t addr;
    uint32_t flags;
-@@ -1280,20 +1348,59 @@
+@@ -1290,20 +1359,59 @@ returning:
    return res;
  }
  
@@ -211,7 +217,7 @@ index ba4a8739f6..174311958e 100644
    struct ibv_qp_attr qpAttr;
    memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
    qpAttr.qp_state = IBV_QPS_INIT;
-@@ -1303,6 +1410,9 @@
+@@ -1313,6 +1421,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
    NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
    TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
      ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
@@ -221,7 +227,7 @@ index ba4a8739f6..174311958e 100644
    return ncclSuccess;
  }
  
-@@ -1386,7 +1496,7 @@
+@@ -1396,7 +1507,7 @@ fail:
    goto exit;
  }
  
@@ -230,7 +236,7 @@ index ba4a8739f6..174311958e 100644
    ncclResult_t ret = ncclSuccess;
    struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
    struct ncclIbCommStage* stage = &handle->stage;
-@@ -1394,8 +1504,13 @@
+@@ -1404,8 +1515,13 @@ ncclResult_t ncclIbConnect(int dev, ncclNetCommConfig_t* config, void* opaqueHan
    int ready;
    uint8_t link_layer = IBV_LINK_LAYER_UNSPECIFIED;
    int isP2p = 0; 
@@ -244,7 +250,7 @@ index ba4a8739f6..174311958e 100644
    if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
    if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
    if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-@@ -1476,7 +1591,7 @@
+@@ -1486,7 +1602,7 @@ ib_recv_dev_list:
    for (int q = 0; q < comm->base.nqps; q++) {
      ncclIbSendCommDev* commDev = comm->devs + devIndex;
      ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
@@ -253,7 +259,7 @@ index ba4a8739f6..174311958e 100644
      comm->base.qps[q].devIndex = devIndex;
      meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
      meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
-@@ -1501,7 +1616,11 @@
+@@ -1511,7 +1627,11 @@ ib_recv_dev_list:
      devInfo->lid           = ibDev->portAttr.lid;
      devInfo->ibv_dev_index = commDev->base.ibDevN;
      // Prepare my fifo
@@ -266,7 +272,7 @@ index ba4a8739f6..174311958e 100644
      devInfo->fifoRkey = commDev->fifoMr->rkey;
  
      // Pack local GID info
-@@ -1543,7 +1662,11 @@
+@@ -1553,7 +1673,11 @@ ib_recv_dev_list:
        return ncclInternalError;
      }
    }
@@ -279,7 +285,7 @@ index ba4a8739f6..174311958e 100644
    meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
    meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
    strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-@@ -1688,18 +1811,22 @@
+@@ -1698,18 +1822,22 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
    return ncclSuccess;
  }
  
@@ -304,7 +310,7 @@ index ba4a8739f6..174311958e 100644
    if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
    if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
    if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
-@@ -1829,7 +1956,7 @@
+@@ -1839,7 +1967,7 @@ ib_recv:
      // Local ibDevN
      ibDevN = rComm->devs[devIndex].base.ibDevN;
      ibDev = ncclIbDevs + ibDevN;
@@ -313,7 +319,7 @@ index ba4a8739f6..174311958e 100644
      qp->devIndex = devIndex;
      devIndex = (devIndex + 1) % rComm->base.vProps.ndevs;
  
-@@ -1855,16 +1982,22 @@
+@@ -1865,16 +1993,22 @@ ib_recv:
  
    useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);
    rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || useDmaBuf)
@@ -339,7 +345,7 @@ index ba4a8739f6..174311958e 100644
  
      // Allocate Flush dummy buffer for GPU Direct RDMA
      if (rComm->flushEnabled) {
-@@ -1902,7 +2035,7 @@
+@@ -1912,7 +2046,7 @@ ib_recv:
        rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
        rCommDev->gpuFlush.sge.length = 1;
        rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
@@ -348,9 +354,9 @@ index ba4a8739f6..174311958e 100644
        struct ncclIbDevInfo devInfo;
        devInfo.lid         = ibDev->portAttr.lid;
        devInfo.link_layer  = ibDev->portAttr.link_layer;
-@@ -2164,10 +2297,15 @@
-   return ncclSuccess;
+@@ -2176,10 +2310,15 @@ ncclResult_t ncclIbGetRecvChecksums(void* recvComm, int n, uint32_t* checksums)
  }
+ #endif // RCCL_IB_CHECKSUM_DEVICE_ENABLED
  
 -ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
 +ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot, bool use_write_op) {
@@ -366,7 +372,7 @@ index ba4a8739f6..174311958e 100644
    if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
  
    uint64_t wr_id = 0ULL;
-@@ -2179,7 +2317,11 @@
+@@ -2191,7 +2330,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
      sge->addr=(uintptr_t)reqs[r]->send.data;
      wr->opcode = IBV_WR_RDMA_WRITE;
      wr->send_flags = 0;
@@ -379,16 +385,16 @@ index ba4a8739f6..174311958e 100644
      wr->next = wr + 1;
      wr_id += (reqs[r] - comm->base.reqs) << (r*8);
  #ifdef NCCL_ENABLE_NET_PROFILING
-@@ -2190,7 +2332,7 @@
+@@ -2202,7 +2345,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
    // Write size (and optional checksum) as immediate data. In the case of multi-send,
    // only write 0 or 1 as size to indicate whether there was data sent or received.
    uint32_t immData = 0;
 -  if (nreqs == 1) {
 +  if ((nreqs == 1) && (use_write_op == false)) {
      int size = reqs[0]->send.size;
+ #if RCCL_IB_CHECKSUM_DEVICE_ENABLED
      if (rcclParamIbRdmaChecksum() && ncclIbImmCanPack(size)) {
-       uint32_t csum = reqs[0]->send.checksum;
-@@ -2209,22 +2351,24 @@
+@@ -2225,22 +2368,28 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
    }
  
    struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
@@ -404,7 +410,8 @@ index ba4a8739f6..174311958e 100644
 -      lastWr->num_sge = 1;
 -      lastWr->sg_list = &comm->remSizesFifo.sge;
 +  if (use_write_op == false) {
-+    if (nreqs > 1 || (comm->ar && reqs[0]->send.size > ncclParamIbArThreshold())) {
++    if (nreqs > 1 || (comm->ar && reqs[0]->send.size > ncclParamRocmIbArThreshold())) {
++      comm->extraWrCount++;
 +      // When using ADAPTIVE_ROUTING, send the bulk of the data first as an
 +      // RDMA_WRITE, then a 0-byte RDMA_WRITE_WITH_IMM to trigger a remote
 +      // completion.
@@ -416,6 +423,9 @@ index ba4a8739f6..174311958e 100644
 +        lastWr->num_sge = 1;
 +        lastWr->sg_list = &comm->remSizesFifo.sge;
 +      }
++
++      INFO(NCCL_NET, "NET/IB: ncclIbMultiSend extra-WR comm=%p #%lu slot=%d nreqs=%d ar=%d qpIndex=%d fifoHead=%lu immData=0x%x",
++        comm, comm->extraWrCount, slot, nreqs, comm->ar, comm->base.qpIndex, comm->fifoHead, immData);
      }
 +    lastWr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
 +    lastWr->imm_data = immData;
@@ -426,7 +436,7 @@ index ba4a8739f6..174311958e 100644
    lastWr->next = NULL;
    lastWr->send_flags = IBV_SEND_SIGNALED;
  
-@@ -2240,7 +2384,11 @@
+@@ -2256,7 +2405,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
        //ncclIbAddEvent(reqs[r], devIndex, &comm->devs[devIndex].base);
  
        // Select proper rkey (needed even for 0-size send)
@@ -439,7 +449,7 @@ index ba4a8739f6..174311958e 100644
  
        int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
        int length = std::min(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
-@@ -2256,7 +2404,7 @@
+@@ -2272,7 +2425,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
        }
      }
  
@@ -448,7 +458,7 @@ index ba4a8739f6..174311958e 100644
        // Also make sure lastWr writes remote sizes using the right lkey
        comm->remSizesFifo.sge.lkey = comm->remSizesFifo.mrs[devIndex]->lkey;
        lastWr->wr.rdma.rkey = comm->remSizesFifo.rkeys[devIndex];
-@@ -2314,32 +2462,46 @@
+@@ -2330,32 +2483,46 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
    NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
  
    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
@@ -485,9 +495,7 @@ index ba4a8739f6..174311958e 100644
 +  }
    for (int r=0; r<nreqs; r++) {
 -    if (reqs[r] != NULL || slots[r].tag != tag) continue;
-+    if (!rcclCtsOffloadEnabled) {
-+      if (reqs[r] != NULL || slots[r].tag != tag) continue;
- 
+-
 -    if (size > slots[r].size) size = slots[r].size;
 -    // Sanity checks
 -    if (slots[r].size < 0 || slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
@@ -497,6 +505,9 @@ index ba4a8739f6..174311958e 100644
 -      WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
 -        r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
 -      return ncclInternalError;
++    if (!rcclCtsOffloadEnabled) {
++      if (reqs[r] != NULL || slots[r].tag != tag) continue;
++
 +      if (size > slots[r].size) size = slots[r].size;
 +      // Sanity checks
 +      if (slots[r].size < 0 || slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
@@ -512,7 +523,7 @@ index ba4a8739f6..174311958e 100644
      }
  
      struct ncclIbRequest* req;
-@@ -2384,10 +2546,12 @@
+@@ -2402,10 +2569,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
      }
  
      TIME_START(0);
@@ -527,7 +538,7 @@ index ba4a8739f6..174311958e 100644
      memset(reqs, 0, NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbRequest*));
      comm->fifoHead++;
      TIME_STOP(0);
-@@ -2400,30 +2564,60 @@
+@@ -2418,30 +2587,60 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
  
  ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, size_t* sizes, int* tags, void** mhandles, struct ncclIbRequest* req) {
    struct ibv_send_wr wr;
@@ -577,22 +588,21 @@ index ba4a8739f6..174311958e 100644
 +      localElemCtsInline[i].tag = tags[i];
 +      localElemCtsInline[i].idx = comm->remFifo.fifoTail+1;
 +      localElemRef = (uint64_t)localElemCtsInline;
++
++    } else {
++      localElem[i].addr = (uint64_t)data[i];
  
 -    // Send all applicable rkeys
 -    for (int j = 0; j < comm->base.vProps.ndevs; j++)
 -      localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
--
++      // Send all applicable rkeys
++      for (int j = 0; j < comm->base.vProps.ndevs; j++)
++        localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
+ 
 -    localElem[i].nreqs = n;
 -    localElem[i].size = sizes[i]; // Sanity/Debugging
 -    localElem[i].tag = tags[i];
 -    localElem[i].idx = comm->remFifo.fifoTail+1;
-+    } else {
-+      localElem[i].addr = (uint64_t)data[i];
-+
-+      // Send all applicable rkeys
-+      for (int j = 0; j < comm->base.vProps.ndevs; j++)
-+        localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
-+
 +      localElem[i].nreqs = n;
 +      localElem[i].size = sizes[i]; // Sanity/Debugging
 +      localElem[i].tag = tags[i];
@@ -602,7 +612,7 @@ index ba4a8739f6..174311958e 100644
    }
    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
  
-@@ -2431,8 +2625,12 @@
+@@ -2449,8 +2648,12 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
    wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].fifoRkey;
  
    // Set the correct sge properties
@@ -617,7 +627,7 @@ index ba4a8739f6..174311958e 100644
    wr.sg_list = &comm->devs[ctsQp->devIndex].fifoSge;
    wr.num_sge = 1;
  
-@@ -2462,7 +2660,13 @@
+@@ -2480,7 +2683,13 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
    //
    // slot == devIndex - When writing to fifo slot N, and this QP lives on device index N, it should send signalled.
    // This works out that each fifo posting QP gets drained
@@ -632,7 +642,7 @@ index ba4a8739f6..174311958e 100644
      wr.send_flags |= IBV_SEND_SIGNALED;
      wr.wr_id = req - comm->base.reqs;
      ncclIbAddEvent(req, ctsQp->devIndex, &comm->devs[ctsQp->devIndex].base);
-@@ -2477,10 +2681,16 @@
+@@ -2495,10 +2704,16 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
  
    comm->remFifo.fifoTail++;
  
@@ -649,7 +659,7 @@ index ba4a8739f6..174311958e 100644
    struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
    if (comm->base.ready == 0) {
      WARN("NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
-@@ -2490,6 +2700,11 @@
+@@ -2508,6 +2723,11 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
    if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
    NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
  
@@ -661,7 +671,7 @@ index ba4a8739f6..174311958e 100644
    struct ncclIbRequest* req;
    NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
    req->type = NCCL_NET_IB_REQ_RECV;
-@@ -2511,50 +2726,64 @@
+@@ -2531,50 +2751,64 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
      req->devBases[i] = &comm->devs[i].base;
    }
  
@@ -670,10 +680,6 @@ index ba4a8739f6..174311958e 100644
 -  wr.wr_id = req - comm->base.reqs;
 -  wr.sg_list = NULL;
 -  wr.num_sge = 0;
--
--  TIME_START(1);
--  // Select either all QPs, or one qp per-device
--  const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
 +  if (!netOptRecvCompletionEnabled) {
 +    struct ibv_recv_wr wr;
 +    memset(&wr, 0, sizeof(wr));
@@ -681,15 +687,18 @@ index ba4a8739f6..174311958e 100644
 +    wr.sg_list = NULL;
 +    wr.num_sge = 0;
  
+-  TIME_START(1);
+-  // Select either all QPs, or one qp per-device
+-  const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
++    TIME_START(1);
++    // Select either all QPs, or one qp per-device
++    const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
+ 
 -  // Post recvs
 -  struct ibv_recv_wr* bad_wr;
 -  for (int i = 0; i < nqps; i++) {
 -    struct ncclIbQp* qp = comm->base.qps + comm->base.qpIndex;
 -    ncclIbAddEvent(req, qp->devIndex, &comm->devs[qp->devIndex].base);
-+    TIME_START(1);
-+    // Select either all QPs, or one qp per-device
-+    const int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
-+
 +    // Post recvs
 +    struct ibv_recv_wr* bad_wr;
 +    int qpIndex = comm->base.qpIndex;
@@ -759,7 +768,7 @@ index ba4a8739f6..174311958e 100644
  }
  
  ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request) {
-@@ -2623,6 +2852,8 @@
+@@ -2643,6 +2877,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
  }
  #endif
  
@@ -768,7 +777,7 @@ index ba4a8739f6..174311958e 100644
  ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
    struct ncclIbRequest *r = (struct ncclIbRequest*)request;
    *done = 0;
-@@ -2665,13 +2896,18 @@
+@@ -2689,13 +2925,18 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
  
      int totalWrDone = 0;
      int wrDone = 0;
@@ -789,7 +798,7 @@ index ba4a8739f6..174311958e 100644
          totalWrDone += wrDone;
          if (wrDone == 0) { TIME_CANCEL(3); } else { TIME_STOP(3); }
          if (wrDone == 0) continue;
-@@ -2833,7 +3069,7 @@
+@@ -2861,7 +3102,7 @@ ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p) {
  }
  
  ncclNet_t ncclNetIb = {


### PR DESCRIPTION
Add a per-comm counter (extraWrCount) to ncclIbSendComm and an INFO log in ncclIbMultiSend() to trace when an extra 0-byte RDMA_WRITE_WITH_IMM work request is inserted for multi-recv (nreqs > 1) or adaptive routing paths. The log emits comm pointer, per-comm hit count, slot, nreqs, AR flag, qpIndex, fifoHead, and immData to allow correlating extra WR activity to a specific connection and QP cycle.

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
_One sentence describing the work done._

**Why were the changes made?**  
_Explain the motivation behind the work. Provide any publicly-available historical context._

**How was the outcome achieved?**  
_Technical details behind the work. Explain any publicly-available hardware peculiarities._

**Additional Documentation:**  
_What else should the reviewer know?_

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
