### PR TITLE
ROCM IB Plugin: add 0-byte send/recv tracing to IB transport

### DIFF
--- a/ext-src/rocm_netib.patch
+++ b/ext-src/rocm_netib.patch
@@ -1,5 +1,5 @@
 diff --git a/src/transport/net_ib.cc b/src/transport/net_ib.cc
-index 53b2f42b..36acca61 100644
+index 14492c94..f281e90c 100644
 --- a/src/transport/net_ib.cc
 +++ b/src/transport/net_ib.cc
 @@ -28,6 +28,7 @@
@@ -9,8 +9,8 @@ index 53b2f42b..36acca61 100644
 +#include "ionic/ionicdvwrap.h"
  #include "graph/xml.h"
  #include "net_ib_checksum.h"
- 
-@@ -108,9 +109,31 @@ struct ncclIbMergedDev ncclIbMergedDevs[MAX_IB_VDEVS];
+ // For the optional RCCL_IB_RDMA_CHECKSUM_SEND_VERIFY hook: pointer-kind
+@@ -113,9 +114,31 @@ struct ncclIbMergedDev ncclIbMergedDevs[MAX_IB_VDEVS];
  struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
  pthread_mutex_t ncclIbLock = PTHREAD_MUTEX_INITIALIZER;
  static int ncclIbRelaxedOrderingEnabled = 0;
@@ -42,9 +42,9 @@ index 53b2f42b..36acca61 100644
  #define NCCL_IB_SL_DEFAULT 0
  #define NCCL_IB_TC_DEFAULT 0
  
-@@ -145,6 +168,13 @@ RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
- // XOR latency.
- RCCL_PARAM(IbRdmaChecksumBytes, "IB_RDMA_CHECKSUM_BYTES", 0);
+@@ -183,6 +206,13 @@ RCCL_PARAM(IbRdmaChecksumIters, "IB_RDMA_CHECKSUM_ITERS", 2);
+ // turn the feature off entirely).
+ RCCL_PARAM(IbRdmaChecksumSendVerify, "IB_RDMA_CHECKSUM_SEND_VERIFY", 1);
  #endif
 +NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 1);
 +
@@ -56,7 +56,7 @@ index 53b2f42b..36acca61 100644
  
  static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
    __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
-@@ -635,6 +665,10 @@ ncclResult_t ncclIbInit(ncclDebugLogger_t logFunction, ncclProfilerCallback_t pr
+@@ -682,6 +712,10 @@ ncclResult_t ncclIbInit(ncclDebugLogger_t logFunction, ncclProfilerCallback_t pr
    static int shownIbHcaEnv = 0;
    if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
    if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
@@ -67,7 +67,7 @@ index 53b2f42b..36acca61 100644
  
    // Detect IB cards
    int nIbDevs = 0;
-@@ -788,6 +822,24 @@ ncclResult_t ncclIbInit(ncclDebugLogger_t logFunction, ncclProfilerCallback_t pr
+@@ -835,6 +869,24 @@ ncclResult_t ncclIbInit(ncclDebugLogger_t logFunction, ncclProfilerCallback_t pr
      INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
            ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
  
@@ -92,7 +92,7 @@ index 53b2f42b..36acca61 100644
      pthread_mutex_unlock(&ncclIbLock);
    }
  exit:
-@@ -1124,6 +1176,8 @@ struct ncclIbListenComm {
+@@ -1171,6 +1223,8 @@ struct ncclIbListenComm {
    struct ncclIbCommStage stage;
  };
  
@@ -101,7 +101,7 @@ index 53b2f42b..36acca61 100644
  struct alignas(64) ncclIbSendFifo {
    uint64_t addr;
    uint64_t size;
-@@ -1134,10 +1188,21 @@ struct alignas(64) ncclIbSendFifo {
+@@ -1181,10 +1235,21 @@ struct alignas(64) ncclIbSendFifo {
    char padding[16];
  };
  
@@ -123,7 +123,7 @@ index 53b2f42b..36acca61 100644
  };
  
  struct ncclIbRemSizesFifo {
-@@ -1184,6 +1249,7 @@ struct ncclIbSendComm {
+@@ -1231,6 +1296,7 @@ struct ncclIbSendComm {
    struct ncclIbNetCommBase base;
    // Start with fifo and ibv structs as they have alignment restrictions
    struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -131,15 +131,7 @@ index 53b2f42b..36acca61 100644
    struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
    struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
    // Each dev correlates to a mergedIbDev
-@@ -1195,6 +1261,7 @@ struct ncclIbSendComm {
- #endif
-   uint64_t fifoHead;
-   int ar; // Use adaptive routing when all merged devices have it enabled
-+  uint64_t extraWrCount; // Per-comm counter for extra WR insertions (multi-recv / AR)
- };
- // The SendFifo needs to be 32-byte aligned and each element needs
- // to be a 32-byte multiple, so that an entry does not get split and
-@@ -1202,6 +1269,7 @@ struct ncclIbSendComm {
+@@ -1249,6 +1315,7 @@ struct ncclIbSendComm {
  static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
  static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
  static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
@@ -147,7 +139,7 @@ index 53b2f42b..36acca61 100644
  static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
  static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
  
-@@ -1216,6 +1284,7 @@ struct ncclIbGpuFlush {
+@@ -1263,6 +1330,7 @@ struct ncclIbGpuFlush {
  
  struct ncclIbRemFifo {
    struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
@@ -155,7 +147,7 @@ index 53b2f42b..36acca61 100644
    uint64_t fifoTail;
    uint64_t addr;
    uint32_t flags;
-@@ -1290,20 +1359,59 @@ returning:
+@@ -1337,20 +1405,59 @@ returning:
    return res;
  }
  
@@ -217,7 +209,7 @@ index 53b2f42b..36acca61 100644
    struct ibv_qp_attr qpAttr;
    memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
    qpAttr.qp_state = IBV_QPS_INIT;
-@@ -1313,6 +1421,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
+@@ -1360,6 +1467,9 @@ ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base,
    NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
    TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
      ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
@@ -227,7 +219,7 @@ index 53b2f42b..36acca61 100644
    return ncclSuccess;
  }
  
-@@ -1396,7 +1507,7 @@ fail:
+@@ -1443,7 +1553,7 @@ fail:
    goto exit;
  }
  
@@ -236,7 +228,7 @@ index 53b2f42b..36acca61 100644
    ncclResult_t ret = ncclSuccess;
    struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
    struct ncclIbCommStage* stage = &handle->stage;
-@@ -1404,8 +1515,13 @@ ncclResult_t ncclIbConnect(int dev, ncclNetCommConfig_t* config, void* opaqueHan
+@@ -1451,8 +1561,13 @@ ncclResult_t ncclIbConnect(int dev, ncclNetCommConfig_t* config, void* opaqueHan
    int ready;
    uint8_t link_layer = IBV_LINK_LAYER_UNSPECIFIED;
    int isP2p = 0; 
@@ -250,7 +242,7 @@ index 53b2f42b..36acca61 100644
    if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
    if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
    if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-@@ -1486,7 +1602,7 @@ ib_recv_dev_list:
+@@ -1533,7 +1648,7 @@ ib_recv_dev_list:
    for (int q = 0; q < comm->base.nqps; q++) {
      ncclIbSendCommDev* commDev = comm->devs + devIndex;
      ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
@@ -259,7 +251,7 @@ index 53b2f42b..36acca61 100644
      comm->base.qps[q].devIndex = devIndex;
      meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
      meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
-@@ -1511,7 +1627,11 @@ ib_recv_dev_list:
+@@ -1558,7 +1673,11 @@ ib_recv_dev_list:
      devInfo->lid           = ibDev->portAttr.lid;
      devInfo->ibv_dev_index = commDev->base.ibDevN;
      // Prepare my fifo
@@ -272,7 +264,7 @@ index 53b2f42b..36acca61 100644
      devInfo->fifoRkey = commDev->fifoMr->rkey;
  
      // Pack local GID info
-@@ -1553,7 +1673,11 @@ ib_recv_dev_list:
+@@ -1600,7 +1719,11 @@ ib_recv_dev_list:
        return ncclInternalError;
      }
    }
@@ -285,7 +277,7 @@ index 53b2f42b..36acca61 100644
    meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
    meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
    strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
-@@ -1698,18 +1822,22 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
+@@ -1745,18 +1868,22 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
    return ncclSuccess;
  }
  
@@ -310,7 +302,7 @@ index 53b2f42b..36acca61 100644
    if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
    if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
    if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
-@@ -1839,7 +1967,7 @@ ib_recv:
+@@ -1886,7 +2013,7 @@ ib_recv:
      // Local ibDevN
      ibDevN = rComm->devs[devIndex].base.ibDevN;
      ibDev = ncclIbDevs + ibDevN;
@@ -319,7 +311,7 @@ index 53b2f42b..36acca61 100644
      qp->devIndex = devIndex;
      devIndex = (devIndex + 1) % rComm->base.vProps.ndevs;
  
-@@ -1865,16 +1993,22 @@ ib_recv:
+@@ -1912,16 +2039,22 @@ ib_recv:
  
    useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);
    rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || useDmaBuf)
@@ -345,7 +337,7 @@ index 53b2f42b..36acca61 100644
  
      // Allocate Flush dummy buffer for GPU Direct RDMA
      if (rComm->flushEnabled) {
-@@ -1912,7 +2046,7 @@ ib_recv:
+@@ -1959,7 +2092,7 @@ ib_recv:
        rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
        rCommDev->gpuFlush.sge.length = 1;
        rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
@@ -354,7 +346,7 @@ index 53b2f42b..36acca61 100644
        struct ncclIbDevInfo devInfo;
        devInfo.lid         = ibDev->portAttr.lid;
        devInfo.link_layer  = ibDev->portAttr.link_layer;
-@@ -2176,10 +2310,15 @@ ncclResult_t ncclIbGetRecvChecksums(void* recvComm, int n, uint32_t* checksums)
+@@ -2223,10 +2356,15 @@ ncclResult_t ncclIbGetRecvChecksums(void* recvComm, int n, uint32_t* checksums)
  }
  #endif // RCCL_IB_CHECKSUM_DEVICE_ENABLED
  
@@ -372,7 +364,7 @@ index 53b2f42b..36acca61 100644
    if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
  
    uint64_t wr_id = 0ULL;
-@@ -2191,7 +2330,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2238,7 +2376,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
      sge->addr=(uintptr_t)reqs[r]->send.data;
      wr->opcode = IBV_WR_RDMA_WRITE;
      wr->send_flags = 0;
@@ -385,7 +377,7 @@ index 53b2f42b..36acca61 100644
      wr->next = wr + 1;
      wr_id += (reqs[r] - comm->base.reqs) << (r*8);
  #ifdef NCCL_ENABLE_NET_PROFILING
-@@ -2202,7 +2345,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2249,7 +2391,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
    // Write size (and optional checksum) as immediate data. In the case of multi-send,
    // only write 0 or 1 as size to indicate whether there was data sent or received.
    uint32_t immData = 0;
@@ -394,7 +386,7 @@ index 53b2f42b..36acca61 100644
      int size = reqs[0]->send.size;
  #if RCCL_IB_CHECKSUM_DEVICE_ENABLED
      if (rcclParamIbRdmaChecksum() && ncclIbImmCanPack(size)) {
-@@ -2225,22 +2368,28 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2272,25 +2414,37 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
    }
  
    struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
@@ -411,7 +403,6 @@ index 53b2f42b..36acca61 100644
 -      lastWr->sg_list = &comm->remSizesFifo.sge;
 +  if (use_write_op == false) {
 +    if (nreqs > 1 || (comm->ar && reqs[0]->send.size > ncclParamRocmIbArThreshold())) {
-+      comm->extraWrCount++;
 +      // When using ADAPTIVE_ROUTING, send the bulk of the data first as an
 +      // RDMA_WRITE, then a 0-byte RDMA_WRITE_WITH_IMM to trigger a remote
 +      // completion.
@@ -423,9 +414,6 @@ index 53b2f42b..36acca61 100644
 +        lastWr->num_sge = 1;
 +        lastWr->sg_list = &comm->remSizesFifo.sge;
 +      }
-+
-+      INFO(NCCL_NET, "NET/IB: ncclIbMultiSend extra-WR comm=%p #%lu slot=%d nreqs=%d ar=%d qpIndex=%d fifoHead=%lu immData=0x%x",
-+        comm, comm->extraWrCount, slot, nreqs, comm->ar, comm->base.qpIndex, comm->fifoHead, immData);
      }
 +    lastWr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
 +    lastWr->imm_data = immData;
@@ -436,7 +424,20 @@ index 53b2f42b..36acca61 100644
    lastWr->next = NULL;
    lastWr->send_flags = IBV_SEND_SIGNALED;
  
-@@ -2256,7 +2405,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
++  // Log 0-byte RDMA_WRITE_WITH_IMM scenarios
++  for (int r=0; r<nreqs; r++) {
++    if (reqs[r]->send.size == 0) {
++      static uint64_t zeroByteMsendCnt = 0;
++      uint64_t cnt = __atomic_fetch_add(&zeroByteMsendCnt, 1, __ATOMIC_RELAXED) + 1;
++      INFO(NCCL_NET, "NET/IB: ncclIbMultiSend 0-byte payload: cnt=%lu slot=%d req=%d/%d immData=0x%x ar=%d use_write_op=%d",
++        cnt, slot, r, nreqs, immData, comm->ar, use_write_op);
++    }
++  }
++
+   // Multi-QP: make sure IB writes are multiples of 128B so that LL and LL128 protocols still work
+   const int align = 128;
+   int nqps = ncclParamIbSplitDataOnQps() ? comm->base.nqps : comm->base.nDataQps;
+@@ -2303,7 +2457,11 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
        //ncclIbAddEvent(reqs[r], devIndex, &comm->devs[devIndex].base);
  
        // Select proper rkey (needed even for 0-size send)
@@ -449,7 +450,7 @@ index 53b2f42b..36acca61 100644
  
        int chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
        int length = std::min(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
-@@ -2272,7 +2425,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
+@@ -2319,7 +2477,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
        }
      }
  
@@ -458,7 +459,7 @@ index 53b2f42b..36acca61 100644
        // Also make sure lastWr writes remote sizes using the right lkey
        comm->remSizesFifo.sge.lkey = comm->remSizesFifo.mrs[devIndex]->lkey;
        lastWr->wr.rdma.rkey = comm->remSizesFifo.rkeys[devIndex];
-@@ -2330,32 +2483,46 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2377,32 +2535,47 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
    NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
  
    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
@@ -493,6 +494,7 @@ index 53b2f42b..36acca61 100644
 +    for (int r=1; r<nreqs; r++) while(slots[r].idx != idx);
 +    __sync_synchronize(); // order the nreqsPtr load against tag/rkey/addr loads below
 +  }
++  size_t origSize = size;
    for (int r=0; r<nreqs; r++) {
 -    if (reqs[r] != NULL || slots[r].tag != tag) continue;
 -
@@ -523,7 +525,20 @@ index 53b2f42b..36acca61 100644
      }
  
      struct ncclIbRequest* req;
-@@ -2402,10 +2569,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2414,6 +2587,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+     req->send.size = size;
+     req->send.data = data;
+     req->send.offset = 0;
++    if (size == 0) {
++      static uint64_t zeroByteIsendCnt = 0;
++      uint64_t cnt = __atomic_fetch_add(&zeroByteIsendCnt, 1, __ATOMIC_RELAXED) + 1;
++      INFO(NCCL_NET, "NET/IB: rocmIbIsend 0-byte send: cnt=%lu slot=%d tag=%d nreqs=%d origSize=%ld recvPostedSize=%ld ctsOffload=%d",
++        cnt, slot, tag, nreqs, (long)origSize, rcclCtsOffloadEnabled ? -1L : (long)slots[r].size, rcclCtsOffloadEnabled);
++    }
+ #if RCCL_IB_CHECKSUM_DEVICE_ENABLED
+     req->send.checksum = comm->proxyChecksum[slot];
+ #endif
+@@ -2449,10 +2628,12 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
      }
  
      TIME_START(0);
@@ -538,7 +553,7 @@ index 53b2f42b..36acca61 100644
      memset(reqs, 0, NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbRequest*));
      comm->fifoHead++;
      TIME_STOP(0);
-@@ -2418,30 +2587,60 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
+@@ -2465,30 +2646,66 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
  
  ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, size_t* sizes, int* tags, void** mhandles, struct ncclIbRequest* req) {
    struct ibv_send_wr wr;
@@ -588,13 +603,13 @@ index 53b2f42b..36acca61 100644
 +      localElemCtsInline[i].tag = tags[i];
 +      localElemCtsInline[i].idx = comm->remFifo.fifoTail+1;
 +      localElemRef = (uint64_t)localElemCtsInline;
-+
-+    } else {
-+      localElem[i].addr = (uint64_t)data[i];
  
 -    // Send all applicable rkeys
 -    for (int j = 0; j < comm->base.vProps.ndevs; j++)
 -      localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
++    } else {
++      localElem[i].addr = (uint64_t)data[i];
++
 +      // Send all applicable rkeys
 +      for (int j = 0; j < comm->base.vProps.ndevs; j++)
 +        localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
@@ -609,10 +624,16 @@ index 53b2f42b..36acca61 100644
 +      localElem[i].idx = comm->remFifo.fifoTail+1;
 +      localElemRef = (uint64_t)localElem;
 +    }
++    if (sizes[i] == 0) {
++      static uint64_t zeroByteCtsCnt = 0;
++      uint64_t cnt = __atomic_fetch_add(&zeroByteCtsCnt, 1, __ATOMIC_RELAXED) + 1;
++      INFO(NCCL_NET, "NET/IB: CTS posted with 0-byte recv buffer size: cnt=%lu slot=%d req=%d/%d tag=%d addr=0x%lx ctsInline=%d",
++        cnt, slot, i, n, tags[i], (unsigned long)data[i], rcclCtsInlineData);
++    }
    }
    wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
  
-@@ -2449,8 +2648,12 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2496,8 +2713,12 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
    wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].fifoRkey;
  
    // Set the correct sge properties
@@ -627,7 +648,7 @@ index 53b2f42b..36acca61 100644
    wr.sg_list = &comm->devs[ctsQp->devIndex].fifoSge;
    wr.num_sge = 1;
  
-@@ -2480,7 +2683,13 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2527,7 +2748,13 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
    //
    // slot == devIndex - When writing to fifo slot N, and this QP lives on device index N, it should send signalled.
    // This works out that each fifo posting QP gets drained
@@ -642,7 +663,7 @@ index 53b2f42b..36acca61 100644
      wr.send_flags |= IBV_SEND_SIGNALED;
      wr.wr_id = req - comm->base.reqs;
      ncclIbAddEvent(req, ctsQp->devIndex, &comm->devs[ctsQp->devIndex].base);
-@@ -2495,10 +2704,16 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
+@@ -2542,10 +2769,16 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, siz
  
    comm->remFifo.fifoTail++;
  
@@ -659,7 +680,7 @@ index 53b2f42b..36acca61 100644
    struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
    if (comm->base.ready == 0) {
      WARN("NET/IB: ncclIbIrecv() called when comm->base.ready == 0");
-@@ -2508,6 +2723,11 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
+@@ -2555,6 +2788,11 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
    if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
    NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
  
@@ -671,7 +692,7 @@ index 53b2f42b..36acca61 100644
    struct ncclIbRequest* req;
    NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
    req->type = NCCL_NET_IB_REQ_RECV;
-@@ -2531,50 +2751,64 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
+@@ -2578,50 +2816,64 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
      req->devBases[i] = &comm->devs[i].base;
    }
  
@@ -768,7 +789,7 @@ index 53b2f42b..36acca61 100644
  }
  
  ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request) {
-@@ -2643,6 +2877,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
+@@ -2690,6 +2942,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
  }
  #endif
  
@@ -777,7 +798,7 @@ index 53b2f42b..36acca61 100644
  ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
    struct ncclIbRequest *r = (struct ncclIbRequest*)request;
    *done = 0;
-@@ -2689,13 +2925,18 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
+@@ -2862,13 +3116,18 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
  
      int totalWrDone = 0;
      int wrDone = 0;
@@ -798,7 +819,7 @@ index 53b2f42b..36acca61 100644
          totalWrDone += wrDone;
          if (wrDone == 0) { TIME_CANCEL(3); } else { TIME_STOP(3); }
          if (wrDone == 0) continue;
-@@ -2861,7 +3102,7 @@ ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p) {
+@@ -3034,7 +3293,7 @@ ncclResult_t rcclNetP2pPolicy(void* handle, int isP2p) {
  }
  
  ncclNet_t ncclNetIb = {


### PR DESCRIPTION
Add INFO-level logs with atomic counters at three points in net_ib_rocm.cc to trace 0-byte RDMA WRITE_WITH_IMM scenarios: receiver CTS posting, sender isend, and MultiSend.
